### PR TITLE
Fix the formatting in #index-section Step 3.7

### DIFF
--- a/draft-yasskin-dispatch-bundled-exchanges.md
+++ b/draft-yasskin-dispatch-bundled-exchanges.md
@@ -332,9 +332,9 @@ the parser MUST do the following:
       * header list is `headers`, and
       * client is null.
 
-   1. Let `streamOffset` be `sectionsStart + section-offsets\["responses"].offset
-      + offset`. That is, offsets in the index are relative to the start of the
-      "responses" section.
+   1. Let `streamOffset` be `sectionsStart +
+      section-offsets["responses"].offset + offset`. That is, offsets in the
+      index are relative to the start of the "responses" section.
    1. If `offset + length` is greater than
       `sectionOffsets["responses"].length`, return an error.
    1. Set `requests`\[`http-request`] to a struct whose "offset" item is


### PR DESCRIPTION
The leading `+` in L336 caused the markdown parser to interpret it as a new unordered list. This PR fixes it by moving the `+` to the end of previous line.