### PR TITLE
Sign just the headers and identify a header to guard the payload.

### DIFF
--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -157,11 +157,11 @@ The `Signature` header is a Structured Header as defined by
 {{!I-D.ietf-httpbis-header-structure}}).
 
 Each parameterised label MUST have parameters named "sig", "integrity",
-"validityUrl", "date", and "expires", and either "certUrl" and "certSha256"
-parameters or an "ed25519Key" parameter. This specification gives no meaning to
-the label itself, which can be used as a human-readable identifier for the
-signature (see {{parameterised-binary}}). The present parameters MUST have the
-following values:
+"validityUrl", "date", and "expires". Each parameterised label MUST also have
+either "certUrl" and "certSha256" parameters or an "ed25519Key" parameter. This
+specification gives no meaning to the label itself, which can be used as a
+human-readable identifier for the signature (see {{parameterised-binary}}). The
+present parameters MUST have the following values:
 
 "sig"
 

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -444,14 +444,18 @@ there are no non-significant response header fields in the exchange.
    is present of `certificate-chain` or `ed25519Key`. Otherwise, return
    "invalid".
 
-   Note that the above algorithm can determine that an exchange's headers are
-   potentially-valid before the exchange's payload is received. The client MAY
-   process those headers as soon as they are validated. If `integrity`
-   identifies a header field like `MI` ({{?I-D.thomson-http-mice}}) that can
-   incrementally validate the payload, the client MAY also incrementally process
-   the validated parts of the payload as soon as they are validated. The client
-   MUST NOT process any part of the headers or payload before it has been
-   validated either by the signature or the header field named by `integrity`.
+Note that the above algorithm can determine that an exchange's headers are
+potentially-valid before the exchange's payload is received. Similarly, if
+`integrity` identifies a header field like `MI` ({{?I-D.thomson-http-mice}})
+that can incrementally validate the payload, early parts of the payload can be
+determined to be potentially-valid before later parts of the payload.
+Higher-level protocols MAY process parts of the exchange that have been
+determined to be potentially-valid as soon as that determination is made but
+MUST NOT process parts of the exchange that are not yet potentially-valid.
+Similarly, as the higher-level protocol determines that parts of the exchange
+are actually valid, the client MAY process those parts of the exchange and MUST
+wait to process other parts of the exchange until they too are determined to be
+valid.
 
 ## Updating signature validity ## {#updating-validity}
 


### PR DESCRIPTION
[Preview](https://jyasskin.github.io/webpackage/incremental-validity/draft-yasskin-http-origin-signed-responses.html), [Diff](https://tools.ietf.org/rfcdiff?url1=https://jyasskin.github.io/webpackage/draft-yasskin-http-origin-signed-responses.txt&url2=https://jyasskin.github.io/webpackage/incremental-validity/draft-yasskin-http-origin-signed-responses.txt) (When TravisCI recovers.)

This limits the length of the signed data, which helps validation
routines use the non-prehashed variant of ed25519, and if the MI header
field is used, it allows clients to incrementally trust the beginning
chunks of the payload as they are received instead of needing to wait
for the whole thing. 