### PR TITLE
Avoid use of "CDN", which implies a CNAME to many people.

### DIFF
--- a/draft-yasskin-dispatch-web-packaging.md
+++ b/draft-yasskin-dispatch-web-packaging.md
@@ -55,35 +55,7 @@ details can be found in that repository.
 Use Cases    {#use-cases}
 ---------
 
-### Offline Installation
-
-People with expensive or intermittent internet connections are used
-to sharing files via P2P links and shared SD cards. They should be
-able to install web applications they received this way. Installing a
-web application requires a guarantee of the same kind as an HTTPS
-connection that it came from and can use data owned by a particular
-origin.
-
-### Snapshot packages
-
-Verification of the origin of the content isn't always necessary.
-For example, users currently share screenshots and MHTML documents
-with their peers, with no guarantee that the shared content is
-authentic. However, these formats have low fidelity (screenshots)
-and/or aren't interoperable (MHTML). We'd like an interoperable format
-that lets both publishers and readers package such content for use in
-an untrusted mode.
-
-### CDNs
-
-CDNs want to re-publish other origins' content so readers can access
-it more quickly or more privately. Currently, to attribute that
-content to the original origin, they need the full ability to publish
-arbitrary content under that origin's name. There should be a way to
-let them attribute only the exact content that the original origin
-published.
-
-### ...
+See {{?I-D.yasskin-webpackage-use-cases}}.
 
 Why not ZIP?   {#not-zip}
 ------------

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -90,28 +90,30 @@ Then to avoid the need to look up and connect to `jquery.com` in the critical
 path, `example.com` might PUSH that resource ({{?RFC7540}}, section 8.2), signed
 by `jquery.com`.
 
-## Explicit use of a CDN for subresources {#uc-explicit-cdn}
+## Explicit use of a content distributor for subresources {#uc-explicit-distributor}
 
 In order to speed up loading but still maintain control over its content, an
 HTML page in a particular origin `O.com` could tell clients to load its
-subresources from an intermediate CDN that's not authoritative, but require that
-those resources be signed by `O.com` so that the CDN couldn't modify the
-resources.
+subresources from an intermediate content distributor that's not authoritative,
+but require that those resources be signed by `O.com` so that the distributor
+couldn't modify the resources. This is more constrained than the common CDN case
+where `O.com` has a CNAME granting the CDN the right to serve arbitrary content
+as `O.com`.
 
 ~~~html
 <img logicalsrc="https://O.com/img.png"
-     physicalsrc="https://cdn.com/O.com/img.png">
+     physicalsrc="https://distributor.com/O.com/img.png">
 ~~~
 
-To make it easier to configure the right CDN for a given request, computation of
-the `physicalsrc` could be encapsulated in a custom element:
+To make it easier to configure the right distributor for a given request,
+computation of the `physicalsrc` could be encapsulated in a custom element:
 
 ~~~html
-<cdn-img src="https://O.com/img.png"></cdn-img>
+<dist-img src="https://O.com/img.png"></dist-img>
 ~~~
 
-where the `<cdn-img>` implementation generates an appropriate `<img>` based on,
-for example, a `<meta name="cdn-base">` tag elsewhere in the page.
+where the `<dist-img>` implementation generates an appropriate `<img>` based on,
+for example, a `<meta name="dist-base">` tag elsewhere in the page.
 
 This could be used for some of the same purposes as SRI ({{uc-sri}}).
 

--- a/draft-yasskin-webpackage-use-cases.md
+++ b/draft-yasskin-webpackage-use-cases.md
@@ -255,33 +255,34 @@ Associated requirements:
 
 * {{external-dependencies}}{:format="title"}
 
-### CDNs {#cdns}
+### Content Distributors {#content-distributors}
 
-CDNs want to re-publish other origins' content so readers can access
-it more quickly or more privately. Currently, to attribute that
-content to the original origin, they need the full ability to publish
-arbitrary content under that origin's name. There should be a way to
-let them attribute only the exact content that the original origin
-published.
+Content distributors want to re-publish other origins' content so readers can
+access it more quickly or more privately. Currently, to attribute that content
+to the original origin, they need to be full CDNs with the ability to publish
+arbitrary content under that origin's name. There should be a way to let them
+attribute only the exact content that the original origin published.
 
-Web Packages would allow CDNs to publish content as another site as
-long as the user visited a URL explicitly mentioning the CDN.
+Web Packages would allow distributors to publish another site's signed content
+as long as the user visited a URL explicitly mentioning the distributor.
 
-CDNs want to serve only the bytes that most optimally represent the
-content the current user needs, even though the origin needs to
-provide representations for all users. Think PNG vs WebP and small vs
-large resolutions.
+Content distributors want to serve only the bytes that most optimally represent
+the content the current user needs, even though the origin needs to provide
+representations for all users. Think PNG vs WebP and small vs large resolutions.
+
+This use case is also addressed by
+{{?I-D.yasskin-http-origin-signed-responses}}.
 
 Associated requirements:
 
 * {{streamed-loading}}{:format="title"}: To get optimal performance, the browser
-  should be able to start loading early resources before the CDN finishes
-  sending the whole package.
+  should be able to start loading early resources before the distributor
+  finishes sending the whole package.
 * {{signing}}{:format="title"}: To prove the content came from the original
   origin.
 * {{subsetting}}{:format="title"}: If a package includes both WebP and PNG
-  versions of an image, the CDN should be able to select the best one to send to
-  each client.
+  versions of an image, the distributor should be able to select the best one to
+  send to each client.
 * {{transfer-compression}}{:format="title"}
 
 ### Installation from a self-extracting executable {#self-extracting}

--- a/explainer.md
+++ b/explainer.md
@@ -57,8 +57,21 @@ package signed by a compromised certificate. When the client gets back to a
 public network, it should attempt to validate both the certificate and the
 package using the mechanisms alluded to under [Local Sharing](#local-sharing).
 
-### Content Distribution Networks and Web caches.
-The CDNs can provide service of hosting web content that should be delivered at scale. This includes both hosting subresources (JS libraries, images) as well as entire content ([Google AMP](https://developers.google.com/amp/cache/overview)) on network of servers, often provided as a service by 3rd party. Unfortunately, origin-based security model of the Web limits the ways a 3rd-party caches/servers can be used. Indeed, for example in case of hosting JS subresources, the original document must explicitly trust the CDN origin to serve the trusted script. The user agent must use protocol-based means to verify the subresource is coming from the trusted CDN. Another example is a CDN that caches the whole content. Because the origin of CDN is different from the origin of the site, the browser normally can't afford the origin treatment of the site to the loaded content. Look at how an article from USA Today is represented:
+### Content Distributors and Web caches.
+Content distributors can provide the service of hosting web content that should
+be delivered at scale. This includes both hosting subresources (JS libraries,
+images) as well as entire content ([Google
+AMP](https://developers.google.com/amp/cache/overview)) on a network of servers,
+often provided as a service by 3rd party. Unfortunately, the origin-based
+security model of the Web limits the ways 3rd-party caches/servers can be used.
+For example in the case of hosting JS subresources, the original document must
+explicitly trust the distributor's origin to serve the trusted script. The user
+agent must use protocol-based means to verify the subresource is coming from the
+trusted distributor. Another example is a content distributor that caches the
+whole content. Because the origin of the distributor is different from the
+origin of the site, the browser normally can't afford the origin treatment of
+the site to the loaded content. Look at how an article from USA Today is
+represented:
 
 <img align="center" width=350 src="buick.png">
 
@@ -66,8 +79,9 @@ Note the address bar indicating google.com. Also, since the content of USA Today
 - Can't request permissions
 - Can't be added to homescreen
 
-Packages served to CDNs can staple an OCSP response and have a short expiration
-time, avoiding the above problems with outdated packages.
+Packages served to content distributors can staple an OCSP response and have a
+short expiration time, avoiding the problems with outdated packages under "Local
+Sharing".
 
 
 ## Goals and non-goals


### PR DESCRIPTION
Use "content distributor" instead, in the hope that it only implies
distribution without authority.

How's this, @yoavweiss?

Previews in https://jyasskin.github.io/webpackage/clarify-cdn/.