### PR TITLE
Fix #169: Explicitly ignore SCTs in X.509 and OCSP extensions.

### DIFF
--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -863,6 +863,9 @@ returns "valid", return "valid". Otherwise, return "invalid".
    1. Validate that `main-certificate` has an `sct` property
       ({{cert-chain-format}}) containing valid SCTs from trusted logs.
       ({{!RFC6962}})
+
+      Note that SCTs embedded in the certificate via an X.509 extension or in
+      the OCSP response via an OCSP extension are ignored.
 1. Return "valid".
 
 ## Stateful header fields {#stateful-headers}


### PR DESCRIPTION
Thanks @irori.

@davidben @sleevi, is this the right thing to do? Or should I match [RFC6962](https://tools.ietf.org/html/rfc6962#section-3.3) by requiring clients to look in all three places?