### PR TITLE
Add IANA registrations for Accept-Signature and Signed-Headers headers.

### DIFF
--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -1302,6 +1302,36 @@ Author/Change controller:  IETF
 
 Specification document(s):  {{signature-header}} of this document
 
+## Accept-Signature Header Field Registration
+
+This section registers the `Accept-Signature` header field in the "Permanent
+Message Header Field Names" registry ({{!RFC3864}}).
+
+Header field name:  `Accept-Signature`
+
+Applicable protocol:  http
+
+Status:  standard
+
+Author/Change controller:  IETF
+
+Specification document(s):  {{accept-signature}} of this document
+
+## Signed-Headers Header Field Registration
+
+This section registers the `Signed-Headers` header field in the "Permanent
+Message Header Field Names" registry ({{!RFC3864}}).
+
+Header field name:  `Signed-Headers`
+
+Applicable protocol:  http
+
+Status:  standard
+
+Author/Change controller:  IETF
+
+Specification document(s):  {{signed-headers}} of this document
+
 ## HTTP/2 Settings
 
 This section establishes an entry for the HTTP/2 Settings Registry that was


### PR DESCRIPTION
[Preview](https://jyasskin.github.io/webpackage/register-headers/draft-yasskin-http-origin-signed-responses.html), [Diff](https://tools.ietf.org/rfcdiff?url1=https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.txt&url2=https://jyasskin.github.io/webpackage/register-headers/draft-yasskin-http-origin-signed-responses.txt)