### PR TITLE
Try all PEM blocks in private key file.

### DIFF
--- a/go/signedexchange/cmd/gen-signedexchange/main.go
+++ b/go/signedexchange/cmd/gen-signedexchange/main.go
@@ -81,14 +81,14 @@ func run() error {
 
 	var privkey crypto.PrivateKey
 	for {
-		var parsedPrivKey *pem.Block
-		parsedPrivKey, privkeytext = pem.Decode(privkeytext)
-		if parsedPrivKey == nil {
-			return fmt.Errorf("invalid private key")
+		var pemBlock *pem.Block
+		pemBlock, privkeytext = pem.Decode(privkeytext)
+		if pemBlock == nil {
+			return fmt.Errorf("invalid PEM block in private key file %q.", *flagPrivateKey)
 		}
 
 		var err error
-		privkey, err = signedexchange.ParsePrivateKey(parsedPrivKey.Bytes)
+		privkey, err = signedexchange.ParsePrivateKey(pemBlock.Bytes)
 		if err == nil || len(privkeytext) == 0 {
 			break
 		}


### PR DESCRIPTION
Change gen-signedexchange to try parsing all blocks in the key file as a
private key. On OpenSSL 1.1.0h, the instructions at README.md result in
a key file that has two blocks, where the first is an EC PARAMETERS
block and the second is the EC PRIVATE KEY. This allows that file to be
read.