### PR TITLE
gen-certurl: Make -sct flag optional

### DIFF
--- a/go/signedexchange/cmd/gen-certurl/main.go
+++ b/go/signedexchange/cmd/gen-certurl/main.go
@@ -32,9 +32,12 @@ func run(pemFilePath, ocspFilePath, sctFilePath string) error {
 		return err
 	}
 
-	sct, err := ioutil.ReadFile(sctFilePath)
-	if err != nil {
-		return err
+	var sct []byte
+	if sctFilePath != "" {
+		sct, err = ioutil.ReadFile(sctFilePath)
+		if err != nil {
+			return err
+		}
 	}
 
 	out, err := certurl.CertificateMessageFromPEM(in, ocsp, sct)


### PR DESCRIPTION
As discussed in #171, the sct field of the cbor cert chain should be optional. (See also #175)

cc: @jyasskin @horo-t