### PR TITLE
gen-signedexchange: Re-add the 64-byte signature padding

### DIFF
--- a/go/signedexchange/signedexchange_test.go
+++ b/go/signedexchange/signedexchange_test.go
@@ -109,7 +109,7 @@ s5B6gZsV/ojttR+aaeRknfrhQwEIA/k2r2oZE9yp8djzyiiqGswgw8yO0WSJztbx
 GRqzPwjon7ESIVpKLrVuh5qlMhUkOFUeF9wvViWX4qnV5Fvg
 -----END RSA PRIVATE KEY-----
 `
-	expectedSignatureHeader = "label; sig=*KKhJTqL1HCJYlh8ejPwuc0QucGsJoIW1OY0HV8AfF93+51K/QYtijCoWG0jefNGCOf2MOA/syhMwRtEqWzmBR92uBTWs27YSq6gO9ObC+IUXeUIUJX+Tr3spvDejWL20SR9qkLepa7/JrJdmM7Kw9brEd8LlcmKPYXqiDyfdtDdRvb5LuxVdZjZ2UvRcvGlfHVrQ7NA5tr7QF4tcwdL6xHeBiPkn9r0sPBtaOcXU04xTraQgSzusvjQjyqqnij1UcvpQsLL5ENsJJlVhAz+d8SMa4v0hHyvmvpoW+DYpvZRZMXhtoponfSszQxQdcZ230VG+FyZ5yDkMR4pz5iD5eQ==*; validity-url=\"https://example.com/resource.validity\"; integrity=\"mi\"; cert-url=\"https://example.com/cert.msg\"; cert-sha256=*ZC3lTYTDBJQVf1P2V7+fibTqbIsWNR/X7CWNVW+CEEA=*; date=1517418800; expires=1517422400"
+	expectedSignatureHeader = "label; sig=*WBpXmSAfHvg0ONKuqGy1sI0+U0j7kE7ZoclSxr1/VZwvHvwU5exZR2jD7HnCMkvSQBtoMseXkXwy/75xwDfksIH+vpGPyb51FNwONOO9HwCzlIN3IM1KIqgm/OQNKoNJs7CGZw9S+m+aj+n5cq6v30SU46jlgEn1qXzEhPLIE2x2eK2rBkk76ifqgjUuAwY46jOwq3ihjdGBakvbTrxjhGbhI3O1bn3Ueaucx5/dU+UKl+XqFq1r0kxIUF2KLXckPVYG4hVj2eHS9sGjG8C1vEDboxgcjB9lcmoryDCTCKfixQwSoZ+c84sb1x2rjjzuf8NskKReTsUExsiGsh9/Yg==*; validity-url=\"https://example.com/resource.validity\"; integrity=\"mi\"; cert-url=\"https://example.com/cert.msg\"; cert-sha256=*ZC3lTYTDBJQVf1P2V7+fibTqbIsWNR/X7CWNVW+CEEA=*; date=1517418800; expires=1517422400"
 )
 
 type zeroReader struct{}

--- a/go/signedexchange/signer.go
+++ b/go/signedexchange/signer.go
@@ -45,17 +45,22 @@ func (s *Signer) serializeSignedMessage(e *Exchange) ([]byte, error) {
 	// attacks when TLS certificates are used to sign manifests." [spec text]
 	var buf bytes.Buffer
 
-	// "1. A context string: the ASCII encoding of "HTTP Exchange"." [spec text]
+	// "1. A string that consists of octet 32 (0x20) repeated 64 times." [spec text]
+	for i := 0; i < 64; i++ {
+		buf.WriteByte(0x20)
+	}
+
+	// "2. A context string: the ASCII encoding of "HTTP Exchange"." [spec text]
 	buf.WriteString(contextString)
 
-	// "2. A single 0 byte which serves as a separator." [spec text]
+	// "3. A single 0 byte which serves as a separator." [spec text]
 	buf.WriteByte(0)
 
-	// "3. The bytes of the canonical CBOR serialization (Section 3.5) of a CBOR map
+	// "4. The bytes of the canonical CBOR serialization (Section 3.5) of a CBOR map
 	// mapping:" [spec text]
 	mes := []*cbor.MapEntryEncoder{}
 
-	// "3.1. If cert-sha256 is set: The text string "cert-sha256" to the byte string
+	// "4.1. If cert-sha256 is set: The text string "cert-sha256" to the byte string
 	// cert-sha256." [spec text]
 	if b := certSha256(s.Certs); len(b) > 0 {
 		mes = append(mes,
@@ -66,25 +71,25 @@ func (s *Signer) serializeSignedMessage(e *Exchange) ([]byte, error) {
 	}
 
 	mes = append(mes,
-		// "3.2. The text string "validity-url" to the byte string value of validity-url."
+		// "4.2. The text string "validity-url" to the byte string value of validity-url."
 		// [spec text]
 		cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
 			keyE.EncodeTextString("validity-url")
 			valueE.EncodeByteString([]byte(s.ValidityUrl.String()))
 		}),
-		// "3.3. The text string "date" to the integer value of date."
+		// "4.3. The text string "date" to the integer value of date."
 		// [spec text]
 		cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
 			keyE.EncodeTextString("date")
 			valueE.EncodeInt(s.Date.Unix())
 		}),
-		// "3.4. The text string "expires" to the integer value of expires."
+		// "4.4. The text string "expires" to the integer value of expires."
 		// [spec text]
 		cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
 			keyE.EncodeTextString("expires")
 			valueE.EncodeInt(s.Expires.Unix())
 		}),
-		// "3.5. The text string "headers" to the CBOR representation (Section
+		// "4.5. The text string "headers" to the CBOR representation (Section
 		// 3.4) of exchange's headers."
 		cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
 			keyE.EncodeTextString("headers")


### PR DESCRIPTION
Follows spec change after #180.