### PR TITLE
Update key strings in serializeSignedMessage to lower-case

### DIFF
--- a/go/signedexchange/signedexchange_test.go
+++ b/go/signedexchange/signedexchange_test.go
@@ -109,7 +109,7 @@ s5B6gZsV/ojttR+aaeRknfrhQwEIA/k2r2oZE9yp8djzyiiqGswgw8yO0WSJztbx
 GRqzPwjon7ESIVpKLrVuh5qlMhUkOFUeF9wvViWX4qnV5Fvg
 -----END RSA PRIVATE KEY-----
 `
-	expectedSignatureHeader = "label; sig=*Ps6tOmsrdWWG0yHEOIfDhlVHPGMDHHWH5uatD054w7qcJy6l9TPu1lVBTy7bI1uK0Iz4IYcw8ObpbBTzdBVwyVy63axMVBiAjrYodCjKENC17Po3WJQ3IHnBAsxu9jOU+1Wsx7Jwg+kSBo075shBMs5AI9xmRdJVzEH2FySpxTK6SpPa77ZI7Cvf07WQ1OhRLefUAhy3+CcJGR/N8QdAgv/POvKv2xTcRcNNKJkcjlHrG0l5Zll9V9AE9b64Jj7jmM7ugBTfRopFAdqpLokBqf+Ip2vO/HGol4M93+M71h/YNPoVlpRakgK4dqVhZ3JzFi4ScvdktCv8F3BTru94tA==*; validity-url=\"https://example.com/resource.validity\"; integrity=\"mi\"; cert-url=\"https://example.com/cert.msg\"; cert-sha256=*ZC3lTYTDBJQVf1P2V7+fibTqbIsWNR/X7CWNVW+CEEA=*; date=1517418800; expires=1517422400"
+	expectedSignatureHeader = "label; sig=*Lmp9BbKLyARNvPkCec5oV/G9kbd/OzMbMBZq1502RZl5ieR3mcHxaeQyyIcJT3FUyMJTNV4lDtBWV2AobiF3J1ZXAOFrOp1SzYamGzjoRkJkEbKTgOu79zQTXq43D/pPIy//lCTKsRC+QoprnwdThxLXXvk73n7aG4CnKZUW1p0LzFcxFWDQ+xMCF4CYWVfL/AIGDu2+DsnYzyFO05jKeEAzR1jyc8ru2LYS2PgT19yC4jzFExNM+xz8lSRL5sDBsNSJ+yqfz2G3B+9fZIgyS8QeIMcXO4rrZtHxleIbVGXVgyZzz9dv7QkLgMWpChrBU6AQzljhDhknopyaPAzK3A==*; validity-url=\"https://example.com/resource.validity\"; integrity=\"mi\"; cert-url=\"https://example.com/cert.msg\"; cert-sha256=*ZC3lTYTDBJQVf1P2V7+fibTqbIsWNR/X7CWNVW+CEEA=*; date=1517418800; expires=1517422400"
 )
 
 type zeroReader struct{}

--- a/go/signedexchange/signer.go
+++ b/go/signedexchange/signer.go
@@ -51,21 +51,21 @@ func (s *Signer) serializeSignedMessage(e *Exchange) ([]byte, error) {
 	// mapping:" [spec text]
 	mes := []*cbor.MapEntryEncoder{}
 
-	// "3.1. If certSha256 is set: The text string "certSha256" to the byte string
-	// certSha256." [spec text]
+	// "3.1. If cert-sha256 is set: The text string "cert-sha256" to the byte string
+	// cert-sha256." [spec text]
 	if b := certSha256(s.Certs); len(b) > 0 {
 		mes = append(mes,
 			cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
-				keyE.EncodeTextString("certSha256")
+				keyE.EncodeTextString("cert-sha256")
 				valueE.EncodeByteString(b)
 			}))
 	}
 
 	mes = append(mes,
-		// "3.2. The text string "validityUrl" to the byte string value of validityUrl."
+		// "3.2. The text string "validity-url" to the byte string value of validity-url."
 		// [spec text]
 		cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
-			keyE.EncodeTextString("validityUrl")
+			keyE.EncodeTextString("validity-url")
 			valueE.EncodeByteString([]byte(s.ValidityUrl.String()))
 		}),
 		// "3.3. The text string "date" to the integer value of date."


### PR DESCRIPTION
This is a follow-up to #190.

#178 also changed the key strings in the canonical CBOR map.