### PR TITLE
Start the -impl-01 draft.

### DIFF
--- a/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
+++ b/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
@@ -481,13 +481,11 @@ to retrieve an updated OCSP from the original server.
    anyone uses the same key in a TLS certificate and an exchange-signing
    certificate.
    1. A string that consists of octet 32 (0x20) repeated 64 times.
-   1. A context string: the ASCII encoding of "HTTP Exchange 1".
+   1. A context string: the ASCII encoding of "HTTP Exchange 1 b1".
 
-      Note: RFC EDITOR PLEASE DELETE THIS NOTE; The implementation of the final
-      RFC MUST use this context string, but implementations of drafts MUST NOT
-      use it and MUST use another draft-specific string beginning with "HTTP
-      Exchange 1 ” instead. This ensures that signers can predict how their
-      signatures will be used.
+      Note: As this is a snapshot of a draft of
+      {{?I-D.yasskin-http-origin-signed-responses}}, it uses a distinct context
+      string.
    1. A single 0 byte which serves as a separator.
    1. The bytes of the canonical CBOR serialization ({{canonical-cbor}}) of a
       CBOR map mapping:
@@ -965,14 +963,13 @@ and header fields, and a response payload.
 
 This content type consists of the concatenation of the following items:
 
-1. The ASCII characters "sxg1" followed by a 0 byte, to serve as a file
+1. The ASCII characters "sxg1-b1" followed by a 0 byte, to serve as a file
    signature. This is redundant with the MIME type, and recipients that receive
    both MUST check that they match and stop parsing if they don't.
 
-   Note: RFC EDITOR PLEASE DELETE THIS NOTE; The implementation of the final RFC
-   MUST use this file signature, but implementations of drafts MUST NOT use it
-   and MUST use another implementation-specific string beginning with "sxg1-" and
-   ending with a 0 byte instead.
+   Note: As this is a snapshot of a draft of
+   {{?I-D.yasskin-http-origin-signed-responses}}, it uses a distinct file
+   signature.
 1. 3 bytes storing a big-endian integer `sigLength`. If this is larger
    than 16kB, parsing MUST fail.
 1. 3 bytes storing a big-endian integer `headerLength`. If this is larger than
@@ -1058,52 +1055,14 @@ HTTP without TLS.
 
 # IANA considerations
 
-TODO: possibly register the validity-url format.
+This depends on the following IANA registrations in {{?I-D.yasskin-http-origin-signed-responses}}:
 
-## Signature Header Field Registration
+* The `Signature` header field
+* The `Accept-Signature` header field
+* The `Signed-Headers` header field
+* The application/cert-chain+cbor media type
 
-This section registers the `Signature` header field in the "Permanent Message
-Header Field Names" registry ({{!RFC3864}}).
-
-Header field name:  `Signature`
-
-Applicable protocol:  http
-
-Status:  standard
-
-Author/Change controller:  IETF
-
-Specification document(s):  {{signature-header}} of this document
-
-## Accept-Signature Header Field Registration
-
-This section registers the `Accept-Signature` header field in the "Permanent
-Message Header Field Names" registry ({{!RFC3864}}).
-
-Header field name:  `Accept-Signature`
-
-Applicable protocol:  http
-
-Status:  standard
-
-Author/Change controller:  IETF
-
-Specification document(s):  {{accept-signature}} of this document
-
-## Signed-Headers Header Field Registration
-
-This section registers the `Signed-Headers` header field in the "Permanent
-Message Header Field Names" registry ({{!RFC3864}}).
-
-Header field name:  `Signed-Headers`
-
-Applicable protocol:  http
-
-Status:  standard
-
-Author/Change controller:  IETF
-
-Specification document(s):  {{signed-headers}} of this document
+This document also modifies the registration for:
 
 ## Internet Media Type application/signed-exchange
 
@@ -1114,95 +1073,20 @@ Subtype name:  signed-exchange
 Required parameters:
 
 * v: A string denoting the version of the file format. ({{!RFC5234}} ABNF:
-  `version = DIGIT/%x61-7A`) The version defined in this specification is `1`.
+  `version = DIGIT/%x61-7A`) The version defined in this specification is `b1`.
   When used with the `Accept` header field (Section 5.3.1 of {{!RFC7231}}), this
   parameter can be a comma (,)-separated list of version strings. ({{!RFC5234}}
   ABNF: `version-list = version *( "," version )`) The server is then expected
   to reply with a resource using a particular version from that list.
 
-  Note: RFC EDITOR PLEASE DELETE THIS NOTE; Implementations of drafts of this
-  specification MUST NOT use simple integers to describe their versions, and
-  MUST instead define implementation-specific strings to identify which draft is
-  implemented.
+  Note: As this is a snapshot of a draft of
+  {{?I-D.yasskin-http-origin-signed-responses}}, it uses a distinct version
+  number.
 
-Optional parameters:  N/A
+Magic number(s):  73 78 67 31 2D 62 31 00
 
-Encoding considerations:  binary
-
-Security considerations:  see Section 6.6 of {{!I-D.yasskin-http-origin-signed-responses}}
-
-Interoperability considerations:  N/A
-
-Published specification:  This specification (see
-{{application-signed-exchange}}).
-
-Applications that use this media type:  N/A
-
-Fragment identifier considerations:  N/A
-
-Additional information:
-
-  Deprecated alias names for this type:  N/A
-
-  Magic number(s):  73 78 67 31 00
-
-  File extension(s): .sxg
-
-  Macintosh file type code(s):  N/A
-
-Person and email address to contact for further information: See Authors'
-  Addresses section.
-
-Intended usage:  COMMON
-
-Restrictions on usage:  N/A
-
-Author:  See Authors' Addresses section.
-
-Change controller:  IESG
-
-## Internet Media Type application/cert-chain+cbor
-
-Type name:  application
-
-Subtype name:  cert-chain+cbor
-
-Required parameters:  N/A
-
-Optional parameters:  N/A
-
-Encoding considerations:  binary
-
-Security considerations:  N/A
-
-Interoperability considerations:  N/A
-
-Published specification:  This specification (see {{cert-chain-format}}).
-
-Applications that use this media type:  N/A
-
-Fragment identifier considerations:  N/A
-
-Additional information:
-
-  Deprecated alias names for this type:  N/A
-
-  Magic number(s): 1*9(??) 67 F0 9F 93 9C E2 9B 93
-
-  File extension(s): N/A
-
-  Macintosh file type code(s):  N/A
-
-Person and email address to contact for further information: See Authors'
-  Addresses section.
-
-Intended usage:  COMMON
-
-Restrictions on usage:  N/A
-
-Author:  See Authors' Addresses section.
-
-Change controller:  IESG
+The other fields are the same as the registration in
+{{?I-D.yasskin-http-origin-signed-responses}}.
 
 --- back
 
@@ -1218,6 +1102,7 @@ Vs. {{I-D.yasskin-http-origin-signed-responses-04}}:
 * Removed non-normative sections.
 * The mi-sha256 encoding must have records <= 16kB.
 * The signature and HTTP headers must each be <=16kB long.
+* Versions in file signatures and context strings are "b1".
 
 draft-00
 

--- a/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
+++ b/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
@@ -326,19 +326,19 @@ cert-chain = [
 ]
 ~~~
 
-The first item in the CBOR array is treated as the end-entity certificate, and
-the client will attempt to build a path ({{?RFC5280}}) to it from a trusted root
-using the other certificates in the chain.
+The first map (second item) in the CBOR array is treated as the end-entity
+certificate, and the client will attempt to build a path ({{?RFC5280}}) to it
+from a trusted root using the other certificates in the chain.
 
 1. Each `cert` value MUST be a DER-encoded X.509v3 certificate ({{!RFC5280}}).
    Other key/value pairs in the same array item define properties of this
    certificate.
-1. The first certificate's `ocsp` value if any MUST be a complete, DER-encoded
-   OCSP response for that certificate (using the ASN.1 type `OCSPResponse`
-   defined in {{!RFC6960}}). Subsequent certificates MUST NOT have an `ocsp`
-   value.
-1. Each certificate's `sct` value MUST be a `SignedCertificateTimestampList` for
-   that certificate as defined by Section 3.3 of {{!RFC6962}}.
+1. The first certificate's `ocsp` value MUST be a complete, DER-encoded OCSP
+   response for that certificate (using the ASN.1 type `OCSPResponse` defined in
+   {{!RFC6960}}). Subsequent certificates MUST NOT have an `ocsp` value.
+1. Each certificate's `sct` value if any MUST be a
+   `SignedCertificateTimestampList` for that certificate as defined by Section
+   3.3 of {{!RFC6962}}.
 
 Loading a `cert-url` takes a `forceFetch` flag. The client MUST:
 
@@ -554,7 +554,7 @@ Signature:
 
 At 2017-11-27 11:02 UTC, `sig1` has expired, so the client needs to fetch
 `https://example.com/resource.validity.1511157180` (the `validity-url` of
-`sig1`) to update that signature. This URL might contain:
+`sig1`) if it wishes to update that signature. This URL might contain:
 
 ~~~cbor-diag
 {
@@ -935,10 +935,9 @@ This content type consists of the concatenation of the following items:
 ### Cross-origin trust in application/signed-exchange {#co-trust-app-signed-exchange}
 
 To determine whether to trust a cross-origin exchange stored in an
-`application/signed-exchange` resource, pass the `Signature` header field from
-the non-signed header section and an exchange consisting of the headers from the
-signed headers section and the payload body, to the algorithm in
-{{cross-origin-trust}}.
+`application/signed-exchange` resource, pass the `Signature` header field's
+value and an exchange consisting of the headers from the signed headers section
+and the payload body, to the algorithm in {{cross-origin-trust}}.
 
 ### Example ## {#example-application-signed-exchange}
 
@@ -950,8 +949,8 @@ header field and payload elided with a ...:
 
 ~~~
 sxg1\0<3-byte length of the following header
-value>sig1; sig=*...; integrity="mi-draft2"; ...<3-byte length of the encoding of the
-following array>[
+value><3-byte length of the encoding of the
+following array>sig1; sig=*...; integrity="mi-draft2"; ...[
   {
     ':method': 'GET',
     ':url': 'https://example.com/',
@@ -1070,5 +1069,5 @@ Vs. {{I-D.yasskin-http-origin-signed-responses-03}}:
 
 # Acknowledgements
 
-Thanks to Ilari Liusvaara, Justin Schuh, Mark Nottingham, Mike Bishop, Ryan
-Sleevi, and Yoav Weiss for comments that improved this draft.
+Thanks to Devin Mullins, Ilari Liusvaara, Justin Schuh, Mark Nottingham, Mike
+Bishop, Ryan Sleevi, and Yoav Weiss for comments that improved this draft.

--- a/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
+++ b/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
@@ -218,7 +218,7 @@ readability.
 Signature:
  sig1;
   sig=*MEUCIQDXlI2gN3RNBlgFiuRNFpZXcDIaUpX6HIEwcZEc0cZYLAIga9DsVOMM+g5YpwEBdGW3sS+bvnmAJJiSMwhuBdqp5UY=*;
-  integrity="mi";
+  integrity="mi-draft2";
   validity-url="https://example.com/resource.validity.1511128380";
   cert-url="https://example.com/oldcerts";
   cert-sha256=*W7uB969dFW3Mb5ZefPS9Tq5ZbH5iSmOILpjv2qEArmI=*;
@@ -314,8 +314,8 @@ Accept: */*
 
 HTTP/1.1 200
 Content-Type: text/html
-MI: mi-sha256=20addcf7368837f616d549f035bf6784ea6d4bf4817a3736cd2fc7a763897fe3
-Signed-Headers: "content-type", "mi"
+MI-Draft2: mi-sha256-draft2=dcRDgR2GM35DluAV13PzgnG6-pvQwPywfFvAu1UeFrs
+Signed-Headers: "content-type", "mi-draft2"
 
 <!doctype html>
 <html>
@@ -333,7 +333,7 @@ extended diagnostic notation from {{?I-D.ietf-cbor-cddl}} appendix G:
     ':method': 'GET',
   },
   {
-    'mi': 'mi-sha256=20addcf7368837f616d549f035bf6784ea6d4bf4817a3736cd2fc7a763897fe3',
+    'mi-draft2': 'mi-sha256-draft2=dcRDgR2GM35DluAV13PzgnG6-pvQwPywfFvAu1UeFrs',
     ':status': '200',
     'content-type': 'text/html'
   }
@@ -447,15 +447,15 @@ to retrieve an updated OCSP from the original server.
    * `date` be the signature's "date" parameter, interpreted as a Unix time.
    * `expires` be the signature's "expires" parameter, interpreted as a Unix
      time.
-1. If `integrity` names a header field that is not present in `exchange`'s
-   response headers or which the client cannot use to check the integrity of
-   `payload` (for example, the header field is new and hasn't been implemented
-   yet), then return "invalid". If the selected header field provides integrity
-   guarantees weaker than SHA-256, return "invalid". If validating integrity
+1. If `integrity` names a header field other than `MI-Draft2` or this header
+   field is not present in `exchange`'s response headers, then return "invalid".
+   If validating integrity
    using the selected header field requires the client to process records larger
-   than TBD bytes, return "invalid". Clients MUST implement at least the `MI`
-   ({{!I-D.thomson-http-mice}}) header field with its `mi-sha256` content
-   encoding.
+   than TBD (for example, if the `mi-sha256-draft2` record length is greater
+   than TBD), return "invalid". Clients MUST be able to check the integrity of
+   `payload` using the `MI-Draft2` header field with its `mi-sha256-draft2`
+   content encoding, which are defined equivalently to the `MI` header field and
+   `mi-sha256` content encoding from {{!I-D.thomson-http-mice}}.
 1. Set `publicKey` and `signing-alg` depending on which key fields are present:
    1. If `cert-url` is present:
       1. Let `certificate-chain` be the result of loading the certificate chain
@@ -514,7 +514,7 @@ to retrieve an updated OCSP from the original server.
 
 Note that the above algorithm can determine that an exchange's headers are
 potentially-valid before the exchange's payload is received. Similarly, if
-`integrity` identifies a header field like `MI` ({{?I-D.thomson-http-mice}})
+`integrity` identifies a header field like `MI-Draft2` ({{?I-D.thomson-http-mice}})
 that can incrementally validate the payload, early parts of the payload can be
 determined to be potentially-valid before later parts of the payload.
 Higher-level protocols MAY process parts of the exchange that have been
@@ -609,7 +609,7 @@ and `sig2`) to update those signatures. This URL might contain:
     'sig1; '
     'sig=*MEQCIC/I9Q+7BZFP6cSDsWx43pBAL0ujTbON/+7RwKVk+ba5AiB3FSFLZqpzmDJ0NumNwN04pqgJZE99fcK86UjkPbj4jw==*; '
     'validity-url="https://example.com/resource.validity.1511157180"; '
-    'integrity="mi"; '
+    'integrity="mi-draft2"; '
     'cert-url="https://example.com/newcerts"; '
     'cert-sha256=*J/lEm9kNRODdCmINbvitpvdYKNQ+YgBj99DlYp4fEXw=*; '
     'date=1511733180; expires=1512337980'
@@ -680,15 +680,16 @@ parameters on existing identifiers may be defined by future specifications.
 
 ### Integrity identifiers ### {#accept-signature-integrity}
 
-Identifiers starting with "mi/" indicate that the client supports the `MI`
-header field ({{!I-D.thomson-http-mice}}) with the parameter from the HTTP MI
+Identifiers starting with "mi-draft2/" indicate that the client supports the
+`MI-Draft2` header field (equivalent to `MI` in {{!I-D.thomson-http-mice}}) with
+the parameter from the HTTP MI
 Parameter Registry registry named in lower-case by the rest of the identifier.
-For example, "mi/mi-blake2" indicates support for Merkle integrity with the
-as-yet-unspecified mi-blake2 parameter, and "-digest/mi-sha256" indicates
-non-support for Merkle integrity with the mi-sha256 content encoding.
+For example, "mi-draft2/mi-blake2" indicates support for Merkle integrity with the
+as-yet-unspecified mi-blake2 parameter, and "-mi-draft2/mi-sha256-draft2" indicates
+non-support for Merkle integrity with the mi-sha256-draft2 content encoding.
 
 If the `Accept-Signature` header field is present, servers SHOULD assume support
-for "mi/mi-sha256" unless the header field states otherwise.
+for "mi-draft2/mi-sha256-draft2" unless the header field states otherwise.
 
 ### Key type identifiers ### {#accept-signature-key-types}
 
@@ -738,11 +739,11 @@ as=script href="...">` where the public key isn't known until the matching
 ### Examples ### {#accept-signature-examples}
 
 ~~~http
-Accept-Signature: mi/mi-sha256
+Accept-Signature: mi-draft2/mi-sha256
 ~~~
 
 states that the client will accept signatures with payload integrity assured by
-the `MI` header and `mi-sha256` content encoding and implies that the client
+the `MI-Draft2` header and `mi-sha256-draft2` content encoding and implies that the client
 will accept integrity assured by the `Digest: SHA-256` header and signatures
 from ECDSA keys on the secp256r1 curve.
 
@@ -751,8 +752,8 @@ Accept-Signature: -ecdsa/secp256r1, ecdsa/secp384r1
 ~~~
 
 states that the client will accept ECDSA keys on the secp384r1 curve but not the
-secp256r1 curve and payload integrity assured with the `MI: mi-sha256` header
-field.
+secp256r1 curve and payload integrity assured with the `MI-Draft2:
+mi-sha256-draft2` header field.
 
 # Cross-origin trust {#cross-origin-trust}
 
@@ -1011,7 +1012,7 @@ header field and payload elided with a ...:
 
 ~~~
 sxg1\0<3-byte length of the following header
-value>sig1; sig=*...; integrity="mi"; ...<3-byte length of the encoding of the
+value>sig1; sig=*...; integrity="mi-draft2"; ...<3-byte length of the encoding of the
 following array>[
   {
     ':method': 'GET',
@@ -1211,8 +1212,8 @@ draft-01
 
 Vs. {{I-D.yasskin-http-origin-signed-responses-04}}:
 
-* The mi-sha256 content-encoding is renamed to mi-sha256-draft2 in case
-  {{?I-D.thomson-http-mice}} changes.
+* The MI header and mi-sha256 content-encoding are renamed to MI-Draft2 and
+  mi-sha256-draft2 in case {{?I-D.thomson-http-mice}} changes.
 * Signed exchanges cannot be transmitted using HTTP/2 Push.
 * Removed non-normative sections.
 

--- a/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
+++ b/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
@@ -953,56 +953,7 @@ to include in the `Signed-Headers` header field.
 
 ## HTTP/2 extension for cross-origin Server Push # {#cross-origin-push}
 
-To allow servers to Server-Push (Section 8.2 of {{?RFC7540}}) signed exchanges
-({{proposal}}) signed by an authority for which the server is not authoritative
-(Section 9.1 of {{?RFC7230}}), this section defines an HTTP/2 extension.
-
-### Indicating support for cross-origin Server Push # {#setting}
-
-Clients that might accept signed Server Pushes with an authority for which the
-server is not authoritative indicate this using the HTTP/2 SETTINGS parameter
-ENABLE_CROSS_ORIGIN_PUSH (0xSETTING-TBD).
-
-An ENABLE_CROSS_ORIGIN_PUSH value of 0 indicates that the client does not
-support cross-origin Push. A value of 1 indicates that the client does support
-cross-origin Push.
-
-A client MUST NOT send a ENABLE_CROSS_ORIGIN_PUSH setting with a value other
-than 0 or 1 or a value of 0 after previously sending a value of 1. If a server
-receives a value that violates these rules, it MUST treat it as a connection
-error (Section 5.4.1 of {{!RFC7540}}) of type PROTOCOL_ERROR.
-
-The use of a SETTINGS parameter to opt-in to an otherwise incompatible protocol
-change is a use of "Extending HTTP/2" defined by Section 5.5 of {{?RFC7540}}. If
-a server were to send a cross-origin Push without first receiving a
-ENABLE_CROSS_ORIGIN_PUSH setting with the value of 1 it would be a protocol
-violation.
-
-### NO_TRUSTED_EXCHANGE_SIGNATURE error code {#error-code}
-
-The signatures on a Pushed cross-origin exchange may be untrusted for several
-reasons, for example that the certificate could not be fetched, that the
-certificate does not chain to a trusted root, that the signature itself doesn't
-validate, that the signature is expired, etc. This draft conflates all of these
-possible failures into one error code, NO_TRUSTED_EXCHANGE_SIGNATURE
-(0xERROR-TBD).
-
-### Validating a cross-origin Push ## {#validating-cross-origin-push}
-
-If the client has set the ENABLE_CROSS_ORIGIN_PUSH setting to 1, the server MAY
-Push a signed exchange for which it is not authoritative, and the client MUST
-NOT treat a PUSH_PROMISE for which the server is not authoritative as a stream
-error (Section 5.4.2 of {{!RFC7540}}) of type PROTOCOL_ERROR, as described in
-Section 8.2 of {{?RFC7540}}.
-
-Instead, the client MUST validate such a PUSH_PROMISE and its response by taking
-the `Signature` header field from the response, and the exchange consisting of
-the PUSH_PROMISE and the response without that `Signature` header field, and
-passing them to the algorithm in {{cross-origin-trust}}. If this returns
-"invalid", the client MUST treat the response as a stream error (Section 5.4.2
-of {{!RFC7540}}) of type NO_TRUSTED_EXCHANGE_SIGNATURE. Otherwise, the client
-MUST treat the pushed response as if the server were authoritative for the
-PUSH_PROMISE's authority.
+Cross origin push is not implemented.
 
 ## application/signed-exchange format # {#application-signed-exchange}
 
@@ -1153,33 +1104,6 @@ Author/Change controller:  IETF
 
 Specification document(s):  {{signed-headers}} of this document
 
-## HTTP/2 Settings
-
-This section establishes an entry for the HTTP/2 Settings Registry that was
-established by Section 11.3 of {{!RFC7540}}
-
-Name: ENABLE_CROSS_ORIGIN_PUSH
-
-Code: 0xSETTING-TBD
-
-Initial Value: 0
-
-Specification: This document
-
-## HTTP/2 Error code
-
-This section establishes an entry for the HTTP/2 Error Code Registry that was
-established by Section 11.4 of {{!RFC7540}}
-
-Name: NO_TRUSTED_EXCHANGE_SIGNATURE
-
-Code: 0xERROR-TBD
-
-Description: The client does not trust the signature for a cross-origin Pushed
-signed exchange.
-
-Specification: This document
-
 ## Internet Media Type application/signed-exchange
 
 Type name:  application
@@ -1289,6 +1213,7 @@ Vs. {{I-D.yasskin-http-origin-signed-responses-04}}:
 
 * The mi-sha256 content-encoding is renamed to mi-sha256-draft2 in case
   {{?I-D.thomson-http-mice}} changes.
+* Signed exchanges cannot be transmitted using HTTP/2 Push.
 * Removed non-normative sections.
 
 draft-00

--- a/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
+++ b/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
@@ -26,12 +26,6 @@ normative:
     author:
       org: WHATWG
     date: Living Standard
-  HTML:
-    target: https://html.spec.whatwg.org/multipage
-    title: HTML
-    author:
-      org: WHATWG
-    date: Living Standard
   POSIX:
     target: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/
     title: The Open Group Base Specifications Issue 7
@@ -48,15 +42,9 @@ normative:
     author:
       org: WHATWG
     date: Living Standard
-  I-D.ietf-httpbis-header-structure-02:
-    target: https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-02
-    title: Structured Headers for HTTP
-    author:
-      - name: Mark Nottingham
-      - name: Poul-Henning Kamp
-    seriesinfo:
-      Internet-Draft: draft-ietf-httpbis-header-structure-02
-    date: 2017-11-27
+
+informative:
+  SRI: W3C.REC-SRI-20160623
 
 --- abstract
 
@@ -82,14 +70,24 @@ Each version of this document describes a checkpoint of
 clients, intermediates, and publishers. It defines a technique to detect which
 version each party has implemented so that mismatches can be detected up-front.
 
+# Terminology {#terminology}
 
+Absolute URL
+: A string for which the [URL
+ parser](https://url.spec.whatwg.org/#concept-url-parser) ({{URL}}), when run
+ without a base URL, returns a URL rather than a failure, and for which that URL
+ has a null fragment. This is similar to the [absolute-URL
+ string](https://url.spec.whatwg.org/#absolute-url-string) concept defined by
+ ({{URL}}) but might not include exactly the same strings.
 
-# Terminology
+Author
+: The entity that wrote the content in a particular resource. This specification
+  deals with publishers rather than authors.
 
 Publisher
 : The entity that controls the server for a particular origin {{?RFC6454}}. The
-  publisher can get a CA to issue certificates for their private keys and can run a
-  TLS server for their origin.
+  publisher can get a CA to issue certificates for their private keys and can
+  run a TLS server for their origin.
 
 Exchange (noun)
 : An HTTP request/response pair. This can either be a request from a client and
@@ -97,7 +95,7 @@ the matching response from a server or the request in a PUSH_PROMISE and its
 matching response stream. Defined by Section 8 of {{!RFC7540}}.
 
 Intermediate
-: An entity that fetches signed HTTP exchanges from an publisher or another
+: An entity that fetches signed HTTP exchanges from a publisher or another
   intermediate and forwards them to another intermediate or a client.
 
 Client
@@ -135,59 +133,63 @@ this validity information for some period of time.
 
 ## The Signature Header ## {#signature-header}
 
-The `Signature` header field conveys a single signature for an exchange,
-accompanied by information about how to determine the authority of and
+The `Signature` header field conveys a list of signatures for an exchange, each
+one accompanied by information about how to determine the authority of and
 refresh that signature. Each signature directly signs the exchange's headers and
 identifies one of those headers that enforces the integrity of the exchange's
 payload.
 
 The `Signature` header is a Structured Header as defined by
-{{I-D.ietf-httpbis-header-structure-02}}. Its value MUST be a list (Section 4.8 of
-{{I-D.ietf-httpbis-header-structure-02}}) of parameterised labels (Section 4.4 of
-{{I-D.ietf-httpbis-header-structure-02}}), and the list MUST contain exactly one
-element.
+{{!I-D.ietf-httpbis-header-structure}}. Its value MUST be a parameterised list
+(Section 3.3 of {{!I-D.ietf-httpbis-header-structure}}). Its ABNF is:
 
-Each parameterised label MUST have parameters named "sig", "integrity",
-"validityUrl", "date", and "expires". Each parameterised label MUST also have
-"certUrl" and "certSha256" parameters. This
-specification gives no meaning to the label itself, which can be used as a
-human-readable identifier for the signature (see {{parameterised-binary}}). The
-present parameters MUST have the following values:
+    Signature = sh-param-list
+
+Each parameterised identifier in the list MUST have parameters named "sig",
+"integrity", "validity-url", "date", and "expires". Each parameterised identifier
+MUST also have either "cert-url" and "cert-sha256" parameters or an "ed25519key"
+parameter. This specification gives no meaning to the identifier itself, which
+can be used as a human-readable identifier for the signature (see
+{{parameterised-binary}}). The present parameters MUST have the following
+values:
 
 "sig"
 
-: Binary content (Section 4.5 of {{I-D.ietf-httpbis-header-structure-02}}) holding
+: Binary content (Section 3.9 of {{!I-D.ietf-httpbis-header-structure}}) holding
   the signature of most of these parameters and the exchange's headers.
 
 "integrity"
 
-: A string (Section 4.2 of {{I-D.ietf-httpbis-header-structure-02}}) containing
+: A string (Section 3.7 of {{!I-D.ietf-httpbis-header-structure}}) containing
   the lowercase name of the response header field that guards the response
   payload's integrity.
 
-"certUrl"
+"cert-url"
 
-: A string (Section 4.2 of {{I-D.ietf-httpbis-header-structure-02}}) containing
-  an [absolute-URL string](https://url.spec.whatwg.org/#absolute-url-string)
-  ({{URL}}).
+: A string (Section 3.7 of {{!I-D.ietf-httpbis-header-structure}}) containing an
+  absolute URL ({{terminology}}) with a scheme of "https" or "data".
 
-"certSha256"
+"cert-sha256"
 
-: Binary content (Section 4.5 of {{I-D.ietf-httpbis-header-structure-02}}) holding
-  the SHA-256 hash of the first certificate found at "certUrl".
+: Binary content (Section 3.9 of {{!I-D.ietf-httpbis-header-structure}}) holding
+  the SHA-256 hash of the first certificate found at "cert-url".
 
-{:#signature-validityurl} "validityUrl"
+"ed25519key"
 
-: A string (Section 4.2 of {{I-D.ietf-httpbis-header-structure-02}}) containing
-  an [absolute-URL string](https://url.spec.whatwg.org/#absolute-url-string)
-  ({{URL}}).
+: Binary content (Section 3.9 of {{!I-D.ietf-httpbis-header-structure}}) holding
+  an Ed25519 public key ({{!RFC8032}}).
+
+{:#signature-validityurl} "validity-url"
+
+: A string (Section 3.7 of {{!I-D.ietf-httpbis-header-structure}}) containing an
+  absolute URL ({{terminology}}) with a scheme of "https".
 
 "date" and "expires"
 
-: An unsigned integer (Section 4.1 of {{I-D.ietf-httpbis-header-structure-02}})
+: An integer (Section 3.5 of {{!I-D.ietf-httpbis-header-structure}})
   representing a Unix time.
 
-The "certUrl" parameter is *not* signed, so intermediates can update it with a
+The "cert-url" parameter is *not* signed, so intermediates can update it with a
 pointer to a cached version.
 
 ### Examples ### {#example-signature-header}
@@ -199,45 +201,79 @@ readability.
 ~~~http
 Signature:
  sig1;
-  sig=*t7LoYw6vwL2FSZRNJPYdNdYjfZSQkaCQeqpBD1whcy/6AAamVJ2OryXoXv6ACVBQgPV13o5de9oOVcOGGMX9fsf2ve1UDw/ITpeimB7n3zcuDEePzIcPbUnicicN2yodZAfr5il7BBJTs8L+V2ZERI16nJfrOZOvUfhvuUaMDGQXx5StIj7XLiX7/caxPz5ctwglgVAwCmoVPhmYFLq391O+hEssHSk2xkY6r/D9V2cKMikBBOTZ+JFyrnS/f2B4li7YASIY0YX64ifCmCw97cQTngXax6Upoie44IAe+6JngOie9JlDgcMF3YZ1uxNGWl9VwlalSwWgi1YA9Ff7mQ;
-  integrity="mi-draft2";
-  validityUrl="https://example.com/resource.validity.1511128380";
-  certUrl="https://example.com/certs";
-  certSha256=*W7uB969dFW3Mb5ZefPS9Tq5ZbH5iSmOILpjv2qEArmI;
-  date=1511128380; expires=1511733180
+  sig=*MEUCIQDXlI2gN3RNBlgFiuRNFpZXcDIaUpX6HIEwcZEc0cZYLAIga9DsVOMM+g5YpwEBdGW3sS+bvnmAJJiSMwhuBdqp5UY=*;
+  integrity="mi";
+  validity-url="https://example.com/resource.validity.1511128380";
+  cert-url="https://example.com/oldcerts";
+  cert-sha256=*W7uB969dFW3Mb5ZefPS9Tq5ZbH5iSmOILpjv2qEArmI=*;
+  date=1511128380; expires=1511733180,
+ sig2;
+  sig=*MEQCIGjZRqTRf9iKNkGFyzRMTFgwf/BrY2ZNIP/dykhUV0aYAiBTXg+8wujoT4n/W+cNgb7pGqQvIUGYZ8u8HZJ5YH26Qg=*;
+  integrity="mi";
+  validity-url="https://example.com/resource.validity.1511128380";
+  cert-url="https://example.com/newcerts";
+  cert-sha256=*J/lEm9kNRODdCmINbvitpvdYKNQ+YgBj99DlYp4fEXw=*;
+  date=1511128380; expires=1511733180,
+ srisig;
+  sig=*lGZVaJJM5f2oGczFlLmBdKTDL+QADza4BgeO494ggACYJOvrof6uh5OJCcwKrk7DK+LBch0jssDYPp5CLc1SDA=*
+  integrity="mi";
+  validity-url="https://example.com/resource.validity.1511128380";
+  ed25519key=*zsSevyFsxyZHiUluVBDd4eypdRLTqyWRVOJuuKUz+A8=*
+  date=1511128380; expires=1511733180,
+ thirdpartysig;
+  sig=*MEYCIQCNxJzn6Rh2fNxsobktir8TkiaJYQFhWTuWI1i4PewQaQIhAMs2TVjc4rTshDtXbgQEOwgj2mRXALhfXPztXgPupii+=*;
+  integrity="mi";
+  validity-url="https://thirdparty.example.com/resource.validity.1511161860";
+  cert-url="https://thirdparty.example.com/certs";
+  cert-sha256=*UeOwUPkvxlGRTyvHcsMUN0A2oNsZbU8EUvg8A9ZAnNc=*;
+  date=1511133060; expires=1511478660,
 ~~~
 
-The signatures uses a 2048-bit RSA certificate within `https://example.com/`.
+There are 4 signatures: 2 from different secp256r1 certificates within
+`https://example.com/`, one using a raw ed25519 public key that's also
+controlled by `example.com`, and a fourth using a secp256r1 certificate owned by
+`thirdparty.example.com`.
 
-It relies on the `MI-Draft2` response header to guard the integrity of the response
-payload.
+All 4 signatures rely on the `MI` response header to guard the integrity of the
+response payload.
 
-The signature includes a "validityUrl" that includes the first time the resource
+The signatures include a "validity-url" that includes the first time the resource
 was seen. This allows multiple versions of a resource at the same URL to be
 updated with new signatures, which allows clients to avoid transferring extra
 data while the old versions don't have known security bugs.
 
-The certificate at `https://example.com/certs` has a `subjectAltName` of `example.com`, meaning
-that if it and its signature validate, the exchange can be trusted as
-having an origin of `https://example.com/`.
+The certificates at `https://example.com/oldcerts` and
+`https://example.com/newcerts` have `subjectAltName`s of `example.com`, meaning
+that if they and their signatures validate, the exchange can be trusted as
+having an origin of `https://example.com/`. The publisher might be using two
+certificates because their readers have disjoint sets of roots in their trust
+stores.
+
+The publisher signed with all three certificates at the same time, so they share
+a validity range: 7 days starting at 2017-11-19 21:53 UTC.
+
+The publisher then requested an additional signature from
+`thirdparty.example.com`, which did some validation or processing and then
+signed the resource at 2017-11-19 23:11 UTC. `thirdparty.example.com` only
+grants 4-day signatures, so clients will need to re-validate more often.
 
 ### Open Questions ### {#oq-signature-header}
 
-{{I-D.ietf-httpbis-header-structure-02}} provides a way to parameterise labels but
-not other supported types like binary content. If the `Signature` header field
-is notionally a list of parameterised signatures, maybe we should add a
-"parameterised binary content" type.
+{{?I-D.ietf-httpbis-header-structure}} provides a way to parameterise
+identifiers but not other supported types like binary content. If the
+`Signature` header field is notionally a list of parameterised signatures, maybe
+we should add a "parameterised binary content" type.
 {:#parameterised-binary}
 
-Should the certUrl and validityUrl be lists so that intermediates can offer a
+Should the cert-url and validity-url be lists so that intermediates can offer a
 cache without losing the original URLs? Putting lists in dictionary fields is
-more complex than {{I-D.ietf-httpbis-header-structure-02}} allows, so they're
+more complex than {{?I-D.ietf-httpbis-header-structure}} allows, so they're
 single items for now.
 
 ## CBOR representation of exchange headers ## {#cbor-representation}
 
 To sign an exchange's headers, they need to be serialized into a byte string.
-Since intermediaries and distributors might
+Since intermediaries and [distributors](#uc-explicit-distributor) might
 rearrange, add, or just reserialize headers, we can't use the literal bytes of
 the headers as this serialization. Instead, this section defines a CBOR
 representation that can be embedded into other CBOR, canonically serialized
@@ -250,10 +286,14 @@ The CBOR representation of an exchange `exchange`'s headers is the CBOR
    * The byte string ':method' to the byte string containing `exchange`'s
      request's method.
    * The byte string ':url' to the byte string containing `exchange`'s request's
-     effective request URI, which MUST be an [absolute-URL
-     string](https://url.spec.whatwg.org/#absolute-url-string) ({{URL}}).
-   * For each request header field in `exchange`, the header field's lowercase
-     name as a byte string to the header field's value as a byte string.
+     effective request URI, which MUST be an absolute URL ({{terminology}}) with
+     a scheme of "https".
+   * For each request header field in `exchange` except for the `Host` header
+     field, the header field's lowercase name as a byte string to the header
+     field's value as a byte string.
+
+     Note: `Host` is excluded because it is already part of the effective
+     request URI.
 1. The map mapping:
    * the byte string ':status' to the byte string containing `exchange`'s
      response's 3-digit status code, and
@@ -265,15 +305,16 @@ The CBOR representation of an exchange `exchange`'s headers is the CBOR
 Given the HTTP exchange:
 
 ~~~http
-GET https://example.com/ HTTP/1.1
+GET / HTTP/1.1
+Host: example.com
 Accept: */*
 
 HTTP/1.1 200
 Content-Type: text/html
-Content-Encoding: mi-sha256-draft2
-MI: mi-sha256-draft2=20addcf7368837f616d549f035bf6784ea6d4bf4817a3736cd2fc7a763897fe3
+MI: mi-sha256=20addcf7368837f616d549f035bf6784ea6d4bf4817a3736cd2fc7a763897fe3
+Signed-Headers: "content-type", "mi"
 
-<0x0000000000004000><!doctype html>
+<!doctype html>
 <html>
 ...
 ~~~
@@ -284,43 +325,58 @@ extended diagnostic notation from {{?I-D.ietf-cbor-cddl}} appendix G:
 ~~~cbor-diag
 [
   {
-    ':url': 'https://example.com/'
+    ':url': 'https://example.com/',
+    'accept': '*/*',
     ':method': 'GET',
   },
   {
-    'mi': 'mi-sha256-draft2=20addcf7368837f616d549f035bf6784ea6d4bf4817a3736cd2fc7a763897fe3',
+    'mi': 'mi-sha256=20addcf7368837f616d549f035bf6784ea6d4bf4817a3736cd2fc7a763897fe3',
     ':status': '200',
     'content-type': 'text/html'
-    'content-encoding': 'mi-sha256-draft2',
   }
 ]
 ~~~
 
 ## Loading a certificate chain ## {#cert-chain-format}
 
-The resource at a signature's `certUrl` MUST contain a TLS 1.3 Certificate
-message (Section 4.4.2 of {{!I-D.ietf-tls-tls13}}) containing X.509v3
-certificates.
+The resource at a signature's `cert-url` MUST have the
+`application/cert-chain+cbor` content type, MUST be canonically-encoded CBOR
+({{canonical-cbor}}), and MUST match the following CDDL:
 
-Parsing notes:
+~~~cddl
+cert-chain = [
+  "📜⛓", ; U+1F4DC U+26D3
+  + {
+    cert: bytes,
+    ? ocsp: bytes,
+    ? sct: bytes,
+    * tstr => any,
+  }
+]
+~~~
 
-1. This resource MUST NOT include the 4-byte header that would appear in a
-   Handshake message.
-1. Since this fetch is not in response to a CertificateRequest, the
-   certificate_request_context MUST be empty, and a non-empty value MUST cause
-   the parse to fail.
+The first item in the CBOR array is treated as the end-entity certificate, and
+the client will attempt to build a path ({{?RFC5280}}) to it from a trusted root
+using the other certificates in the chain.
 
-The client MUST ignore unknown or unexpected extensions.
+1. Each `cert` value MUST be a DER-encoded X.509v3 certificate ({{!RFC5280}}).
+   Other key/value pairs in the same array item define properties of this
+   certificate.
+1. The first certificate's `ocsp` value if any MUST be a complete, DER-encoded
+   OCSP response for that certificate (using the ASN.1 type `OCSPResponse`
+   defined in {{!RFC6960}}). Subsequent certificates MUST NOT have an `ocsp`
+   value.
+1. Each certificate's `sct` value MUST be a `SignedCertificateTimestampList` for
+   that certificate as defined by Section 3.3 of {{!RFC6962}}.
 
-Loading a `certUrl` takes a `forceFetch` flag. The client MUST:
+Loading a `cert-url` takes a `forceFetch` flag. The client MUST:
 
-1. Let `raw-chain` be the result of fetching ({{FETCH}}) `certUrl`. If
+1. Let `raw-chain` be the result of fetching ({{FETCH}}) `cert-url`. If
    `forceFetch` is *not* set, the fetch can be fulfilled from a cache using
    normal HTTP semantics {{!RFC7234}}. If this fetch fails, return
    "invalid".
 1. Let `certificate-chain` be the array of certificates and properties produced
-   by parsing `raw-chain` as the TLS Certificate message as described above. If
-   any of the requirements above
+   by parsing `raw-chain` using the CDDL above. If any of the requirements above
    aren't satisfied, return "invalid". Note that this validation requirement
    might be impractical to completely achieve due to certificate validation
    implementations that don't enforce DER encoding or other standard
@@ -352,8 +408,8 @@ complex data types, so it doesn't need rules to canonicalize those.
 
 ## Signature validity ## {#signature-validity}
 
-The client MUST parse the `Signature` header field as the list of parameterised
-values (Section 4.8.1 of {{I-D.ietf-httpbis-header-structure-02}}) described in
+The client MUST parse the `Signature` header field as the parameterised list
+(Section 4.2.3 of {{!I-D.ietf-httpbis-header-structure}}) described in
 {{signature-header}}. If an error is thrown during this parsing or any of the
 requirements described there aren't satisfied, the exchange has no valid
 signatures. Otherwise, each member of this list represents a signature with
@@ -369,86 +425,93 @@ Potentially-valid results include:
   determine whether it's actually valid.
 
 This algorithm accepts a `forceFetch` flag that avoids the cache when fetching
-URLs.
+URLs. A client that determines that a potentially-valid certificate chain is
+actually invalid due to an expired OCSP response MAY retry with `forceFetch` set
+to retrieve an updated OCSP from the original server.
 {:#force-fetch}
 
 1. Let `payload` be the payload body (Section 3.3 of {{!RFC7230}}) of
    `exchange`. Note that the payload body is the message body with any transfer
    encodings removed.
 1. Let:
-   * `signature` be the signature (binary content in the parameterised label's
-     "sig" parameter).
+   * `signature` be the signature (binary content in the parameterised
+     identifier's "sig" parameter).
    * `integrity` be the signature's "integrity" parameter.
-   * `validityUrl` be the signature's "validityUrl" parameter.
-   * `certUrl` be the signature's "certUrl" parameter, if any.
-   * `certSha256` be the signature's "certSha256" parameter, if any.
+   * `validity-url` be the signature's "validity-url" parameter.
+   * `cert-url` be the signature's "cert-url" parameter, if any.
+   * `cert-sha256` be the signature's "cert-sha256" parameter, if any.
+   * `ed25519key` be the signature's "ed25519key" parameter, if any.
    * `date` be the signature's "date" parameter, interpreted as a Unix time.
    * `expires` be the signature's "expires" parameter, interpreted as a Unix
      time.
-1. If `integrity` names a header field other than `MI-Draft2`
-   ({{!I-D.thomson-http-mice}}) or this header field is not present in
-   `exchange`'s response headers or which the client cannot use to check the
-   integrity of `payload` (for example, the header field is new and hasn't been
-   implemented yet), then return "invalid". Clients MUST be able to check the
-   integrity of `payload` using the `MI-Draft2` header field, which is defined
-   equivalently to the `MI` header from draft 02 of {{!I-D.thomson-http-mice}}.
+1. If `integrity` names a header field that is not present in `exchange`'s
+   response headers or which the client cannot use to check the integrity of
+   `payload` (for example, the header field is new and hasn't been implemented
+   yet), then return "invalid". If the selected header field provides integrity
+   guarantees weaker than SHA-256, return "invalid". If validating integrity
+   using the selected header field requires the client to process records larger
+   than TBD bytes, return "invalid". Clients MUST implement at least the `MI`
+   ({{!I-D.thomson-http-mice}}) header field with its `mi-sha256` content
+   encoding.
 1. Set `publicKey` and `signing-alg` depending on which key fields are present:
-   1. Assert: `certUrl` is present.
+   1. If `cert-url` is present:
       1. Let `certificate-chain` be the result of loading the certificate chain
-         at `certUrl` passing the `forceFetch` flag ({{cert-chain-format}}). If
+         at `cert-url` passing the `forceFetch` flag ({{cert-chain-format}}). If
          this returns "invalid", return "invalid".
       1. Let `main-certificate` be the first certificate in `certificate-chain`.
       1. Set `publicKey` to `main-certificate`'s public key.
-      1. If `publicKey` is not a 2048-bit RSA public key, return "invalid".
-      1. The client MUST define a partial function from public key types to
-         signing algorithms, and this function must at the minimum include the
-         following mappings:
-
-         RSA, 2048 bits:
-         : rsa_pss_rsae_sha256 or rsa_pss_pss_sha256, as defined in Section
-           4.2.3 of {{!I-D.ietf-tls-tls13}}, depending on which of the
-           rsaEncryption OID or RSASSA-PSS OID {{!RFC8017}} is used.
-
-         Set `signing-alg` to the result of applying this function to the type of
-         `main-certificate`'s public key. If the function is undefined on this
-         input, return "invalid".
+      1. If `publicKey` is an RSA key, return "invalid".
+      1. If `publicKey` is a key using the secp256r1 elliptic curve, set
+         `signing-alg` to ecdsa_secp256r1_sha256 as defined in Section 4.2.3 of
+         {{!I-D.ietf-tls-tls13}}.
+      1. Otherwise, either return "invalid" or set `signing-alg` to a non-legacy
+         signing algorithm defined by TLS 1.3 or later
+         ({{!I-D.ietf-tls-tls13}}). This choice MUST depend only on
+         `publicKey`'s type and not on any other context.
+   1. If `ed25519key` is present, set `publicKey` to `ed25519key` and
+      `signing-alg` to ed25519, as defined by {{!RFC8032}}
 1. If `expires` is more than 7 days (604800 seconds) after `date`, return
    "invalid".
 1. If the current time is before `date` or after `expires`, return "invalid".
 1. Let `message` be the concatenation of the following byte strings. This
-   matches the {{?I-D.ietf-tls-tls13}} format to avoid cross-protocol attacks
-   when TLS certificates are used to sign manifests.
+   matches the {{?I-D.ietf-tls-tls13}} format to avoid cross-protocol attacks if
+   anyone uses the same key in a TLS certificate and an exchange-signing
+   certificate.
    1. A string that consists of octet 32 (0x20) repeated 64 times.
-   1. A context string: the ASCII encoding of “HTTP Exchange”.
+   1. A context string: the ASCII encoding of "HTTP Exchange 1".
+
+      Note: RFC EDITOR PLEASE DELETE THIS NOTE; The implementation of the final
+      RFC MUST use this context string, but implementations of drafts MUST NOT
+      use it and MUST use another draft-specific string beginning with "HTTP
+      Exchange 1 ” instead. This ensures that signers can predict how their
+      signatures will be used.
    1. A single 0 byte which serves as a separator.
    1. The bytes of the canonical CBOR serialization ({{canonical-cbor}}) of a
       CBOR map mapping:
-      1. If `certSha256` is set:
-         1. The text string "certSha256" to the byte string value of
-            `certSha256`.
-      1. The text string "validityUrl" to the byte string value of
-         `validityUrl`.
+      1. If `cert-sha256` is set:
+         1. The text string "cert-sha256" to the byte string value of
+            `cert-sha256`.
+      1. The text string "validity-url" to the byte string value of
+         `validity-url`.
       1. The text string "date" to the integer value of `date`.
       1. The text string "expires" to the integer value of `expires`.
       1. The text string "headers" to the CBOR representation
          ({{cbor-representation}}) of `exchange`'s headers.
-1. If `certUrl` is present and the SHA-256 hash of `main-certificate`'s
-   `cert_data` is not equal to `certSha256` (whose presence was checked when the
+1. If `cert-url` is present and the SHA-256 hash of `main-certificate`'s
+   `cert_data` is not equal to `cert-sha256` (whose presence was checked when the
    `Signature` header field was parsed), return "invalid".
 
    Note that this intentionally differs from TLS 1.3, which signs the entire
    certificate chain in its Certificate Verify (Section 4.4.3 of
    {{?I-D.ietf-tls-tls13}}), in order to allow updating the stapled OCSP
-   response without updating signatures at the same time. Note that this
-   difference doesn't matter for this version of this draft since OCSP responses
-   aren't checked.
+   response without updating signatures at the same time.
 1. If `signature` is a valid signature of `message` by `publicKey` using
-   `signing-alg`, return "potentially-valid" with `certificate-chain`.
-   Otherwise, return "invalid".
+   `signing-alg`, return "potentially-valid" with whichever is present of
+   `certificate-chain` or `ed25519key`. Otherwise, return "invalid".
 
 Note that the above algorithm can determine that an exchange's headers are
 potentially-valid before the exchange's payload is received. Similarly, if
-`integrity` identifies a header field like `MI-Draft2` ({{?I-D.thomson-http-mice}})
+`integrity` identifies a header field like `MI` ({{?I-D.thomson-http-mice}})
 that can incrementally validate the payload, early parts of the payload can be
 determined to be potentially-valid before later parts of the payload.
 Higher-level protocols MAY process parts of the exchange that have been
@@ -466,18 +529,22 @@ though these certificates can't be used in TLS servers?
 
 ## Updating signature validity ## {#updating-validity}
 
-Signatures are designed to expire a short
+Both OCSP responses and signatures are designed to expire a short
 time after they're signed, so that revoked certificates and signed exchanges
 with known vulnerabilities are distrusted promptly.
 
-The ["validityUrl" parameter](#signature-validityurl) of the signatures provides
+This specification provides no way to update OCSP responses by themselves.
+Instead, [clients need to re-fetch the "cert-url"](#force-fetch) to get a chain
+including a newer OCSP response.
+
+The ["validity-url" parameter](#signature-validityurl) of the signatures provides
 a way to fetch new signatures or learn where to fetch a complete updated
 exchange.
 
 Each version of a signed exchange SHOULD have its own validity URLs, since each
 version needs different signatures and becomes obsolete at different times.
 
-The resource at a "validityUrl" is "validity data", a CBOR map matching the
+The resource at a "validity-url" is "validity data", a CBOR map matching the
 following CDDL ({{!I-D.ietf-cbor-cddl}}):
 
 ~~~cddl
@@ -489,10 +556,10 @@ validity = {
 ]
 ~~~
 
-The elements of the `signatures` array are parameterised labels (Section 4.4 of
-{{I-D.ietf-httpbis-header-structure-02}}) meant to replace the signatures within
-the `Signature` header field pointing to this validity data. If the signed
-exchange contains a bug severe enough that clients need to stop using the
+The elements of the `signatures` array are parameterised identifiers (Section
+4.2.4 of {{!I-D.ietf-httpbis-header-structure}}) meant to replace the signatures
+within the `Signature` header field pointing to this validity data. If the
+signed exchange contains a bug severe enough that clients need to stop using the
 content, the `signatures` array MUST NOT be present.
 
 If the the `update` map is present, that indicates that a new version of the
@@ -514,26 +581,39 @@ irrelevant fields omitted for ease of reading).
 ~~~http
 Signature:
  sig1;
-  sig=*MEUCIQ...;
+  sig=*MEUCIQ...*;
   ...
-  validityUrl="https://example.com/resource.validity.1511157180";
-  certUrl="https://example.com/oldcerts";
-  date=1511128380; expires=1511733180
+  validity-url="https://example.com/resource.validity.1511157180";
+  cert-url="https://example.com/oldcerts";
+  date=1511128380; expires=1511733180,
+ sig2;
+  sig=*MEQCIG...*;
+  ...
+  validity-url="https://example.com/resource.validity.1511157180";
+  cert-url="https://example.com/newcerts";
+  date=1511128380; expires=1511733180,
+ thirdpartysig;
+  sig=*MEYCIQ...*;
+  ...
+  validity-url="https://thirdparty.example.com/resource.validity.1511161860";
+  cert-url="https://thirdparty.example.com/certs";
+  date=1511478660; expires=1511824260
 ~~~
 
-At 2017-11-27 11:02 UTC, `sig1` has expired, so the client needs to fetch
-`https://example.com/resource.validity.1511157180` (the `validityUrl` of `sig1`)
-to update that signatures. This URL might contain:
+At 2017-11-27 11:02 UTC, `sig1` and `sig2` have expired, but `thirdpartysig`
+doesn't exipire until 23:11 that night, so the client needs to fetch
+`https://example.com/resource.validity.1511157180` (the `validity-url` of `sig1`
+and `sig2`) to update those signatures. This URL might contain:
 
 ~~~cbor-diag
 {
   "signatures": [
     'sig1; '
-    'sig=*MEQCIC/I9Q+7BZFP6cSDsWx43pBAL0ujTbON/+7RwKVk+ba5AiB3FSFLZqpzmDJ0NumNwN04pqgJZE99fcK86UjkPbj4jw; '
-    'validityUrl="https://example.com/resource.validity.1511157180"; '
+    'sig=*MEQCIC/I9Q+7BZFP6cSDsWx43pBAL0ujTbON/+7RwKVk+ba5AiB3FSFLZqpzmDJ0NumNwN04pqgJZE99fcK86UjkPbj4jw==*; '
+    'validity-url="https://example.com/resource.validity.1511157180"; '
     'integrity="mi"; '
-    'certUrl="https://example.com/newcerts"; '
-    'certSha256=*J/lEm9kNRODdCmINbvitpvdYKNQ+YgBj99DlYp4fEXw; '
+    'cert-url="https://example.com/newcerts"; '
+    'cert-sha256=*J/lEm9kNRODdCmINbvitpvdYKNQ+YgBj99DlYp4fEXw=*; '
     'date=1511733180; expires=1512337980'
   ],
   "update": {
@@ -544,23 +624,150 @@ to update that signatures. This URL might contain:
 
 This indicates that the client could fetch a newer version at
 `https://example.com/resource` (the original URL of the exchange), or that the
-validity period of the old version can be extended by replacing the original
-signature with the new signature provided. The signature of the updated signed
-exchange would be:
+validity period of the old version can be extended by replacing the first two of
+the original signatures (the ones with a validity-url of
+`https://example.com/resource.validity.1511157180`) with the single new
+signature provided. (This might happen at the end of a migration to a new root
+certificate.) The signatures of the updated signed exchange would be:
 
 ~~~http
 Signature:
  sig1;
-  sig=*MEQCIC...;
+  sig=*MEQCIC...*;
   ...
-  validityUrl="https://example.com/resource.validity.1511157180";
-  certUrl="https://example.com/newcerts";
-  date=1511733180; expires=1512337980
+  validity-url="https://example.com/resource.validity.1511157180";
+  cert-url="https://example.com/newcerts";
+  date=1511733180; expires=1512337980,
+ thirdpartysig;
+  sig=*MEYCIQ...*;
+  ...
+  validity-url="https://thirdparty.example.com/resource.validity.1511161860";
+  cert-url="https://thirdparty.example.com/certs";
+  date=1511478660; expires=1511824260
 ~~~
+
+`https://example.com/resource.validity.1511157180` could also expand the set of
+signatures if its `signatures` array contained more than 2 elements.
 
 ## The Accept-Signature header ## {#accept-signature}
 
-This section isn't implemented.
+`Signature` header fields cost on the order of 300 bytes for ECDSA signatures,
+so servers might prefer to avoid sending them to clients that don't intend to
+use them. A client can send the `Accept-Signature` header field to indicate that
+it does intend to take advantage of any available signatures and to indicate
+what kinds of signatures it supports.
+
+When a server receives an `Accept-Signature` header field in a client request,
+it SHOULD reply with any available `Signature` header fields for its response
+that the `Accept-Signature` header field indicates the client supports. However,
+if the `Accept-Signature` value violates a requirement in this section, the
+server MUST behave as if it hadn't received any `Accept-Signature` header at
+all.
+
+The `Accept-Signature` header field is a Structured Header as defined by
+{{!I-D.ietf-httpbis-header-structure}}. Its value MUST be a parameterised list
+(Section 3.3 of {{!I-D.ietf-httpbis-header-structure}}). Its ABNF is:
+
+    Accept-Signature = sh-param-list
+
+The order of identifiers in the `Accept-Signature` list is not significant.
+Identifiers, ignoring any initial "-" character, MUST NOT be duplicated.
+
+Each identifier in the `Accept-Signature` header field's value indicates that a
+feature of the `Signature` header field ({{signature-header}}) is supported. If
+the identifier begins with a "-" character, it instead indicates that the
+feature named by the rest of the identifier is not supported. Unknown
+identifiers and parameters MUST be ignored because new identifiers and new
+parameters on existing identifiers may be defined by future specifications.
+
+### Integrity identifiers ### {#accept-signature-integrity}
+
+Identifiers starting with "mi/" indicate that the client supports the `MI`
+header field ({{!I-D.thomson-http-mice}}) with the parameter from the HTTP MI
+Parameter Registry registry named in lower-case by the rest of the identifier.
+For example, "mi/mi-blake2" indicates support for Merkle integrity with the
+as-yet-unspecified mi-blake2 parameter, and "-digest/mi-sha256" indicates
+non-support for Merkle integrity with the mi-sha256 content encoding.
+
+If the `Accept-Signature` header field is present, servers SHOULD assume support
+for "mi/mi-sha256" unless the header field states otherwise.
+
+### Key type identifiers ### {#accept-signature-key-types}
+
+Identifiers starting with "ecdsa/" indicate that the client supports
+certificates holding ECDSA public keys on the curve named in lower-case by the
+rest of the identifier.
+
+If the `Accept-Signature` header field is present, servers SHOULD assume support
+for "ecdsa/secp256r1" unless the header field states otherwise.
+
+### Key value identifiers ### {#accept-signature-key-values}
+
+The "ed25519key" identifier has parameters indicating the public keys that will
+be used to validate the returned signature. Each parameter's name is
+re-interpreted as binary content (Section 3.9 of
+{{!I-D.ietf-httpbis-header-structure}}) encoding a prefix of the public key. For
+example, if the client will validate signatures using the public key whose
+base64 encoding is `11qYAYKxCrfVS/7TyWQHOg7hcvPapiMlrwIaaPcHURo=`, valid
+`Accept-Signature` header fields include:
+
+~~~http
+Accept-Signature: ..., ed25519key; *11qYAYKxCrfVS/7TyWQHOg7hcvPapiMlrwIaaPcHURo=*
+Accept-Signature: ..., ed25519key; *11qYAYKxCrfVS/7TyWQHOg==*
+Accept-Signature: ..., ed25519key; *11qYAQ==*
+Accept-Signature: ..., ed25519key; **
+~~~
+
+but not
+
+~~~http
+Accept-Signature: ..., ed25519key; *11qYA===*
+~~~
+
+because 5 bytes isn't a valid length for encoded base64, and not
+
+~~~http
+Accept-Signature: ..., ed25519key; 11qYAQ
+~~~
+
+because it doesn't start or end with the `*`s that indicate binary content.
+
+Note that `ed25519key; **` is an empty prefix, which matches all public keys, so
+it's useful in subresource integrity ({{uc-sri}}) cases like `<link rel=preload
+as=script href="...">` where the public key isn't known until the matching
+`<script src="..." integrity="...">` tag.
+
+### Examples ### {#accept-signature-examples}
+
+~~~http
+Accept-Signature: mi/mi-sha256
+~~~
+
+states that the client will accept signatures with payload integrity assured by
+the `MI` header and `mi-sha256` content encoding and implies that the client
+will accept integrity assured by the `Digest: SHA-256` header and signatures
+from ECDSA keys on the secp256r1 curve.
+
+~~~http
+Accept-Signature: -ecdsa/secp256r1, ecdsa/secp384r1
+~~~
+
+states that the client will accept ECDSA keys on the secp384r1 curve but not the
+secp256r1 curve and payload integrity assured with the `MI: mi-sha256` header
+field.
+
+### Open Questions ### {#oq-accept-signature}
+
+Is an `Accept-Signature` header useful enough to pay for itself? If clients wind
+up sending it on most requests, that may cost more than the cost of sending
+`Signature`s unconditionally. On the other hand, it gives servers an indication
+of which kinds of signatures are supported, which can help us upgrade the
+ecosystem in the future.
+
+Is `Accept-Signature` the right spelling, or do we want to imitate `Want-Digest`
+(Section 4.3.1 of {{?RFC3230}}) instead?
+
+Do I have the right structure for the identifiers indicating feature support?
 
 # Cross-origin trust {#cross-origin-trust}
 
@@ -571,7 +778,7 @@ instructions in {{signature-validity}}, and run the following algorithm for each
 signature, stopping at the first one that returns "valid". If any signature
 returns "valid", return "valid". Otherwise, return "invalid".
 
-1. If the signature's ["validityUrl" parameter](#signature-validityurl) is not
+1. If the signature's ["validity-url" parameter](#signature-validityurl) is not
    [same-origin](https://html.spec.whatwg.org/multipage/origin.html#same-origin)
    with `exchange`'s effective request URI (Section 5.5 of {{!RFC7230}}), return
    "invalid".
@@ -592,12 +799,28 @@ returns "valid", return "valid". Otherwise, return "invalid".
       ({{!RFC5280}} and other undocumented conventions). Let `path` be the path
       that was used from the `main-certificate` to a trusted root, including the
       `main-certificate` but excluding the root.
+   1. Validate that `main-certificate` has the CanSignHttpExchanges extension
+      ({{cross-origin-cert-req}}).
+   1. Validate that `main-certificate` has an `ocsp` property
+      ({{cert-chain-format}}) with a valid OCSP response whose lifetime
+      (`nextUpdate - thisUpdate`) is less than 7 days ({{!RFC6960}}). Note that
+      this does not check for revocation of intermediate certificates, and
+      clients SHOULD implement another mechanism for that.
+   1. Validate that valid SCTs from trusted logs are available from any of:
+
+      * The `SignedCertificateTimestampList` in `main-certificate`'s `sct`
+        property ({{cert-chain-format}}),
+      * An OCSP extension in the OCSP response in `main-certificate`'s `ocsp`
+        property, or
+      * An X.509 extension in the certificate in `main-certificate`'s `cert`
+        property,
+
+      as described by Section 3.3 of {{!RFC6962}}.
 1. Return "valid".
 
 ## Stateful header fields {#stateful-headers}
 
-As described in Section 6.1 of {{?I-D.yasskin-http-origin-signed-responses}}, a
-publisher can cause problems if they
+As described in {{seccons-over-signing}}, a publisher can cause problems if they
 sign an exchange that includes private information. There's no way for a client
 to be sure an exchange does or does not include private information, but header
 fields that store or convey stored state in the client are a good sign.
@@ -628,7 +851,50 @@ These include but are not limited to:
 
 ## Certificate Requirements {#cross-origin-cert-req}
 
-For this draft, no new X.509 extension is required.
+We define a new X.509 extension, CanSignHttpExchanges to be used in the
+certificate when the certificate permits the usage of signed exchanges.  When
+this extension is not present the client MUST NOT accept a signature from the
+certificate as proof that a signed exchange is authoritative for a domain
+covered by the certificate. When it is present, the client MUST follow the
+validation procedure in {{cross-origin-trust}}.
+
+~~~asn.1
+   id-ce-canSignHttpExchanges OBJECT IDENTIFIER ::= { TBD }
+
+   CanSignHttpExchanges ::= NULL
+~~~
+
+Note that this extension contains an ASN.1 NULL (bytes `05 00`) because some
+implementations have bugs with empty extensions.
+
+Leaf certificates without this extension need to be revoked if the private key
+is exposed to an unauthorized entity, but they generally don't need to be
+revoked if a signing oracle is exposed and then removed.
+
+CA certificates, by contrast, need to be revoked if an unauthorized entity is
+able to make even one unauthorized signature.
+
+Certificates with this extension MUST be revoked if an unauthorized entity is
+able to make even one unauthorized signature.
+
+Conforming CAs MUST mark this extension as critical, and clients MUST NOT accept
+certificates with this extension in TLS connections (Section 4.4.2.2 of
+{{!I-D.ietf-tls-tls13}}).  This simplifies security analysis of this protocol
+and avoids encouraging server operators to put exchange-signing keys on servers
+exposed directly to the internet.
+
+RFC EDITOR PLEASE DELETE THE REST OF THE PARAGRAPHS IN THIS SECTION
+
+~~~asn.1
+   id-ce-google OBJECT IDENTIFIER ::= { 1 3 6 1 4 1 11129 }
+   id-ce-testCanSignHttpExchanges OBJECT IDENTIFIER ::= { id-ce-google 2 1 22 }
+~~~
+
+Implementations of drafts of this specification MAY recognize the
+`id-ce-testCanSignHttpExchanges` OID as identifying the CanSignHttpExchanges
+extension. This OID might or might not be used as the final OID for the
+extension, so certificates including it might need to be reissued once the final
+RFC is published.
 
 # Transferring a signed exchange {#transfer}
 
@@ -637,70 +903,320 @@ described here.
 
 ## Same-origin response {#same-origin-response}
 
-Receiving a Signature header as part of a normal HTTP exchange is not implemented.
+The signature for a signed exchange can be included in a normal HTTP response.
+Because different clients send different request header fields, and intermediate
+servers add response header fields, it can be impossible to have a signature for
+the exact request and response that the client sees. Therefore, when a client
+validates the `Signature` header field for an exchange represented as a normal
+HTTP request/response pair, it MUST pass only the subset of header fields
+defined by {{significant-headers}} to the validation procedure
+({{signature-validity}}).
+
+If the client relies on signature validity for any aspect of its behavior, it
+MUST ignore any header fields that it didn't pass to the validation procedure.
+
+### Significant headers for a same-origin response {#significant-headers}
+
+The significant headers of an exchange represented as a normal HTTP
+request/response pair (Section 2.1 of {{?RFC7230}} or Section 8.1 of
+{{?RFC7540}}) are:
+
+* The method (Section 4 of {{!RFC7231}}) and effective request URI (Section 5.5
+  of {{!RFC7230}}) of the request.
+* The response status code (Section 6 of {{!RFC7231}}) and the response header
+  fields whose names are listed in that exchange's `Signed-Headers` header field
+  ({{signed-headers}}), in the order they appear in that header field. If a
+  response header field name from `Signed-Headers` does not appear in the
+  exchange's response header fields, the exchange has no significant headers.
+
+If the exchange's `Signed-Headers` header field is not present, doesn't parse as
+a Structured Header ({{!I-D.ietf-httpbis-header-structure}}) or doesn't follow
+the constraints on its value described in {{signed-headers}}, the exchange has
+no significant headers.
+
+#### Open Questions {#oq-significant-headers}
+
+Do the significant headers of an exchange need to include the `Signed-Headers`
+header field itself?
+
+### The Signed-Headers Header {#signed-headers}
+
+The `Signed-Headers` header field identifies an ordered list of response header
+fields to include in a signature. The request URL and response status are
+included unconditionally. This allows a TLS-terminating intermediate to reorder
+headers without breaking the signature. This *can* also allow the intermediate
+to add headers that will be ignored by some higher-level protocols, but
+{{signature-validity}} provides a hook to let other higher-level protocols
+reject such insecure headers.
+
+This header field appears once instead of being incorporated into the
+signatures' parameters because the signed header fields need to be consistent
+across all signatures of an exchange, to avoid forcing higher-level protocols to
+merge the header field lists of valid signatures.
+
+See {{how-much-to-sign}} for a discussion of why only the URL from the request
+is included and not other request headers.
+
+`Signed-Headers` is a Structured Header as defined by
+{{!I-D.ietf-httpbis-header-structure}}. Its value MUST be a list (Section 3.2 of
+{{!I-D.ietf-httpbis-header-structure}}). Its ABNF is:
+
+    Signed-Headers = sh-list
+
+Each element of the `Signed-Headers` list must be a lowercase string (Section
+3.7 of {{!I-D.ietf-httpbis-header-structure}}) naming an HTTP response header
+field. Pseudo-header field names (Section 8.1.2.1 of {{!RFC7540}}) MUST NOT
+appear in this list.
+
+Higher-level protocols SHOULD place requirements on the minimum set of headers
+to include in the `Signed-Headers` header field.
+
+
 
 ## HTTP/2 extension for cross-origin Server Push # {#cross-origin-push}
 
-Cross origin push is not implemented.
+To allow servers to Server-Push (Section 8.2 of {{?RFC7540}}) signed exchanges
+({{proposal}}) signed by an authority for which the server is not authoritative
+(Section 9.1 of {{?RFC7230}}), this section defines an HTTP/2 extension.
+
+### Indicating support for cross-origin Server Push # {#setting}
+
+Clients that might accept signed Server Pushes with an authority for which the
+server is not authoritative indicate this using the HTTP/2 SETTINGS parameter
+ENABLE_CROSS_ORIGIN_PUSH (0xSETTING-TBD).
+
+An ENABLE_CROSS_ORIGIN_PUSH value of 0 indicates that the client does not
+support cross-origin Push. A value of 1 indicates that the client does support
+cross-origin Push.
+
+A client MUST NOT send a ENABLE_CROSS_ORIGIN_PUSH setting with a value other
+than 0 or 1 or a value of 0 after previously sending a value of 1. If a server
+receives a value that violates these rules, it MUST treat it as a connection
+error (Section 5.4.1 of {{!RFC7540}}) of type PROTOCOL_ERROR.
+
+The use of a SETTINGS parameter to opt-in to an otherwise incompatible protocol
+change is a use of "Extending HTTP/2" defined by Section 5.5 of {{?RFC7540}}. If
+a server were to send a cross-origin Push without first receiving a
+ENABLE_CROSS_ORIGIN_PUSH setting with the value of 1 it would be a protocol
+violation.
+
+### NO_TRUSTED_EXCHANGE_SIGNATURE error code {#error-code}
+
+The signatures on a Pushed cross-origin exchange may be untrusted for several
+reasons, for example that the certificate could not be fetched, that the
+certificate does not chain to a trusted root, that the signature itself doesn't
+validate, that the signature is expired, etc. This draft conflates all of these
+possible failures into one error code, NO_TRUSTED_EXCHANGE_SIGNATURE
+(0xERROR-TBD).
+
+#### Open Questions ### {#oq-error-code}
+
+How fine-grained should this specification's error codes be?
+
+### Validating a cross-origin Push ## {#validating-cross-origin-push}
+
+If the client has set the ENABLE_CROSS_ORIGIN_PUSH setting to 1, the server MAY
+Push a signed exchange for which it is not authoritative, and the client MUST
+NOT treat a PUSH_PROMISE for which the server is not authoritative as a stream
+error (Section 5.4.2 of {{!RFC7540}}) of type PROTOCOL_ERROR, as described in
+Section 8.2 of {{?RFC7540}}.
+
+Instead, the client MUST validate such a PUSH_PROMISE and its response by taking
+the `Signature` header field from the response, and the exchange consisting of
+the PUSH_PROMISE and the response without that `Signature` header field, and
+passing them to the algorithm in {{cross-origin-trust}}. If this returns
+"invalid", the client MUST treat the response as a stream error (Section 5.4.2
+of {{!RFC7540}}) of type NO_TRUSTED_EXCHANGE_SIGNATURE. Otherwise, the client
+MUST treat the pushed response as if the server were authoritative for the
+PUSH_PROMISE's authority.
+
+#### Open Questions ### {#oq-cross-origin-push}
+
+Is it right that "validity-url" is required to be same-origin with the exchange?
+This allows the mitigation against downgrades in {{seccons-downgrades}}, but
+prohibits intermediates from providing a cache of the validity information. We
+could do both with a list of URLs.
 
 ## application/signed-exchange format # {#application-signed-exchange}
 
-To parse a resource with content type `application/signed-exchange;v=b0`, the
-client MUST run the following algorithm:
+To allow signed exchanges to be the targets of `<link rel=prefetch>` tags, we
+define the  `application/signed-exchange` content type that represents a signed
+HTTP exchange, including request metadata and header fields, response metadata
+and header fields, and a response payload.
 
-Read 3 bytes and interpret them as a big-endian integer `headerLength`.
+This content type consists of the concatenation of the following items:
 
-If `headerLength` is larger than 524288 (512kB), parsing MUST fail.
+1. The ASCII characters "sxg1" followed by a 0 byte, to serve as a file
+   signature. This is redundant with the MIME type, and recipients that receive
+   both MUST check that they match and stop parsing if they don't.
 
-Read `headerLength` bytes, and parse them as a CBOR item. If this item isn't
-canonically encoded ({{canonical-cbor}}) or doesn't match the following CDDL,
-parsing MUST fail:
+   Note: RFC EDITOR PLEASE DELETE THIS NOTE; The implementation of the final RFC
+   MUST use this file signature, but implementations of drafts MUST NOT use it
+   and MUST use another implementation-specific string beginning with "sxg1-" and
+   ending with a 0 byte instead.
+1. 3 bytes storing a big-endian integer `sigLength`. If this is larger
+   than TBD, parsing MUST fail.
+1. 3 bytes storing a big-endian integer `headerLength`. If this is larger than
+   TBD, parsing MUST fail.
+1. `sigLength` bytes holding the `Signature` header field's value
+   ({{signature-header}}).
+1. `headerLength` bytes holding the signed headers, the canonical serialization
+   ({{canonical-cbor}}) of the CBOR representation of the request and response
+   headers of the exchange represented by the `application/signed-exchange`
+   resource ({{cbor-representation}}), excluding the `Signature` header field.
 
-~~~cddl
-signed-exchange-header = [
-  { ':method': bytes,
-    ':url': bytes,
-    * bytes => bytes,
+   Note that this is exactly the bytes used when checking signature validity in
+   {{signature-validity}}.
+1. The payload body (Section 3.3 of {{!RFC7230}}) of the exchange represented by
+   the `application/signed-exchange` resource.
+
+   Note that the use of the payload body here means that a `Transfer-Encoding`
+   header field inside the `application/signed-exchange` header block has no
+   effect. A `Transfer-Encoding` header field on the outer HTTP response that
+   transfers this resource still has its normal effect.
+
+### Cross-origin trust in application/signed-exchange {#co-trust-app-signed-exchange}
+
+To determine whether to trust a cross-origin exchange stored in an
+`application/signed-exchange` resource, pass the `Signature` header field from
+the non-signed header section and an exchange consisting of the headers from the
+signed headers section and the payload body, to the algorithm in
+{{cross-origin-trust}}.
+
+### Example ## {#example-application-signed-exchange}
+
+An example `application/signed-exchange` file representing a possible signed
+exchange with <https://example.com/> follows, with lengths represented by
+descriptions in `<>`s, CBOR represented in the extended diagnostic format
+defined in Appendix G of {{?I-D.ietf-cbor-cddl}}, and most of the `Signature`
+header field and payload elided with a ...:
+
+~~~
+sxg1\0<3-byte length of the following header
+value>sig1; sig=*...; integrity="mi"; ...<3-byte length of the encoding of the
+following array>[
+  {
+    ':method': 'GET',
+    ':url': 'https://example.com/',
+    'accept', '*/*'
   },
-  { ':status': bytes,
-    'signature': bytes,
-    * bytes => bytes,
-  },
-]
+  {
+    ':status': '200',
+    'content-type': 'text/html'
+  }
+]<!doctype html>\r\n<html>...
 ~~~
 
-The first element of the array is interpreted as the exchange's request headers
-with lowercase names, with the request method in the ':method' key's value, and
-the effective request URI, which MUST be an [absolute-URL
-string](https://url.spec.whatwg.org/#absolute-url-string) ({{URL}}), in the
-':url' key's value.
+### Open Questions ## {#oq-application-signed-exchange}
 
-The second element of the array is interpreted as the exchange's response
-headers with lowercase names, with the 3-digit response status code in the
-':status' key's value.
+Should this be a CBOR format, or is the current mix of binary and CBOR better?
 
-If any header field name includes uppercase characters, parsing MUST fail.
-
-Pass the `Signature` response header and the exchange with that header removed
-to the algorithm in {{cross-origin-trust}}. Fail if this returns "invalid".
-
-The remainder of the resource is the exchange's payload, encoded with the
-`mi-sha256-draft2` content encoding. The `mi-sha256-draft2` content encoding is
-the `mi-sha256` encoding defined in draft 02 of ({{!I-D.thomson-http-mice}}). If
-the `mi-sha256-draft2` record length (the first 8 bytes of the payload) is
-greater than 16kB, or if any of the integrity proofs fail validation, parsing
-MUST fail.
+Are the mime type, extension, and magic number right?
 
 # Security considerations
 
-All of the security considerations from Section 6 of
-{{!I-D.yasskin-http-origin-signed-responses}} apply.
+## Over-signing ## {#seccons-over-signing}
 
-In addition, because this draft does not check for certificate revocation and
-allows signatures from certificates that can be used in normal TLS servers with
-no defense against future-dated signatures, clients MUST NOT trust signed
-exchanges as authoritative for their claimed origin without some explicit opt-in
-by their user.
+If a publisher blindly signs all responses as their origin, they can cause at
+least two kinds of problems, described below. To avoid this, publishers SHOULD
+design their systems to opt particular public content that doesn't depend on
+authentication status into signatures instead of signing by default.
+
+Signing systems SHOULD also incorporate the following mitigations to reduce the
+risk that private responses are signed:
+
+1. Strip the `Cookie` request header field and other identifying information
+   like client authentication and TLS session IDs from requests whose exchange
+   is destined to be signed, before forwarding the request to a backend.
+1. Only sign exchanges where the response includes a `Cache-Control: public`
+   header. Clients are not required to fail signature-checking for exchanges
+   that omit this `Cache-Control` response header field to reduce the risk that
+   naïve signing systems blindly add it.
+
+### Session fixation ### {#seccons-session-fixation}
+
+Blind signing can sign responses that create session cookies or otherwise change
+state on the client to identify a particular session. This breaks certain kinds
+of CSRF defense and can allow an attacker to force a user into the attacker's
+account, where the user might unintentionally save private information, like
+credit card numbers or addresses.
+
+This specification defends against cookie-based attacks by blocking the
+`Set-Cookie` response header, but it cannot prevent Javascript or other response
+content from changing state.
+
+### Misleading content ### {#seccons-misleading-content}
+
+If a site signs private information, an attacker might set up their own account
+to show particular private information, forward that signed information to a
+victim, and use that victim's confusion in a more sophisticated attack.
+
+Stripping authentication information from requests before sending them to
+backends is likely to prevent the backend from showing attacker-specific
+information in the signed response. It does not prevent the attacker from
+showing their victim a signed-out page when the victim is actually signed in,
+but while this is still misleading, it seems less likely to be useful to the
+attacker.
+
+## Off-path attackers ## {#seccons-off-path}
+
+Relaxing the requirement to consult DNS when determining authority for an origin
+means that an attacker who possesses a valid certificate no longer needs to be
+on-path to redirect traffic to them; instead of modifying DNS, they need only
+convince the user to visit another Web site in order to serve responses signed
+as the target. This consideration and mitigations for it are shared by the
+combination of {{?RFC8336}} and {{?I-D.ietf-httpbis-http2-secondary-certs}}.
+
+## Downgrades ## {#seccons-downgrades}
+
+Signing a bad response can affect more users than simply serving a bad response,
+since a served response will only affect users who make a request while the bad
+version is live, while an attacker can forward a signed response until its
+signature expires. Publishers should consider shorter signature expiration times
+than they use for cache expiration times.
+
+Clients MAY also check the ["validity-url"](#signature-validityurl) of an
+exchange more often than the signature's expiration would require. Doing so for
+an exchange with an HTTPS request URI provides a TLS guarantee that the exchange
+isn't out of date (as long as {{oq-cross-origin-push}} is resolved to keep the
+same-origin requirement).
+
+## Signing oracles are permanent ## {#seccons-signing-oracles}
+
+An attacker with temporary access to a signing oracle can sign "still valid"
+assertions with arbitrary timestamps and expiration times. As a result, when a
+signing oracle is removed, the keys it provided access to MUST be revoked so
+that, even if the attacker used them to sign future-dated exchange validity
+assertions, the key's OCSP assertion will expire, causing the exchange as a
+whole to become untrusted.
+
+## Unsigned headers ## {#seccons-unsigned-headers}
+
+The use of a single `Signed-Headers` header field prevents us from signing
+aspects of the request other than its effective request URI (Section 5.5 of
+{{?RFC7230}}). For example, if a publisher signs both `Content-Encoding: br` and
+`Content-Encoding: gzip` variants of a response, what's the impact if an
+attacker serves the brotli one for a request with `Accept-Encoding: gzip`?
+
+The simple form of `Signed-Headers` also prevents us from signing less than the
+full request URL. The SRI use case ({{uc-sri}}) may benefit from being able to
+leave the authority less constrained.
+
+{{signature-validity}} can succeed when some delivered headers aren't included
+in the signed set. This accommodates current TLS-terminating intermediates and
+may be useful for SRI ({{uc-sri}}), but is risky for trusting cross-origin
+responses ({{uc-pushed-subresources}}, {{uc-explicit-distributor}}, and
+{{uc-offline-websites}}). {{cross-origin-push}} requires all headers to be
+included in the signature before trusting cross-origin pushed resources, at Ryan
+Sleevi's recommendation.
+
+## application/signed-exchange ## {#security-application-signed-exchange}
+
+Clients MUST NOT trust an effective request URI claimed by an
+`application/signed-exchange` resource ({{application-signed-exchange}}) without
+either ensuring the resource was transferred from a server that was
+authoritative (Section 9.1 of {{!RFC7230}}) for that URI's origin, or calling
+the algorithm in {{co-trust-app-signed-exchange}} and getting "valid" back.
 
 # Privacy considerations
 
@@ -729,12 +1245,79 @@ HTTP without TLS.
 
 # IANA considerations
 
-This depends on the following IANA registration in
-{{?I-D.yasskin-http-origin-signed-responses}}:
+TODO: possibly register the validity-url format.
 
-* The `Signature` header field
+## Signature Header Field Registration
 
-This document also registers:
+This section registers the `Signature` header field in the "Permanent Message
+Header Field Names" registry ({{!RFC3864}}).
+
+Header field name:  `Signature`
+
+Applicable protocol:  http
+
+Status:  standard
+
+Author/Change controller:  IETF
+
+Specification document(s):  {{signature-header}} of this document
+
+## Accept-Signature Header Field Registration
+
+This section registers the `Accept-Signature` header field in the "Permanent
+Message Header Field Names" registry ({{!RFC3864}}).
+
+Header field name:  `Accept-Signature`
+
+Applicable protocol:  http
+
+Status:  standard
+
+Author/Change controller:  IETF
+
+Specification document(s):  {{accept-signature}} of this document
+
+## Signed-Headers Header Field Registration
+
+This section registers the `Signed-Headers` header field in the "Permanent
+Message Header Field Names" registry ({{!RFC3864}}).
+
+Header field name:  `Signed-Headers`
+
+Applicable protocol:  http
+
+Status:  standard
+
+Author/Change controller:  IETF
+
+Specification document(s):  {{signed-headers}} of this document
+
+## HTTP/2 Settings
+
+This section establishes an entry for the HTTP/2 Settings Registry that was
+established by Section 11.3 of {{!RFC7540}}
+
+Name: ENABLE_CROSS_ORIGIN_PUSH
+
+Code: 0xSETTING-TBD
+
+Initial Value: 0
+
+Specification: This document
+
+## HTTP/2 Error code
+
+This section establishes an entry for the HTTP/2 Error Code Registry that was
+established by Section 11.4 of {{!RFC7540}}
+
+Name: NO_TRUSTED_EXCHANGE_SIGNATURE
+
+Code: 0xERROR-TBD
+
+Description: The client does not trust the signature for a cross-origin Pushed
+signed exchange.
+
+Specification: This document
 
 ## Internet Media Type application/signed-exchange
 
@@ -745,22 +1328,22 @@ Subtype name:  signed-exchange
 Required parameters:
 
 * v: A string denoting the version of the file format. ({{!RFC5234}} ABNF:
-  `version = DIGIT/%x61-7A`) The version defined in this specification is `b0`.
+  `version = DIGIT/%x61-7A`) The version defined in this specification is `1`.
   When used with the `Accept` header field (Section 5.3.1 of {{!RFC7231}}), this
   parameter can be a comma (,)-separated list of version strings. ({{!RFC5234}}
   ABNF: `version-list = version *( "," version )`) The server is then expected
   to reply with a resource using a particular version from that list.
 
-  Note: As this is a snapshot of a draft of
-  {{?I-D.yasskin-http-origin-signed-responses}}, it does not use a simple
-  integer to describe its version.
+  Note: RFC EDITOR PLEASE DELETE THIS NOTE; Implementations of drafts of this
+  specification MUST NOT use simple integers to describe their versions, and
+  MUST instead define implementation-specific strings to identify which draft is
+  implemented.
 
 Optional parameters:  N/A
 
 Encoding considerations:  binary
 
-Security considerations:  see Section 6.6 of
-{{!I-D.yasskin-http-origin-signed-responses}}
+Security considerations:  see {{security-application-signed-exchange}}
 
 Interoperability considerations:  N/A
 
@@ -775,7 +1358,7 @@ Additional information:
 
   Deprecated alias names for this type:  N/A
 
-  Magic number(s):  82 A?
+  Magic number(s):  73 78 67 31 00
 
   File extension(s): .sxg
 
@@ -792,7 +1375,449 @@ Author:  See Authors' Addresses section.
 
 Change controller:  IESG
 
+## Internet Media Type application/cert-chain+cbor
+
+Type name:  application
+
+Subtype name:  cert-chain+cbor
+
+Required parameters:  N/A
+
+Optional parameters:  N/A
+
+Encoding considerations:  binary
+
+Security considerations:  N/A
+
+Interoperability considerations:  N/A
+
+Published specification:  This specification (see {{cert-chain-format}}).
+
+Applications that use this media type:  N/A
+
+Fragment identifier considerations:  N/A
+
+Additional information:
+
+  Deprecated alias names for this type:  N/A
+
+  Magic number(s): 1*9(??) 67 F0 9F 93 9C E2 9B 93
+
+  File extension(s): N/A
+
+  Macintosh file type code(s):  N/A
+
+Person and email address to contact for further information: See Authors'
+  Addresses section.
+
+Intended usage:  COMMON
+
+Restrictions on usage:  N/A
+
+Author:  See Authors' Addresses section.
+
+Change controller:  IESG
+
 --- back
+
+# Use cases
+
+## PUSHed subresources {#uc-pushed-subresources}
+
+To reduce round trips, a server might use HTTP/2 Push (Section 8.2 of
+{{?RFC7540}}) to inject a subresource from another server into the client's
+cache. If anything about the subresource is expired or can't be verified, the
+client would fetch it from the original server.
+
+For example, if `https://example.com/index.html` includes
+
+~~~html
+<script src="https://jquery.com/jquery-1.2.3.min.js">
+~~~
+
+Then to avoid the need to look up and connect to `jquery.com` in the critical
+path, `example.com` might push that resource signed by `jquery.com`.
+
+## Explicit use of a content distributor for subresources {#uc-explicit-distributor}
+
+In order to speed up loading but still maintain control over its content, an
+HTML page in a particular origin `O.com` could tell clients to load its
+subresources from an intermediate content distributor that's not authoritative,
+but require that those resources be signed by `O.com` so that the distributor
+couldn't modify the resources. This is more constrained than the common CDN case
+where `O.com` has a CNAME granting the CDN the right to serve arbitrary content
+as `O.com`.
+
+~~~html
+<img logicalsrc="https://O.com/img.png"
+     physicalsrc="https://distributor.com/O.com/img.png">
+~~~
+
+To make it easier to configure the right distributor for a given request,
+computation of the `physicalsrc` could be encapsulated in a custom element:
+
+~~~html
+<dist-img src="https://O.com/img.png"></dist-img>
+~~~
+
+where the `<dist-img>` implementation generates an appropriate `<img>` based on,
+for example, a `<meta name="dist-base">` tag elsewhere in the page. However,
+this has the downside that the
+[preloader](https://calendar.perfplanet.com/2013/big-bad-preloader/) can no
+longer see the physical source to download it. The resulting delay might cancel
+out the benefit of using a distributor.
+
+This could be used for some of the same purposes as SRI ({{uc-sri}}).
+
+To implement this with the current proposal, the distributor would respond to
+the physical request to `https://distributor.com/O.com/img.png` with first a
+signed PUSH_PROMISE for `https://O.com/img.png` and then a redirect to
+`https://O.com/img.png`.
+
+## Subresource Integrity {#uc-sri}
+
+The W3C WebAppSec group is investigating
+[using signatures](https://github.com/mikewest/signature-based-sri) in {{SRI}}.
+They need a way to transmit the signature with the response, which this proposal
+provides.
+
+Their needs are simpler than most other use cases in that the
+`integrity="ed25519-[public-key]"` attribute and CSP-based ways of expressing a
+public key don't need that key to be wrapped into a certificate.
+
+The "ed25519key" signature parameter supports this simpler way of attaching a
+key.
+
+The current proposal for signature-based SRI describes signing only the content
+of a resource, while this specification requires them to sign the request URI as
+well. This issue is tracked in
+<https://github.com/mikewest/signature-based-sri/issues/5>. The details of what
+they need to sign will affect whether and how they can use this proposal.
+
+## Binary Transparency {#uc-transparency}
+
+So-called "Binary Transparency" may eventually allow users to verify that a
+program they've been delivered is one that's available to the public, and not a
+specially-built version intended to attack just them. Binary transparency
+systems don't exist yet, but they're likely to work similarly to the successful
+Certificate Transparency logs described by {{?RFC6962}}.
+
+Certificate Transparency depends on Signed Certificate Timestamps that prove a
+log contained a particular certificate at a particular time. To build the same
+thing for Binary Transparency logs containing HTTP resources or full websites,
+we'll need a way to provide signatures of those resources, which signed
+exchanges provides.
+
+## Static Analysis {#uc-static-analysis}
+
+Native app stores like the [Apple App
+Store](https://www.apple.com/ios/app-store/) and the [Android Play
+Store](https://play.google.com/store) grant their contents powerful abilities,
+which they attempt to make safe by analyzing the applications before offering
+them to people. The web has no equivalent way for people to wait to run an
+update of a web application until a trusted authority has vouched for it.
+
+While full application analysis probably needs to wait until the authority can
+sign bundles of exchanges, authorities may be able to guarantee certain
+properties by just checking a top-level resource and its {{SRI}}-constrained
+sub-resources.
+
+## Offline websites {#uc-offline-websites}
+
+Fully-offline websites can be represented as bundles of signed exchanges,
+although an optimization to reduce the number of signature verifications may be
+needed. Work on this is in progress in the <https://github.com/WICG/webpackage>
+repository.
+
+# Requirements
+
+## Proof of origin
+
+To verify that a thing came from a particular origin, for use in the same
+context as a TLS connection, we need someone to vouch for the signing key with
+as much verification as the signing keys used in TLS. The obvious way to do this
+is to re-use the web PKI and CA ecosystem.
+
+### Certificate constraints
+
+If we re-use existing TLS server certificates, we incur the risks that:
+
+1. TLS server certificates must be accessible from online servers, so they're
+   easier to steal or use as signing oracles than an offline key. An exchange's
+   signing key doesn't need to be online.
+2. A server using an origin-trusted key for one purpose (e.g. TLS) might
+   accidentally sign something that looks like an exchange, or vice versa.
+
+These risks are considered too high, so we define a new X.509 certificate
+extension in {{cross-origin-cert-req}} that requires CAs to issue new
+certificates for this purpose. We expect at least one low-cost CA to be willing
+to sign certificates with this extension.
+
+### Signature constraints
+
+In order to prevent an attacker who can convince the server to sign some
+resource from causing those signed bytes to be interpreted as something else the
+new X.509 extension here is forbidden from being used in TLS servers. If
+{{cross-origin-cert-req}} changes to allow re-use in TLS servers, we would need
+to:
+
+1. Avoid key types that are used for non-TLS protocols whose output could be
+   confused with a signature. That may be just the `rsaEncryption` OID from
+   {{?RFC8017}}.
+2. Use the same format as TLS's signatures, specified in Section 4.4.3 of
+   {{?I-D.ietf-tls-tls13}}, with a context string that's specific to this use.
+
+The specification also needs to define which signing algorithm to use. It
+currently specifies that as a function from the key type, instead of allowing
+attacker-controlled data to specify it.
+
+### Retrieving the certificate {#certificate-chain}
+
+The client needs to be able to find the certificate vouching for the signing
+key, a chain from that certificate to a trusted root, and possibly other trust
+information like SCTs ({{?RFC6962}}). One approach would be to include the
+certificate and its chain in the signature metadata itself, but this wastes
+bytes when the same certificate is used for multiple HTTP responses. If we
+decide to put the signature in an HTTP header, certificates are also unusually
+large for that context.
+
+Another option is to pass a URL that the client can fetch to retrieve the
+certificate and chain. To avoid extra round trips in fetching that URL, it could
+be [bundled](#uc-offline-websites) with the signed content or
+[PUSHed](#uc-pushed-subresources) with it. The risks from the
+`client_certificate_url` extension (Section 11.3 of {{RFC6066}}) don't seem to
+apply here, since an attacker who can get a client to load an exchange and fetch
+the certificates it references, can also get the client to perform those fetches
+by loading other HTML.
+
+To avoid using an unintended certificate with the same public key as the
+intended one, the content of the leaf certificate or the chain should be
+included in the signed data, like TLS does (Section 4.4.3 of
+{{?I-D.ietf-tls-tls13}}).
+
+## How much to sign ## {#how-much-to-sign}
+
+The previous {{?I-D.thomson-http-content-signature}} and
+{{?I-D.burke-content-signature}} schemes signed just the content, while
+({{?I-D.cavage-http-signatures}} could also sign the response headers and the
+request method and path. However, the same path, response headers, and content
+may mean something very different when retrieved from a different server.
+{{significant-headers}} currently includes the whole request URL in the
+signature, but it's possible we need a more flexible scheme to allow some
+higher-level protocols to accept a less-signed URL.
+
+The question of whether to include other request headers---primarily the
+`accept*` family---is still open. These headers need to be represented so that
+clients wanting a different language, say, can avoid using the wrong-language
+response, but it's not obvious that there's a security vulnerability if an
+attacker can spoof them. For now, the proposal ({{proposal}}) omits other
+request headers.
+
+In order to allow multiple clients to consume the same signed exchange, the
+exchange shouldn't include the exact request headers that any particular client
+sends. For example, a Japanese resource wouldn't include
+
+~~~http
+accept-language: ja-JP, ja;q=0.9, en;q=0.8, zh;q=0.7, *;q=0.5
+~~~
+
+Instead, it would probably include just
+
+~~~http
+accept-language: ja-JP, ja
+~~~
+
+and clients would use the same matching logic as
+for [PUSH_PROMISE](https://tools.ietf.org/html/rfc7540#section-8.2) frame
+headers.
+
+### Conveying the signed headers
+
+HTTP headers are traditionally munged by proxies, making it impossible to
+guarantee that the client will see the same sequence of bytes as the publisher
+published. In the HTTPS world, we have more end-to-end header integrity, but
+it's still likely that there are enough TLS-terminating proxies that the
+publisher's signatures would tend to break before getting to the client.
+
+There's also no way in current HTTP for the response to a client-initiated
+request (Section 8.1 of {{RFC7540}}) to convey the request headers it expected
+to respond to. A PUSH_PROMISE (Section 8.2 of {{RFC7540}}) does not have this
+problem, and it would be possible to introduce a response header to convey the
+expected request headers.
+
+Since proxies are unlikely to modify unknown content types, we can wrap the
+original exchange into an `application/signed-exchange` format
+({{application-signed-exchange}}) and include the `Cache-Control: no-transform`
+header when sending it.
+
+To reduce the likelihood of accidental modification by proxies, the
+`application/signed-exchange` format includes a file signature that doesn't
+collide with other known signatures.
+
+To help the PUSHed subresources use case ({{uc-pushed-subresources}}), we might
+also want to extend the `PUSH_PROMISE` frame type to include a signature, and
+that could tell intermediates not to change the ensuing headers.
+
+## Response lifespan
+
+A normal HTTPS response is authoritative only for one client, for as long as its
+cache headers say it should live. A signed exchange can be re-used for many
+clients, and if it was generated while a server was compromised, it can continue
+compromising clients even if their requests happen after the server recovers.
+This signing scheme needs to mitigate that risk.
+
+### Certificate revocation
+
+Certificates are mis-issued and private keys are stolen, and in response clients
+need to be able to stop trusting these certificates as promptly as possible.
+Online revocation
+checks [don't work](https://www.imperialviolet.org/2012/02/05/crlsets.html), so
+the industry has moved to pushed revocation lists and stapled OCSP responses
+{{?RFC6066}}.
+
+Pushed revocation lists work as-is to block trust in the certificate signing an
+exchange, but the signatures need an explicit strategy to staple OCSP responses.
+One option is to extend the certificate download ({{certificate-chain}}) to
+include the OCSP response too, perhaps in the
+[TLS 1.3 CertificateEntry](https://tlswg.github.io/tls13-spec/draft-ietf-tls-tls13.html#ocsp-and-sct) format.
+
+### Response downgrade attacks {#downgrade}
+
+The signed content in a response might be vulnerable to attacks, such as XSS, or
+might simply be discovered to be incorrect after publication. Once the author
+fixes those vulnerabilities or mistakes, clients should stop trusting the old
+signed content in a reasonable amount of time. Similar to certificate
+revocation, I expect the best option to be stapled "this version is still valid"
+assertions with short expiration times.
+
+These assertions could be structured as:
+
+1. A signed minimum version number or timestamp for a set of request headers:
+   This requires that signed responses need to include a version number or
+   timestamp, but allows a server to provide a single signature covering all
+   valid versions.
+1. A replacement for the whole exchange's signature. This requires the publisher to
+   separately re-sign each valid version and requires each version to include a
+   different update URL, but allows intermediates to serve less data. This is
+   the approach taken in {{proposal}}.
+1. A replacement for the exchange's signature and an update for the embedded
+   `expires` and related cache-control HTTP headers {{?RFC7234}}. This naturally
+   extends publishers' intuitions about cache expiration and the existing cache
+   revalidation behavior to signed exchanges. This is sketched and its downsides
+   explored in {{validity-with-cache-control}}.
+
+The signature also needs to include instructions to intermediates for how to
+fetch updated validity assertions.
+
+## Low implementation complexity
+
+Simpler implementations are, all things equal, less likely to include bugs. This
+section describes decisions that were made in the rest of the specification to
+reduce complexity.
+
+### Limited choices
+
+In general, we're trying to eliminate unnecessary choices in the specification.
+For example, instead of requiring clients to support two methods for verifying
+payload integrity, we only require one.
+
+### Bounded-buffering integrity checking
+
+Clients can be designed with a more-trusted network layer that decides how to
+trust resources and then provides those resources to less-trusted rendering
+processes along with handles to the storage and other resources they're allowed
+to access. If the network layer can enforce that it only operates on chunks of
+data up to a certain size, it can avoid the complexity of spooling large files
+to disk.
+
+To allow the network layer to verify signed exchanges using a bounded amount of
+memory, {{application-signed-exchange}} requires the signature and headers to be
+less than TBD bytes long, and {{signature-validity}} requires that the MI record
+size be less than TBD bytes. This allows the network layer to validate a bounded
+chunk at a time, and pass that chunk on to a renderer, and then forget about
+that chunk before processing the next one.
+
+The `Digest` header field from {{!RFC3230}} requires the network layer to buffer
+the entire response body, so it's disallowed.
+
+# Determining validity using cache control # {#validity-with-cache-control}
+
+This draft could expire signature validity using the normal HTTP cache control
+headers ({{?RFC7234}}) instead of embedding an expiration date in the signature
+itself. This section specifies how that would work, and describes why I haven't
+chosen that option.
+
+The signatures in the `Signature` header field ({{signature-header}}) would no
+longer contain "date" or "expires" fields.
+
+The validity-checking algorithm ({{signature-validity}}) would initialize `date`
+from the resource's `Date` header field (Section 7.1.1.2 of {{?RFC7231}}) and
+initialize `expires` from either the `Expires` header field (Section 5.3 of
+{{?RFC7234}}) or the `Cache-Control` header field's `max-age` directive (Section
+5.2.2.8 of {{?RFC7234}}) (added to `date`), whichever is present, preferring
+`max-age` (or failing) if both are present.
+
+Validity updates ({{updating-validity}}) would include a list of replacement
+response header fields. For each header field name in this list, the client
+would remove matching header fields from the stored exchange's response header
+fields. Then the client would append the replacement header fields to the stored
+exchange's response header fields.
+
+## Example of updating cache control
+
+For example, given a stored exchange of:
+
+~~~http
+GET  / HTTP/1.1
+Host: example.com
+Accept: */*
+
+HTTP/1.1 200
+Date: Mon, 20 Nov 2017 10:00:00 UTC
+Content-Type: text/html
+Date: Tue, 21 Nov 2017 10:00:00 UTC
+Expires: Sun, 26 Nov 2017 10:00:00 UTC
+
+<!doctype html>
+<html>
+...
+~~~
+
+And an update listing the following headers:
+
+~~~http
+Expires: Fri, 1 Dec 2017 10:00:00 UTC
+Date: Sat, 25 Nov 2017 10:00:00 UTC
+~~~
+
+The resulting stored exchange would be:
+
+~~~http
+GET / HTTP/1.1
+Host: example.com
+Accept: */*
+
+HTTP/1.1 200
+Content-Type: text/html
+Expires: Fri, 1 Dec 2017 10:00:00 UTC
+Date: Sat, 25 Nov 2017 10:00:00 UTC
+
+<!doctype html>
+<html>
+...
+~~~
+
+## Downsides of updating cache control ## {#downsides-of-cache-control}
+
+In an exchange with multiple signatures, using cache control to expire
+signatures forces all signatures to initially live for the same period. Worse,
+the update from one signature's "validity-url" might not match the update for
+another signature. Clients would need to maintain a current set of headers for
+each signature, and then decide which set to use when actually parsing the
+resource itself.
+
+This need to store and reconcile multiple sets of headers for a single signed
+exchange argues for embedding a signature's lifetime into the signature.
 
 # Change Log
 
@@ -824,3 +1849,6 @@ Vs. {{?I-D.yasskin-http-origin-signed-responses}}:
 * Require absolute URLs.
 
 # Acknowledgements
+
+Thanks to Ilari Liusvaara, Justin Schuh, Mark Nottingham, Mike Bishop, Ryan
+Sleevi, and Yoav Weiss for comments that improved this draft.

--- a/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
+++ b/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
@@ -44,6 +44,22 @@ normative:
     date: Living Standard
 
 informative:
+  I-D.yasskin-http-origin-signed-responses-03:
+    target: https://tools.ietf.org/html/draft-yasskin-http-origin-signed-responses-03
+    title: Signed HTTP Exchanges
+    author:
+      - name: Jeffrey Yasskin
+    seriesinfo:
+      Internet-Draft: draft-yasskin-http-origin-signed-responses-03
+    date: 2018-03-05
+  I-D.yasskin-http-origin-signed-responses-04:
+    target: https://tools.ietf.org/html/draft-yasskin-http-origin-signed-responses-04
+    title: Signed HTTP Exchanges
+    author:
+      - name: Jeffrey Yasskin
+    seriesinfo:
+      Internet-Draft: draft-yasskin-http-origin-signed-responses-04
+    date: 2018-06-14
   SRI: W3C.REC-SRI-20160623
 
 --- abstract
@@ -1823,12 +1839,14 @@ exchange argues for embedding a signature's lifetime into the signature.
 
 draft-01
 
+Vs. {{I-D.yasskin-http-origin-signed-responses-04}}:
+
 * The mi-sha256 content-encoding is renamed to mi-sha256-draft2 in case
   {{?I-D.thomson-http-mice}} changes.
 
 draft-00
 
-Vs. {{?I-D.yasskin-http-origin-signed-responses}}:
+Vs. {{I-D.yasskin-http-origin-signed-responses-03}}:
 
 * Removed non-normative sections.
 * Only 1 signature is supported.

--- a/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
+++ b/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
@@ -844,8 +844,6 @@ covered by the certificate. When it is present, the client MUST follow the
 validation procedure in {{cross-origin-trust}}.
 
 ~~~asn.1
-   id-ce-canSignHttpExchanges OBJECT IDENTIFIER ::= { TBD }
-
    CanSignHttpExchanges ::= NULL
 ~~~
 
@@ -868,16 +866,15 @@ certificates with this extension in TLS connections (Section 4.4.2.2 of
 and avoids encouraging server operators to put exchange-signing keys on servers
 exposed directly to the internet.
 
-RFC EDITOR PLEASE DELETE THE REST OF THE PARAGRAPHS IN THIS SECTION
+This draft of the specification identifies the CanSignHttpExchanges extension
+with the id-ce-canSignHttpExchangesDraft OID:
 
 ~~~asn.1
    id-ce-google OBJECT IDENTIFIER ::= { 1 3 6 1 4 1 11129 }
-   id-ce-testCanSignHttpExchanges OBJECT IDENTIFIER ::= { id-ce-google 2 1 22 }
+   id-ce-canSignHttpExchangesDraft OBJECT IDENTIFIER ::= { id-ce-google 2 1 22 }
 ~~~
 
-Implementations of drafts of this specification MAY recognize the
-`id-ce-testCanSignHttpExchanges` OID as identifying the CanSignHttpExchanges
-extension. This OID might or might not be used as the final OID for the
+This OID might or might not be used as the final OID for the
 extension, so certificates including it might need to be reissued once the final
 RFC is published.
 

--- a/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
+++ b/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
@@ -451,8 +451,8 @@ to retrieve an updated OCSP from the original server.
    field is not present in `exchange`'s response headers, then return "invalid".
    If validating integrity
    using the selected header field requires the client to process records larger
-   than TBD (for example, if the `mi-sha256-draft2` record length is greater
-   than TBD), return "invalid". Clients MUST be able to check the integrity of
+   than 16kB (for example, if the `mi-sha256-draft2` record length is greater
+   than 16kB), return "invalid". Clients MUST be able to check the integrity of
    `payload` using the `MI-Draft2` header field with its `mi-sha256-draft2`
    content encoding, which are defined equivalently to the `MI` header field and
    `mi-sha256` content encoding from {{!I-D.thomson-http-mice}}.
@@ -974,9 +974,9 @@ This content type consists of the concatenation of the following items:
    and MUST use another implementation-specific string beginning with "sxg1-" and
    ending with a 0 byte instead.
 1. 3 bytes storing a big-endian integer `sigLength`. If this is larger
-   than TBD, parsing MUST fail.
+   than 16kB, parsing MUST fail.
 1. 3 bytes storing a big-endian integer `headerLength`. If this is larger than
-   TBD, parsing MUST fail.
+   16kB, parsing MUST fail.
 1. `sigLength` bytes holding the `Signature` header field's value
    ({{signature-header}}).
 1. `headerLength` bytes holding the signed headers, the canonical serialization
@@ -1216,6 +1216,8 @@ Vs. {{I-D.yasskin-http-origin-signed-responses-04}}:
   mi-sha256-draft2 in case {{?I-D.thomson-http-mice}} changes.
 * Signed exchanges cannot be transmitted using HTTP/2 Push.
 * Removed non-normative sections.
+* The mi-sha256 encoding must have records <= 16kB.
+* The signature and HTTP headers must each be <=16kB long.
 
 draft-00
 


### PR DESCRIPTION
I think this catches everything that we're expecting to be different or missing in the Chrome 69 implementation vs the main spec. Let me know if I've missed anything.

Fixes #186.