### PR TITLE
Make MI encoding optional

### DIFF
--- a/go/signedexchange/cmd/gen-signedexchange/main.go
+++ b/go/signedexchange/cmd/gen-signedexchange/main.go
@@ -113,8 +113,11 @@ func run() error {
 	if resHeader.Get("content-type") == "" {
 		resHeader.Add("content-type", "text/html; charset=utf-8")
 	}
-	e, err := signedexchange.NewExchange(parsedUrl, reqHeader, *flagResponseStatus, resHeader, payload, *flagMIRecordSize)
+	e, err := signedexchange.NewExchange(parsedUrl, reqHeader, *flagResponseStatus, resHeader, payload)
 	if err != nil {
+		return err
+	}
+	if err := e.MiEncodePayload(*flagMIRecordSize); err != nil {
 		return err
 	}
 

--- a/go/signedexchange/signedexchange_test.go
+++ b/go/signedexchange/signedexchange_test.go
@@ -138,8 +138,11 @@ func TestSignedExchange(t *testing.T) {
 	header.Add("Foo", "Bar")
 	header.Add("Foo", "Baz")
 
-	e, err := NewExchange(u, nil, 200, header, []byte(payload), 16)
+	e, err := NewExchange(u, nil, 200, header, []byte(payload))
 	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.MiEncodePayload(16); err != nil {
 		t.Fatal(err)
 	}
 
@@ -236,8 +239,8 @@ func TestSignedExchangeStatefulHeader(t *testing.T) {
 	// Set-Cookie is a stateful header and not available.
 	header.Add("Set-Cookie", "wow, such cookie")
 
-	if _, err := NewExchange(u, nil, 200, header, []byte(payload), 16); err == nil {
-		t.Fail()
+	if _, err := NewExchange(u, nil, 200, header, []byte(payload)); err == nil {
+		t.Fatal(err)
 	}
 
 	// Header names are case-insensitive.
@@ -246,7 +249,7 @@ func TestSignedExchangeStatefulHeader(t *testing.T) {
 	header.Add("cOnTent-TyPe", "text/html; charset=utf-8")
 	header.Add("setProfile", "profile X")
 
-	if _, err := NewExchange(u, nil, 200, header, []byte(payload), 16); err == nil {
-		t.Fail()
+	if _, err := NewExchange(u, nil, 200, header, []byte(payload)); err == nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
WebBundling format doesn't require the payload to be MI encoded. This PR splits the encoding of the payload, so that it is possible to create an exchange without MI encoding.