### PR TITLE
gen-certurl: do not parse input certificates twice

### DIFF
--- a/go/signedexchange/certurl/ocsp.go
+++ b/go/signedexchange/certurl/ocsp.go
@@ -2,19 +2,14 @@ package certurl
 
 import (
 	"bytes"
+	"crypto/x509"
 	"fmt"
 	"golang.org/x/crypto/ocsp"
 	"io/ioutil"
 	"net/http"
-
-	"github.com/WICG/webpackage/go/signedexchange"
 )
 
-func CreateOCSPRequest(certPem []byte) (*http.Request, error) {
-	certs, err := signedexchange.ParseCertificates(certPem)
-	if err != nil {
-		return nil, err
-	}
+func CreateOCSPRequest(certs []*x509.Certificate) (*http.Request, error) {
 	if len(certs) < 2 {
 		return nil, fmt.Errorf("Could not fetch OCSP response: Issuer certificate not found")
 	}
@@ -38,8 +33,8 @@ func CreateOCSPRequest(certPem []byte) (*http.Request, error) {
 	return request, nil
 }
 
-func FetchOCSPResponse(certPem []byte) ([]byte, error) {
-	request, err := CreateOCSPRequest(certPem)
+func FetchOCSPResponse(certs []*x509.Certificate) ([]byte, error) {
+	request, err := CreateOCSPRequest(certs)
 	if err != nil {
 		return nil, err
 	}

--- a/go/signedexchange/certurl/ocsp_test.go
+++ b/go/signedexchange/certurl/ocsp_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	. "github.com/WICG/webpackage/go/signedexchange/certurl"
+	"github.com/WICG/webpackage/go/signedexchange"
 )
 
 func TestOCSP(t *testing.T) {
@@ -16,8 +17,13 @@ func TestOCSP(t *testing.T) {
 		t.Errorf("Cannot read test-cert.pem: %v", err)
 		return
 	}
+	certs, err := signedexchange.ParseCertificates(pem)
+	if err != nil {
+		t.Errorf("Cannot parse test-cert.pem: %v", err)
+		return
+	}
 
-	req, err := CreateOCSPRequest(pem)
+	req, err := CreateOCSPRequest(certs)
 	if err != nil {
 		t.Errorf("CreateOCSPRequest failed: %v", err)
 		return

--- a/go/signedexchange/certurl/parse.go
+++ b/go/signedexchange/certurl/parse.go
@@ -3,46 +3,23 @@ package certurl
 import (
 	"bytes"
 	"crypto/x509"
-	"encoding/pem"
-	"fmt"
 
 	"github.com/WICG/webpackage/go/signedexchange/cbor"
 )
 
-// CertificateMessageFromPEM parses a PEM formatted content to a certUrl content.
-// See https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html for the spec.
-func CertificateMessageFromPEM(pemFileContent, ocspFileContent, sctFileContent []byte) ([]byte, error) {
-	b := pemFileContent
-
-	entries := []*x509.Certificate{}
-	for {
-		block, rest := pem.Decode(b)
-		if block == nil && len(rest) > 0 {
-			return nil, fmt.Errorf("failed to parse PEM file")
-		}
-		c, err := x509.ParseCertificate(block.Bytes)
-		if err != nil {
-			return nil, err
-		}
-
-		entries = append(entries, c)
-
-		if len(rest) == 0 {
-			break
-		}
-		b = rest
-	}
-
+// CreateCertChainCBOR generates a certificate chain of application/cert-chain+cbor format.
+// See https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#cert-chain-format for the spec.
+func CreateCertChainCBOR(certs []*x509.Certificate, ocspFileContent, sctFileContent []byte) ([]byte, error) {
 	buf := &bytes.Buffer{}
 	enc := cbor.NewEncoder(buf)
 
-	if err := enc.EncodeArrayHeader(len(entries) + 1); err != nil {
+	if err := enc.EncodeArrayHeader(len(certs) + 1); err != nil {
 		return nil, err
 	}
 	if err := enc.EncodeTextString("\U0001F4DC\u26D3"); err != nil {
 		return nil, err
 	}
-	for i, entry := range entries {
+	for i, entry := range certs {
 		mes := []*cbor.MapEntryEncoder{
 			cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
 				keyE.EncodeTextString("cert")

--- a/go/signedexchange/certurl/parse_test.go
+++ b/go/signedexchange/certurl/parse_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	. "github.com/WICG/webpackage/go/signedexchange/certurl"
+	"github.com/WICG/webpackage/go/signedexchange"
 	"github.com/WICG/webpackage/go/signedexchange/internal/testhelper"
 )
 
@@ -52,8 +53,13 @@ func TestParsePEM(t *testing.T) {
 		t.Errorf("Cannot read test-cert.pem: %v", err)
 		return
 	}
+	certs, err := signedexchange.ParseCertificates(in)
+	if err != nil {
+		t.Errorf("Cannot parse test-cert.pem: %v", err)
+		return
+	}
 
-	cert, err := CertificateMessageFromPEM(in, nil, nil)
+	cert, err := CreateCertChainCBOR(certs, nil, nil)
 	if err != nil {
 		t.Errorf("failed to parse PEM: %v", err)
 	}

--- a/go/signedexchange/cmd/gen-certurl/main.go
+++ b/go/signedexchange/cmd/gen-certurl/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/WICG/webpackage/go/signedexchange"
 	"github.com/WICG/webpackage/go/signedexchange/certurl"
 )
 
@@ -16,14 +17,18 @@ var (
 )
 
 func run(pemFilePath, ocspFilePath, sctFilePath string) error {
-	in, err := ioutil.ReadFile(pemFilePath)
+	pem, err := ioutil.ReadFile(pemFilePath)
+	if err != nil {
+		return err
+	}
+	certs, err := signedexchange.ParseCertificates(pem)
 	if err != nil {
 		return err
 	}
 
 	var ocsp []byte
 	if *ocspFilepath == "" {
-		ocsp, err = certurl.FetchOCSPResponse(in)
+		ocsp, err = certurl.FetchOCSPResponse(certs)
 		if err != nil {
 			return err
 		}
@@ -42,7 +47,7 @@ func run(pemFilePath, ocspFilePath, sctFilePath string) error {
 		}
 	}
 
-	out, err := certurl.CertificateMessageFromPEM(in, ocsp, sct)
+	out, err := certurl.CreateCertChainCBOR(certs, ocsp, sct)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Now FetchOCSPResponse and CreateCertChainCBOR (renamed from
CertificateMessageFromPEM) take parsed x509.Certificates.