### PR TITLE
In both random-access maps, store the index and contents in the same order.

### DIFF
--- a/draft-yasskin-wpack-bundled-exchanges.md
+++ b/draft-yasskin-wpack-bundled-exchanges.md
@@ -326,9 +326,7 @@ map, and the `metadata` map to fill in, the parser MUST do the following:
    matching the `index` rule in the above CDDL ({{parse-cbor}}). If `index` is
    an error, return an error.
 
-1. Let `currentOffset` be a positive integer.
-
-1. Check that the responses array has the right number of items, and compute `currentOffset`:
+1. Check that the responses array has the right number of items:
    1. Seek to offset `sectionOffsets["responses"].offset` in `stream`. If this
       fails, return an error.
 
@@ -339,9 +337,10 @@ map, and the `metadata` map to fill in, the parser MUST do the following:
    1. If `responsesType` is not `4` (a CBOR array) or `numResponses` is not half
       of the length of `index`, return an error.
 
-   1. Set `currentOffset` to the current offset within `stream` minus
-      `sectionOffsets["responses"].offset`. That is, the length of the array
-      header for the responses array.
+1. Let `currentOffset` be the current offset within `stream` minus
+   `sectionOffsets["responses"].offset`. That is, the length of the array header
+   for the responses array. This will track the offset of the current response
+   relative to the start of the responses array.
 
 1. Let `requests` be an initially-empty map ({{INFRA}}) from HTTP requests
    ({{FETCH}}) to structs ({{INFRA}}) with items named "offset" and "length".
@@ -370,15 +369,14 @@ map, and the `metadata` map to fill in, the parser MUST do the following:
       * header list is `headers`, and
       * client is null.
 
-   1. Let `streamOffset` be `sectionOffsets["responses"].offset +
-      currentOffset`. That is, offsets in the index are relative to the start of
-      the "responses" section.
+   1. Let `responseOffset` be `sectionOffsets["responses"].offset +
+      currentOffset`. This is relative to the start of the stream.
    1. If `currentOffset + length` is greater than
       `sectionOffsets["responses"].length`, return an error.
    1. If `requests`\[`http-request`] exists, return an error. That is, duplicate
       requests are forbidden.
    1. Set `requests`\[`http-request`] to a struct whose "offset" item is
-      `streamOffset` and whose "length" item is `length`.
+      `responseOffset` and whose "length" item is `length`.
    1. Set `currentOffset` to `currentOffset + length`.
 
 1. Set `metadata["requests"]` to `requests`.

--- a/draft-yasskin-wpack-bundled-exchanges.md
+++ b/draft-yasskin-wpack-bundled-exchanges.md
@@ -274,7 +274,7 @@ steps, taking the `stream` as input.
 
 1. Let `metadata` be an empty map ({{INFRA}}).
 
-1. For each `"name"`/\[`offset`, `length`] triple in `sectionOffsets`:
+1. For each (`"name"`, \[`offset`, `length`]) triple in `sectionOffsets`:
    1. If `"name"` isn't in `knownSections`, continue to the next triple.
    1. If `"name"`'s Metadata field ({{section-name-registry}}) is "No", continue
       to the next triple.
@@ -313,10 +313,10 @@ the parser MUST do the following:
 1. Let `requests` be an initially-empty map ({{INFRA}}) from HTTP requests
    ({{FETCH}}) to structs ({{INFRA}}) with items named "offset" and "length".
 
-1. For each `cbor-http-request`/\[`offset`, `length`] triple in `index`:
-   1. Let `headers`/`pseudos` be the result of converting `cbor-http-request` to
-      a header list and pseudoheaders using the algorithm in {{cbor-headers}}.
-      If this returns an error, return that error.
+1. For each (`cbor-http-request`, \[`offset`, `length`]) triple in `index`:
+   1. Let (`headers`, `pseudos`) be the result of converting `cbor-http-request`
+      to a header list and pseudoheaders using the algorithm in
+      {{cbor-headers}}. If this returns an error, return that error.
    1. If `pseudos` does not have keys named ':method' and ':url', or its size
       isn't 2, return an error.
    1. If `pseudos[':method']` is not 'GET', return an error.
@@ -461,7 +461,7 @@ as returned by {{semantics-load-metadata}}.
 1. Let `headerCbor` be the result of reading `headerLength` bytes from `stream`
    and parsing a CBOR item from them matching the `headers` CDDL rule. If either
    the read or parse returns an error, return that error.
-1. Let `headers`/`pseudos` be the result of converting `headerCbor` to a
+1. Let (`headers`, `pseudos`) be the result of converting `headerCbor` to a
    header list and pseudoheaders using the algorithm in {{cbor-headers}}. If
    this returns an error, return that error.
 1. If `pseudos` does not have a key named ':status' or its size isn't 1, return
@@ -567,7 +567,7 @@ parsers MUST do the following:
 1. Let `headers` be a new header list ({{FETCH}}).
 1. Let `pseudos` be an empty map ({{INFRA}}).
 
-1. For each pair `name`/`value` in `item`:
+1. For each pair (`name`, `value`) in `item`:
    1. If `name` contains any upper-case or non-ASCII characters, return an
       error. This matches the requirement in Section 8.1.2 of {{?RFC7540}}.
    1. If `name` starts with a ':':
@@ -584,9 +584,9 @@ parsers MUST do the following:
       Note: This means that a response cannot set more than one cookie, because
       the `Set-Cookie` header ({{?RFC6265}}) has to appear multiple times to set
       multiple cookies.
-   1. Append `name`/`value` to `headers`.
+   1. Append (`name`, `value`) to `headers`.
 
-1. Return `headers`/`pseudos`.
+1. Return (`headers`, `pseudos`).
 
 # Guidelines for bundle authors {#authoring-guidelines}
 

--- a/draft-yasskin-wpack-bundled-exchanges.md
+++ b/draft-yasskin-wpack-bundled-exchanges.md
@@ -203,12 +203,11 @@ The bundle is a CBOR item ({{?I-D.ietf-cbor-7049bis}}) with the following CDDL
 webbundle = [
   ; 🌐📦 in UTF-8.
   magic: h'F0 9F 8C 90 F0 9F 93 A6',
-  section-lengths: bytes .cbor [* (section-name, length: uint) ],
-  sections: [* $section ],
+  section-lengths: bytes .cbor [* (section-name: tstr, length: uint) ],
+  sections: [* any ],
   length: bytes .size 8,  ; Big-endian number of bytes in the bundle.
 ]
 
-section-name = $section-name .within tstr
 $section-name /= "index" / "manifest" / "critical" / "responses"
 
 $section /= index / manifest / critical / responses
@@ -224,7 +223,7 @@ information in the `section-lengths` CBOR item, which holds a list of
 alternating section names and section lengths:
 
 ~~~~~ cddl
-section-lengths = [* (section-name, length: uint) ],
+section-lengths = [* (section-name: tstr, length: uint) ],
 ~~~~~
 
 To implement {{semantics-load-metadata}}, the parser MUST run the following


### PR DESCRIPTION
[Preview](https://jyasskin.github.io/webpackage/ordered-responses/draft-yasskin-wpack-bundled-exchanges.html), [Diff](https://tools.ietf.org/rfcdiff?url1=https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.txt&url2=https://jyasskin.github.io/webpackage/ordered-responses/draft-yasskin-wpack-bundled-exchanges.txt)

This lets us store only lengths in the index, and compute offsets from
them, which in turn enforces that the contents don't overlap and don't
have gaps, making the content array well-formed CBOR.

This applies to both the section index and the request index.

Fixes #212.

Let me know if you see any places that the parser still isn't checking that the bundle is well-formed CBOR.