### PR TITLE
Specifying the Accept-Signature header to ask for signatures.

### DIFF
--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -725,6 +725,7 @@ client will validate signatures using the public key whose base64 encoding is
 Accept-Signature: ..., ed25519key; *If4x36FUomFia/hUBG/SJxt77UtqvkWqWId+9H+XIbk
 Accept-Signature: ..., ed25519key; *If4x36FUomFia/hUBG/SJw
 Accept-Signature: ..., ed25519key; *If4x3w
+Accept-Signature: ..., ed25519key; *
 ~~~
 
 but not
@@ -733,6 +734,11 @@ but not
 Accept-Signature: ..., ed25519key; *If4x3
 Accept-Signature: ..., ed25519key; If4x3w
 ~~~
+
+Note that `ed25519key; *` is an empty prefix, which matches all public keys, so
+it's useful in subresource integrity ({{uc-sri}}) cases like `<link rel=preload
+as=script href="...">` where the public key isn't known until the matching
+`<script src="..." integrity="...">` tag.
 
 ### Examples ### {#accept-signature-examples}
 
@@ -753,6 +759,19 @@ states that the client will accept 4096-bit RSA keys but not 2048-bit RSA keys,
 and implies that the client will accept ECDSA keys on the secp256r1 and
 secp384r1 curves and payload integrity assured with the `MI: mi-sha256` and
 `Digest: SHA-256` header fields.
+
+### Open Questions ### {#oq-accept-signature}
+
+Is an `Accept-Signature` header useful enough to pay for itself? If clients wind
+up sending it on most requests, that may cost more than the cost of sending
+`Signature`s unconditionally. On the other hand, it gives servers an indication
+of which kinds of signatures are supported, which can help us upgrade the
+ecosystem in the future.
+
+Is `Accept-Signature` the right spelling, or do we want to imitate `Want-Digest`
+(Section 4.3.1 of {{?RFC3230}}) instead?
+
+Do I have the right structure for the labels indicating feature support?
 
 # HTTP/2 extension for cross-origin Server Push # {#cross-origin-push}
 

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -662,7 +662,8 @@ When a server receives an `Accept-Signature` header field in a client request,
 it SHOULD reply with any available `Signature` header fields for its response
 that the `Accept-Signature` header field indicates the client supports. However,
 if the `Accept-Signature` value violates a requirement in this section, the
-server MUST NOT send any `Signature` headers.
+server MUST behave as if it hadn't received any `Accept-Signature` header at
+all.
 
 The `Accept-Signature` header field is a Structured Header as defined by
 {{!I-D.ietf-httpbis-header-structure}}. Its value MUST be a list (Section 4.8 of

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -717,23 +717,30 @@ states otherwise.
 The "ed25519key" label has parameters indicating the public keys that will be
 used to validate the returned signature. Each parameter's name is re-interpreted
 as binary content (Section 4.5 of {{!I-D.ietf-httpbis-header-structure}})
-encoding a prefix of the SHA-256 hash of the public key. For example, if the
+encoding a prefix of the public key. For example, if the
 client will validate signatures using the public key whose base64 encoding is
 `11qYAYKxCrfVS/7TyWQHOg7hcvPapiMlrwIaaPcHURo`, valid `Accept-Signature` header fields include:
 
 ~~~http
-Accept-Signature: ..., ed25519key; *If4x36FUomFia/hUBG/SJxt77UtqvkWqWId+9H+XIbk
-Accept-Signature: ..., ed25519key; *If4x36FUomFia/hUBG/SJw
-Accept-Signature: ..., ed25519key; *If4x3w
+Accept-Signature: ..., ed25519key; *11qYAYKxCrfVS/7TyWQHOg7hcvPapiMlrwIaaPcHURo
+Accept-Signature: ..., ed25519key; *11qYAYKxCrfVS/7TyWQHOg
+Accept-Signature: ..., ed25519key; *11qYAQ
 Accept-Signature: ..., ed25519key; *
 ~~~
 
 but not
 
 ~~~http
-Accept-Signature: ..., ed25519key; *If4x3
-Accept-Signature: ..., ed25519key; If4x3w
+Accept-Signature: ..., ed25519key; *11qYA
 ~~~
+
+because 5 bytes isn't a valid length for encoded base64, and not
+
+~~~http
+Accept-Signature: ..., ed25519key; 11qYAQ
+~~~
+
+because it doesn't start with the `*` that indicates binary content.
 
 Note that `ed25519key; *` is an empty prefix, which matches all public keys, so
 it's useful in subresource integrity ({{uc-sri}}) cases like `<link rel=preload


### PR DESCRIPTION
[Preview](https://jyasskin.github.io/webpackage/want-signature/draft-yasskin-http-origin-signed-responses.html), [Diff](https://tools.ietf.org/rfcdiff?url1=https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.txt&url2=https://jyasskin.github.io/webpackage/want-signature/draft-yasskin-http-origin-signed-responses.txt)

[RFC3230](https://tools.ietf.org/html/rfc3230#section-4.3.1) uses `Want-Digest` for a similar purpose, but `Accept-*` seems more common.

@cramforce, does this look sensible? Have I over- or under-complicated it?