### PR TITLE
Fix #161: All HTTP header names should be lowercase.

### DIFF
--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -326,13 +326,13 @@ The CBOR representation of an exchange `exchange`'s headers is the CBOR
      request's method.
    * The byte string ':url' to the byte string containing `exchange`'s request's
      effective request URI.
-   * For each request header field in `exchange`, the header field's name as a
-     byte string to the header field's value as a byte string.
+   * For each request header field in `exchange`, the header field's lowercase
+     name as a byte string to the header field's value as a byte string.
 1. The map mapping:
    * the byte string ':status' to the byte string containing `exchange`'s
      response's 3-digit status code, and
-   * for each response header field in `exchange`, the header field's name as a
-     byte string to the header field's value as a byte string.
+   * for each response header field in `exchange`, the header field's lowercase
+     name as a byte string to the header field's value as a byte string.
 
 ### Example ### {#example-cbor-representation}
 

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -1078,9 +1078,9 @@ values:
 
 "request"
 
-: A map from request header field names to values, encoded as byte strings
-  ({{!RFC7049}}, section 2.1). The request header fields MUST include two
-  pseudo-header fields (Section 8.1.2.1 of {{!RFC7540}}):
+: A map from lowercase request header field names to their values, encoded as
+  byte strings ({{!RFC7049}}, section 2.1). The request header fields MUST
+  include two pseudo-header fields (Section 8.1.2.1 of {{!RFC7540}}):
 
   * `':method'`: The method of the request (Section 4 of {{!RFC7231}}).
   * `':url'`: The effective request URI of the request (Section 5.5 of
@@ -1093,9 +1093,9 @@ values:
 
 "response"
 
-: A map from response header field names to values, encoded as byte strings
-  ({{!RFC7049}}, section 2.1). The response header fields MUST include one
-  pseudo-header field (Section 8.1.2.1 of {{!RFC7540}}):
+: A map from lowercase response header field names to their values, encoded as
+  byte strings ({{!RFC7049}}, section 2.1). The response header fields MUST
+  include one pseudo-header field (Section 8.1.2.1 of {{!RFC7540}}):
 
   * `':status'`: The response's 3-digit status code (Section 6 of
     {{!RFC7231}}]).
@@ -1107,8 +1107,8 @@ values:
 
 "trailer"
 
-: A map of trailer header field names to values, encoded as byte strings
-  (Section 2.1 of {{!RFC7049}}).
+: A map of lowercase trailer header field names to their values, encoded as byte
+  strings (Section 2.1 of {{!RFC7049}}).
 
 A parser MAY return incremental information while parsing
 `application/http-exchange+cbor` content.

--- a/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
+++ b/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
@@ -243,13 +243,13 @@ The CBOR representation of an exchange `exchange`'s headers is the CBOR
      request's method.
    * The byte string ':url' to the byte string containing `exchange`'s request's
      effective request URI.
-   * For each request header field in `exchange`, the header field's name as a
-     byte string to the header field's value as a byte string.
+   * For each request header field in `exchange`, the header field's lowercase
+     name as a byte string to the header field's value as a byte string.
 1. The map mapping:
    * the byte string ':status' to the byte string containing `exchange`'s
      response's 3-digit status code, and
-   * for each response header field in `exchange`, the header field's name as a
-     byte string to the header field's value as a byte string.
+   * for each response header field in `exchange`, the header field's lowercse
+     name as a byte string to the header field's value as a byte string.
 
 ### Example ### {#example-cbor-representation}
 
@@ -661,12 +661,15 @@ signed-exchange-header = [
 ]
 ~~~
 
-The first element of the array is interpreted as the exchange's request headers,
-with the request method in the ':method' key's value, and the effective request
-URI in the ':url' key's value.
+The first element of the array is interpreted as the exchange's request headers
+with lowercase names, with the request method in the ':method' key's value, and
+the effective request URI in the ':url' key's value.
 
 The second element of the array is interpreted as the exchange's response
-headers, with the 3-digit response status code in the ':status' key's value.
+headers with lowercase names, with the 3-digit response status code in the
+':status' key's value.
+
+If any header field name includes uppercase characters, parsing MUST fail.
 
 Pass the `Signature` response header and the exchange with that header removed
 to the algorithm in {{cross-origin-trust}}. Fail if this returns "invalid".

--- a/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
+++ b/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
@@ -248,7 +248,7 @@ The CBOR representation of an exchange `exchange`'s headers is the CBOR
 1. The map mapping:
    * the byte string ':status' to the byte string containing `exchange`'s
      response's 3-digit status code, and
-   * for each response header field in `exchange`, the header field's lowercse
+   * for each response header field in `exchange`, the header field's lowercase
      name as a byte string to the header field's value as a byte string.
 
 ### Example ### {#example-cbor-representation}


### PR DESCRIPTION
Thanks @irori. Please double-check that I fixed everywhere that failed to specify that HTTP headers are named in lowercase.

Spec: [Preview](https://jyasskin.github.io/webpackage/lowercase-headers-in-cbor/draft-yasskin-http-origin-signed-responses.html), [Diff](https://tools.ietf.org/rfcdiff?url1=https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.txt&url2=https://jyasskin.github.io/webpackage/lowercase-headers-in-cbor/draft-yasskin-http-origin-signed-responses.txt)

Impl draft: [Preview](https://jyasskin.github.io/webpackage/lowercase-headers-in-cbor/draft-yasskin-httpbis-origin-signed-exchanges-impl.html), [Diff](https://tools.ietf.org/rfcdiff?url1=https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.txt&url2=https://jyasskin.github.io/webpackage/lowercase-headers-in-cbor/draft-yasskin-httpbis-origin-signed-exchanges-impl.txt)