### PR TITLE
cmd: introduce dump-signedexchange tool

### DIFF
--- a/go/signedexchange/cbor/decoder.go
+++ b/go/signedexchange/cbor/decoder.go
@@ -1,0 +1,102 @@
+package cbor
+
+import (
+	"fmt"
+	"io"
+)
+
+type Decoder struct {
+	r io.Reader
+}
+
+func NewDecoder(r io.Reader) *Decoder {
+	return &Decoder{r}
+}
+
+func (d *Decoder) ReadByte() (byte, error) {
+	b := make([]byte, 1)
+	if _, err := io.ReadFull(d.r, b); err != nil {
+		return 0, err
+	}
+	return b[0], nil
+}
+
+const (
+	MaskType                  = 0xe0
+	MaskAdditionalInformation = 0x1f
+)
+
+func (d *Decoder) decodeTypedUInt() (Type, uint64, error) {
+	b, err := d.ReadByte()
+	if err != nil {
+		return TypeOther, 0, err
+	}
+
+	t := Type(b & MaskType)
+	ai := b & MaskAdditionalInformation
+	nfollow := 0
+	switch ai {
+	case 24:
+		nfollow = 1
+	case 25:
+		nfollow = 2
+	case 26:
+		nfollow = 4
+	case 27:
+		nfollow = 8
+	default:
+		nfollow = 0
+	}
+
+	n := uint64(0)
+
+	var follow []byte
+	if nfollow > 0 {
+		follow = make([]byte, nfollow)
+		if _, err := io.ReadFull(d.r, follow); err != nil {
+			return t, 0, fmt.Errorf("cbor: Failed to read %d bytes following the tag byte: %v", nfollow, err)
+		}
+		for i := 0; i < nfollow; i++ {
+			n = n<<8 | uint64(follow[i])
+		}
+	} else {
+		n = uint64(ai)
+	}
+
+	return t, n, nil
+}
+
+func (d *Decoder) decodeUintOfType(expected Type) (uint64, error) {
+	t, n, err := d.decodeTypedUInt()
+	if err != nil {
+		return 0, err
+	}
+	if t != expected {
+		return 0, fmt.Errorf("cbor: Expected type %v, got type %v", expected, t)
+	}
+	return n, nil
+}
+
+func (d *Decoder) DecodeArrayHeader() (uint64, error) {
+	return d.decodeUintOfType(TypeArray)
+}
+
+func (d *Decoder) DecodeMapHeader() (uint64, error) {
+	return d.decodeUintOfType(TypeMap)
+}
+
+func (d *Decoder) decodeBytesOfType(expected Type) ([]byte, error) {
+	n, err := d.decodeUintOfType(expected)
+	if err != nil {
+		return nil, err
+	}
+	bs := make([]byte, n)
+	if _, err := io.ReadFull(d.r, bs); err != nil {
+		return nil, err
+	}
+	return bs, nil
+}
+
+func (d *Decoder) DecodeByteString() ([]byte, error) {
+	return d.decodeBytesOfType(TypeBytes)
+}

--- a/go/signedexchange/cbor/decoder_test.go
+++ b/go/signedexchange/cbor/decoder_test.go
@@ -1,0 +1,50 @@
+package cbor_test
+
+import (
+	"bytes"
+	"testing"
+
+	. "github.com/WICG/webpackage/go/signedexchange/cbor"
+)
+
+func TestDecodeByteString(t *testing.T) {
+	var bytesTests = []struct {
+		in  []byte
+		out []byte
+	}{
+		{
+			in:  []byte{0x40},
+			out: []byte{},
+		},
+		{
+			in:  []byte{0x41, 0xab},
+			out: []byte{0xab},
+		},
+		{
+			in: []byte{
+				0x58, 0x19, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+				0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+				0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+				0x16, 0x17, 0x18,
+			},
+			out: []byte{
+				0, 1, 2, 3, 4, 5, 6, 7,
+				8, 9, 10, 11, 12, 13, 14, 15,
+				16, 17, 18, 19, 20, 21, 22, 23,
+				24,
+			},
+		},
+	}
+
+	for _, test := range bytesTests {
+		e := NewDecoder(bytes.NewReader(test.in))
+		got, err := e.DecodeByteString()
+		if err != nil {
+			t.Errorf("Encode. err: %v", err)
+		}
+
+		if !bytes.Equal(test.out, got) {
+			t.Errorf("%v expected to encode to %v, actual %v", test.in, test.out, got)
+		}
+	}
+}

--- a/go/signedexchange/cmd/dump-signedexchange/main.go
+++ b/go/signedexchange/cmd/dump-signedexchange/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/WICG/webpackage/go/signedexchange"
+)
+
+var (
+	flagInput = flag.String("i", "out.htxg", "Signed exchange file")
+)
+
+func run() error {
+	r, err := os.Open(*flagInput)
+	if err != nil {
+		return fmt.Errorf("Failed to open input file \"%s\". err: %v", *flagInput, err)
+	}
+
+	e, err := signedexchange.ReadExchangeFile(r)
+	if err != nil {
+		return fmt.Errorf("Failed to read exchange file: %v", err)
+	}
+	e.PrettyPrint(os.Stdout)
+
+	return nil
+}
+
+func main() {
+	flag.Parse()
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR introduces dump-exchange tool to pretty-print an signedexchange file.