### PR TITLE
Define an HTTP/2 extension for cross-origin Server Push.

### DIFF
--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -433,46 +433,6 @@ there are no non-significant response header fields in the exchange.
    is present of `certificate-chain` or `ed25519Key`. Otherwise, return
    "invalid".
 
-### Validating a certificate chain for an authority ### {#authority-chain-validation}
-
-Section 8.2 of {{?RFC7540}} includes the rule:
-
-> The server MUST include a value in the :authority pseudo-header field for
-> which the server is authoritative (see Section 10.1). A client MUST treat a
-> PUSH_PROMISE for which the server is not authoritative as a stream error
-> (Section 5.4.2) of type PROTOCOL_ERROR.
-
-If the Server Push contains a signed exchange for which the server is not
-authoritative, instead of treating it as a stream error, the client MAY search
-for a signature for which the following algorithm returns "valid". If such a
-signature is found, the client MAY treat the server as authoritative for this
-particular exchange and store the exchange as described by {{!RFC7540}}. If not,
-the client MUST treat the exchange as a stream error as described by
-{{!RFC7540}}.
-
-1. Run {{signature-validity}} over the signature with the `allResponseHeaders`
-   flag set, getting `exchange` and `certificate-chain` back. If this returned
-   "invalid" or didn't return a certificate chain, return "invalid".
-1. Let `authority` be the host component of `exchange`'s effective request URI.
-1. Validate the `certificate-chain` using the following substeps. If any of them
-   fail, re-run {{signature-validity}} once over the signature with both the
-   `forceFetch` flag and the `allResponseHeaders` flag set, and restart from
-   step 2. If a substep fails again, return "invalid".
-   1. Use `certificate-chain` to validate that its first entry,
-      `main-certificate` is trusted as `authority`'s server certificate
-      ({{!RFC5280}} and other undocumented conventions). Let `path` be the path
-      that was used from the `main-certificate` to a trusted root, including the
-      `main-certificate` but excluding the root.
-   1. Validate that `main-certificate` includes a "status_request" extension
-      with a valid OCSP response whose lifetime (`nextUpdate - thisUpdate`) is
-      less than 7 days ({{!RFC6960}}). Note that this does not check for
-      revocation of intermediate certificates, and clients SHOULD implement
-      another mechanism for that.
-   1. Validate that all certificates in `path` include
-      "signed_certificate_timestamp" extensions containing valid SCTs from
-      trusted logs. ({{!RFC6962}})
-1. Return "valid".
-
 ### Open Questions
 
 Including the entire exchange in the signed data forces a client to download the
@@ -594,6 +554,88 @@ Signature: sig3;
 https://example.com/resource.validity could also expand the set of signatures if
 its `signatures` array contained more than 2 elements.
 
+# HTTP/2 extension for cross-origin Server Push # {#cross-origin-push}
+
+To allow servers to Server-Push (Section 8.2 of {{?RFC7540}}) signed exchanges
+({{proposal}}) signed by an authority for which the server is not authoritative
+(Section 9.1 of {{?RFC7230}}), this section defines an HTTP/2 extension.
+
+## Indicating support for cross-origin Server Push # {#setting}
+
+Clients that might accept signed Server Pushes with an authority for which the
+server is not authoritative indicate this using the HTTP/2 SETTINGS parameter
+ENABLE_CROSS_ORIGIN_PUSH (0xSETTING-TBD).
+
+An ENABLE_CROSS_ORIGIN_PUSH value of 0 indicates that the client does not
+support cross-origin Push. A value of 1 indicates that the client does support
+cross-origin Push.
+
+A client MUST NOT send a ENABLE_CROSS_ORIGIN_PUSH setting with a value other
+than 0 or 1 or a value of 0 after previously sending a value of 1. If a server
+receives a value that violates these rules, it MUST treat it as a connection
+error (Section 5.4.1 of {{!RFC7540}}) of type PROTOCOL_ERROR.
+
+The use of a SETTINGS parameter to opt-in to an otherwise incompatible protocol
+change is a use of "Extending HTTP/2" defined by Section 5.5 of {{?RFC7540}}. If
+a server were to send a cross-origin Push without first receiving a
+ENABLE_CROSS_ORIGIN_PUSH setting with the value of 1 it would be a protocol
+violation.
+
+## NO_TRUSTED_EXCHANGE_SIGNATURE error code {#error-code}
+
+The signatures on a Pushed cross-origin exchange may be untrusted for several
+reasons, for example that the certificate could not be fetched, that the
+certificate does not chain to a trusted root, that the signature itself doesn't
+validate, that the signature is expired, etc. This draft conflates all of these
+possible failures into one error code, NO_TRUSTED_EXCHANGE_SIGNATURE
+(0xERROR-TBD).
+
+### Open Questions
+
+How fine-grained should this specification's error codes be?
+
+## Validating a cross-origin Push ## {#validating-cross-origin-push}
+
+If the client has set the ENABLE_CROSS_ORIGIN_PUSH setting to 1, the server MAY
+Push a signed exchange for which it is not authoritative, and the client MUST
+NOT treat a PUSH_PROMISE for which the server is not authoritative as a stream
+error (Section 5.4.2 of {{!RFC7540}}) of type PROTOCOL_ERROR, as described in
+Section 8.2 of {{?RFC7540}}.
+
+Instead, the client MUST validate such a PUSH_PROMISE and its response by
+parsing the `Signature` header into a list of signatures according to the
+instructions in {{signature-validity}}, and searching that list for a valid
+signature using the algorithm in {{authority-chain-validation}}. If no valid
+signature is found, the client MUST treat the response as a stream error
+(Section 5.4.2 of {{!RFC7540}}) of type NO_TRUSTED_EXCHANGE_SIGNATURE.
+Otherwise, the client MUST treat the pushed response as if the server were
+authoritative for the PUSH_PROMISE's authority.
+
+### Validating a certificate chain for an authority ### {#authority-chain-validation}
+
+1. Run {{signature-validity}} over the signature with the `allResponseHeaders`
+   flag set, getting `exchange` and `certificate-chain` back. If this returned
+   "invalid" or didn't return a certificate chain, return "invalid".
+1. Let `authority` be the host component of `exchange`'s effective request URI.
+1. Validate the `certificate-chain` using the following substeps. If any of them
+   fail, re-run {{signature-validity}} once over the signature with both the
+   `forceFetch` flag and the `allResponseHeaders` flag set, and restart from
+   step 2. If a substep fails again, return "invalid".
+   1. Use `certificate-chain` to validate that its first entry,
+      `main-certificate` is trusted as `authority`'s server certificate
+      ({{!RFC5280}} and other undocumented conventions). Let `path` be the path
+      that was used from the `main-certificate` to a trusted root, including the
+      `main-certificate` but excluding the root.
+   1. Validate that `main-certificate` includes a "status_request" extension
+      with a valid OCSP response whose lifetime (`nextUpdate - thisUpdate`) is
+      less than 7 days ({{!RFC6960}}). Note that this does not check for
+      revocation of intermediate certificates, and clients SHOULD implement
+      another mechanism for that.
+   1. Validate that all certificates in `path` include
+      "signed_certificate_timestamp" extensions containing valid SCTs from
+      trusted logs. ({{!RFC6962}})
+1. Return "valid".
+
 # Security considerations
 
 Authors MUST NOT include confidential information in a signed response that an
@@ -636,9 +678,9 @@ leave the authority less constrained.
 in the signed set. This accommodates current TLS-terminating intermediates and
 may be useful for SRI ({{uc-sri}}), but is risky for trusting cross-origin
 responses ({{uc-pushed-subresources}}, {{uc-explicit-distributor}}, and
-{{uc-offline-websites}}). {{authority-chain-validation}} requires all headers to
-be included in the signature before trusting cross-origin pushed resources, at
-Ryan Sleevi's recommendation.
+{{uc-offline-websites}}). {{cross-origin-push}} requires all headers to be
+included in the signature before trusting cross-origin pushed resources, at Ryan
+Sleevi's recommendation.
 
 # Privacy considerations
 
@@ -675,6 +717,33 @@ Status:  standard
 Author/Change controller:  IETF
 
 Specification document(s):  {{signature-header}} of this document
+
+## HTTP/2 Settings
+
+This section establishes an entry for the HTTP/2 Settings Registry that was
+established by Section 11.3 of {{!RFC7540}}
+
+Name: ENABLE_CROSS_ORIGIN_PUSH
+
+Code: 0xSETTING-TBD
+
+Initial Value: 0
+
+Specification: This document
+
+## HTTP/2 Error code
+
+This section establishes an entry for the HTTP/2 Error Code Registry that was
+established by Section 11.4 of {{!RFC7540}}
+
+Name: NO_TRUSTED_EXCHANGE_SIGNATURE
+
+Code: 0xERROR-TBD
+
+Description: The client does not trust the signature for a cross-origin Pushed
+signed exchange.
+
+Specification: This document
 
 --- back
 
@@ -1026,5 +1095,5 @@ exchange argues for embedding a signature's lifetime into the signature.
 
 # Acknowledgements
 
-Thanks to Ilari Liusvaara, Mark Nottingham, Ryan Sleevi, and Yoav Weiss for
-comments that improved this draft.
+Thanks to Ilari Liusvaara, Mark Nottingham, Mike Bishop, Ryan Sleevi, and Yoav
+Weiss for comments that improved this draft.


### PR DESCRIPTION
[Preview](https://jyasskin.github.io/webpackage/http-extension/draft-yasskin-http-origin-signed-responses.html), [Diff](https://tools.ietf.org/rfcdiff?url1=https://jyasskin.github.io/webpackage/draft-yasskin-http-origin-signed-responses.txt&url2=https://jyasskin.github.io/webpackage/http-extension/draft-yasskin-http-origin-signed-responses.txt)