### PR TITLE
Replace the application/http-exchange+cbor format with a simpler format.

### DIFF
--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -1063,12 +1063,12 @@ and header fields, and a response payload.
 
 This content type consists of the concatenation of the following items:
 
-1. The ASCII characters "sxg" followed by a 0 byte, to serve as a file
+1. The ASCII characters "sxg1" followed by a 0 byte, to serve as a file
    signature.
 
    Note: RFC EDITOR PLEASE DELETE THIS NOTE; The implementation of the final RFC
    MUST use this file signature, but implementations of drafts MUST NOT use it
-   and MUST use another implementation-specific string beginning with "sxg-" and
+   and MUST use another implementation-specific string beginning with "sxg1-" and
    ending with a 0 byte instead.
 1. 3 bytes storing a big-endian integer `sigLength`. If this is larger
    than TBD, parsing MUST fail.
@@ -1106,7 +1106,7 @@ defined in Appendix G of {{?I-D.ietf-cbor-cddl}}, and most of the `Signature`
 header field and payload elided with a ...:
 
 ~~~
-sxg\0<3-byte length of the following header
+sxg1\0<3-byte length of the following header
 value>sig1; sig=*...; integrity="mi"; ...<3-byte length of the encoding of the
 following array>[
   {
@@ -1312,11 +1312,12 @@ Subtype name:  signed-exchange
 
 Required parameters:
 
-* v: An integer denoting the version of the file format. When used with the
-  `Accept` header field (Section 5.3.1 of {{!RFC7231}}), this parameter can be a
-  hyphen (-)-separated range of version numbers, or a comma (,)-separated list
-  of such ranges or individual version numbers. The server is then expected to
-  reply with a resource using a particular version within those ranges.
+* v: An integer denoting the version of the file format. The version defined in
+  this specification is `1`. When used with the `Accept` header field (Section
+  5.3.1 of {{!RFC7231}}), this parameter can be a hyphen (-)-separated range of
+  version numbers, or a comma (,)-separated list of such ranges or individual
+  version numbers. The server is then expected to reply with a resource using a
+  particular version within those ranges.
 
   Note: RFC EDITOR PLEASE DELETE THIS NOTE; Implementations of drafts of this
   specification MUST NOT use simple integers to describe their versions, and
@@ -1342,7 +1343,7 @@ Additional information:
 
   Deprecated alias names for this type:  N/A
 
-  Magic number(s):  73 78 67 00
+  Magic number(s):  73 78 67 31 00
 
   File extension(s): .sxg
 

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -1064,7 +1064,8 @@ and header fields, and a response payload.
 This content type consists of the concatenation of the following items:
 
 1. The ASCII characters "sxg1" followed by a 0 byte, to serve as a file
-   signature.
+   signature. This is redundant with the MIME type, and receipients that receive
+   both MUST ignore the values in these first 5 bytes.
 
    Note: RFC EDITOR PLEASE DELETE THIS NOTE; The implementation of the final RFC
    MUST use this file signature, but implementations of drafts MUST NOT use it
@@ -1072,10 +1073,10 @@ This content type consists of the concatenation of the following items:
    ending with a 0 byte instead.
 1. 3 bytes storing a big-endian integer `sigLength`. If this is larger
    than TBD, parsing MUST fail.
-1. `sigLength` bytes holding the `Signature` header field's value
-   ({{signature-header}}).
 1. 3 bytes storing a big-endian integer `headerLength`. If this is larger than
    TBD, parsing MUST fail.
+1. `sigLength` bytes holding the `Signature` header field's value
+   ({{signature-header}}).
 1. `headerLength` bytes holding the signed headers, the canonical serialization
    ({{canonical-cbor}}) of the CBOR representation of the request and response
    headers of the exchange represented by the `application/signed-exchange`
@@ -1086,8 +1087,10 @@ This content type consists of the concatenation of the following items:
 1. The payload body (Section 3.3 of {{!RFC7230}}) of the exchange represented by
    the `application/signed-exchange` resource.
 
-   Note that the use of the payload body here means that the `Transfer-Encoding`
-   header field has no effect.
+   Note that the use of the payload body here means that a `Transfer-Encoding`
+   header field inside the `application/signed-exchange` header block has no
+   effect. A `Transfer-Encoding` header field on the outer HTTP response that
+   transfers this resource still has its normal effect.
 
 ### Cross-origin trust in application/signed-exchange {#co-trust-app-signed-exchange}
 
@@ -1312,12 +1315,12 @@ Subtype name:  signed-exchange
 
 Required parameters:
 
-* v: An integer denoting the version of the file format. The version defined in
-  this specification is `1`. When used with the `Accept` header field (Section
-  5.3.1 of {{!RFC7231}}), this parameter can be a hyphen (-)-separated range of
-  version numbers (less than 10000), or a comma (,)-separated list of such
-  ranges or individual version numbers. The server is then expected to reply
-  with a resource using a particular version within those ranges.
+* v: A string denoting the version of the file format. ({{!RFC5234}} ABNF:
+  `version = DIGIT/%x61-7A`) The version defined in this specification is `1`.
+  When used with the `Accept` header field (Section 5.3.1 of {{!RFC7231}}), this
+  parameter can be a comma (,)-separated list of version strings. ({{!RFC5234}}
+  ABNF: `version-list = version *( "," version )`) The server is then expected
+  to reply with a resource using a particular version from that list.
 
   Note: RFC EDITOR PLEASE DELETE THIS NOTE; Implementations of drafts of this
   specification MUST NOT use simple integers to describe their versions, and

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -1065,7 +1065,7 @@ This content type consists of the concatenation of the following items:
 
 1. The ASCII characters "sxg1" followed by a 0 byte, to serve as a file
    signature. This is redundant with the MIME type, and receipients that receive
-   both MUST ignore the values in these first 5 bytes.
+   both MUST check that they match and stop parsing if they don't.
 
    Note: RFC EDITOR PLEASE DELETE THIS NOTE; The implementation of the final RFC
    MUST use this file signature, but implementations of drafts MUST NOT use it

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -1315,9 +1315,9 @@ Required parameters:
 * v: An integer denoting the version of the file format. The version defined in
   this specification is `1`. When used with the `Accept` header field (Section
   5.3.1 of {{!RFC7231}}), this parameter can be a hyphen (-)-separated range of
-  version numbers, or a comma (,)-separated list of such ranges or individual
-  version numbers. The server is then expected to reply with a resource using a
-  particular version within those ranges.
+  version numbers (less than 10000), or a comma (,)-separated list of such
+  ranges or individual version numbers. The server is then expected to reply
+  with a resource using a particular version within those ranges.
 
   Note: RFC EDITOR PLEASE DELETE THIS NOTE; Implementations of drafts of this
   specification MUST NOT use simple integers to describe their versions, and

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -1070,15 +1070,10 @@ This content type consists of the concatenation of the following items:
    MUST use this file signature, but implementations of drafts MUST NOT use it
    and MUST use another implementation-specific string beginning with "sxg-" and
    ending with a 0 byte instead.
-1. 3 bytes storing a big-endian integer `nonsignedLength`. If this is larger
+1. 3 bytes storing a big-endian integer `sigLength`. If this is larger
    than TBD, parsing MUST fail.
-1. `nonsignedLength` bytes holding the non-signed headers, a CBOR map containing
-   at least a key/value pair mapping the byte string 'signature' to a byte
-   string holding the `Signature` header field's value ({{signature-header}}).
-   If this CBOR item is not canonically serialized ({{canonical-cbor}}), parsing
-   MUST fail. Other key/value pairs MUST be ignored.
-
-   Note: This is a map instead of just a byte string for future extensibility.
+1. `sigLength` bytes holding the `Signature` header field's value
+   ({{signature-header}}).
 1. 3 bytes storing a big-endian integer `headerLength`. If this is larger than
    TBD, parsing MUST fail.
 1. `headerLength` bytes holding the signed headers, the canonical serialization
@@ -1111,9 +1106,9 @@ defined in Appendix G of {{?I-D.ietf-cbor-cddl}}, and most of the `Signature`
 header field and payload elided with a ...:
 
 ~~~
-sxg\0<3-byte length of the encoding of the following map>{
-  'signature': '...'
-}<3-byte length of the encoding of the following array>[
+sxg\0<3-byte length of the following header
+value>sig1; sig=*...; integrity="mi"; ...<3-byte length of the encoding of the
+following array>[
   {
     ':method': 'GET',
     ':url': 'https://example.com/',


### PR DESCRIPTION
This format:
* Doesn't require a streaming CBOR parser parse it from a network stream.
* Doesn't allow request payloads or response trailers, which don't fit into
  the signature model.
* Allows checking the signature before parsing the exchange headers.

This is similar to, but not exactly the same as the format @davidben proposed for #139: it pulls out the `Signature` header into bytestring before the other headers so that the second map can be literally the bytes in the signed string. This isn't extensible if we ever want to add new non-signed values, so I added a format version number into the format's magic number.

[Preview](https://jyasskin.github.io/webpackage/no-streaming/draft-yasskin-http-origin-signed-responses.html), [Diff](https://tools.ietf.org/rfcdiff?url1=https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.txt&url2=https://jyasskin.github.io/webpackage/no-streaming/draft-yasskin-http-origin-signed-responses.txt)

Fixes #135.