### PR TITLE
Avoid the TLS 1.3 Certificate message.

### DIFF
--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -569,9 +569,9 @@ there are no non-significant response header fields in the exchange.
    certificate chain in its Certificate Verify (Section 4.4.3 of
    {{?I-D.ietf-tls-tls13}}), in order to allow updating the stapled OCSP
    response without updating signatures at the same time.
-1. If `signature` is `message`'s signature by `publicKey` using `signing-alg`,
-   return "potentially-valid" with `exchange` and whichever is present of
-   `certificate-chain` or `ed25519Key`. Otherwise, return "invalid".
+1. If `signature` is a valid signature of `message` by `publicKey` using
+   `signing-alg`, return "potentially-valid" with `exchange` and whichever is
+   present of `certificate-chain` or `ed25519Key`. Otherwise, return "invalid".
 
 Note that the above algorithm can determine that an exchange's headers are
 potentially-valid before the exchange's payload is received. Similarly, if
@@ -1653,8 +1653,10 @@ RFC EDITOR PLEASE DELETE THIS SECTION.
 draft-03
 
 * Define a CBOR structure to hold the certificate chain instead of re-using the
-  TLS1.3 message. Apparently TLS implementations don't expose their message
-  parsers enough to allow passing a message to a certificate verifier.
+  TLS1.3 message. The TLS 1.3 parser fails on unexpected extensions while this
+  format should ignore them, and apparently TLS implementations don't expose
+  their message parsers enough to allow passing a message to a certificate
+  verifier.
 
 draft-02
 

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -386,7 +386,7 @@ extended diagnostic notation from {{?I-D.ietf-cbor-cddl}} appendix G:
 ]
 ~~~
 
-## Loading a certificate chain ## {#cert-chain}
+## Loading a certificate chain ## {#cert-chain-format}
 
 The resource at a signature's `certUrl` MUST have the
 `application/cert-chain+cbor` content type, MUST be canonically-encoded CBOR
@@ -515,8 +515,8 @@ there are no non-significant response header fields in the exchange.
 1. Set `publicKey` and `signing-alg` depending on which key fields are present:
    1. If `certUrl` is present:
       1. Let `certificate-chain` be the result of loading the certificate chain
-         at `certUrl` passing the `forceFetch` flag ({{cert-chain}}). If this
-         returns "invalid", return "invalid".
+         at `certUrl` passing the `forceFetch` flag ({{cert-chain-format}}). If
+         this returns "invalid", return "invalid".
       1. Let `main-certificate` be the first certificate in `certificate-chain`.
       1. Set `publicKey` to `main-certificate`'s public key.
       1. The client MUST define a partial function from public key types to
@@ -920,13 +920,14 @@ authoritative for the PUSH_PROMISE's authority.
       ({{!RFC5280}} and other undocumented conventions). Let `path` be the path
       that was used from the `main-certificate` to a trusted root, including the
       `main-certificate` but excluding the root.
-   1. Validate that `main-certificate` has an `ocsp` property ({{cert-chain}})
-      with a valid OCSP response whose lifetime (`nextUpdate - thisUpdate`) is
-      less than 7 days ({{!RFC6960}}). Note that this does not check for
-      revocation of intermediate certificates, and clients SHOULD implement
-      another mechanism for that.
-   1. Validate that all certificates in `path` include `sct` properties
-      ({{cert-chain}}) containing valid SCTs from trusted logs. ({{!RFC6962}})
+   1. Validate that `main-certificate` has an `ocsp` property
+      ({{cert-chain-format}}) with a valid OCSP response whose lifetime
+      (`nextUpdate - thisUpdate`) is less than 7 days ({{!RFC6960}}). Note that
+      this does not check for revocation of intermediate certificates, and
+      clients SHOULD implement another mechanism for that.
+   1. Validate that `main-certificate` has an `sct` property
+      ({{cert-chain-format}}) containing valid SCTs from trusted logs.
+      ({{!RFC6962}})
 1. Return "valid".
 
 ### Open Questions ### {#oq-cross-origin-push}
@@ -1246,7 +1247,7 @@ Security considerations:  N/A
 
 Interoperability considerations:  N/A
 
-Published specification:  This specification (see {{cert-chain}}).
+Published specification:  This specification (see {{cert-chain-format}}).
 
 Applications that use this media type:  N/A
 


### PR DESCRIPTION
Use a custom CBOR certificate chain format instead.

Also register this format with IANA.

@sleevi, better?

[Preview](https://jyasskin.github.io/webpackage/avoid-tls-messages/draft-yasskin-http-origin-signed-responses.html), [Diff](https://tools.ietf.org/rfcdiff?url1=https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.txt&url2=https://jyasskin.github.io/webpackage/avoid-tls-messages/draft-yasskin-http-origin-signed-responses.txt)