### PR TITLE
Define application/http-exchange+cbor.

### DIFF
--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -1146,7 +1146,7 @@ Additional information:
 
   Magic number(s):  8? 64 68 74 78 67
 
-  File extension(s):  N/A
+  File extension(s): .htxg
 
   Macintosh file type code(s):  N/A
 

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -976,6 +976,13 @@ defined in Appendix G of {{?I-D.ietf-cbor-cddl}}:
 ]
 ~~~
 
+## Open Questions ## {#oq-application-http-exchange}
+
+Should `application/http-exchange+cbor` support request payloads and trailers,
+or only the aspects needed for signed exchanges?
+
+Are the mime type, extension, and magic number right?
+
 # Security considerations
 
 ## Confidential data ## {#seccons-confidentiality}


### PR DESCRIPTION
[Preview](https://jyasskin.github.io/webpackage/envelope-format/draft-yasskin-http-origin-signed-responses.html#application-http-exchange)

This format wraps an HTTP exchange, which allows an HTTP/1 connection to
transfer cross-origin signed exchanges, and which may have other uses.

@kinu @yoavweiss Does this look reasonable?