### PR TITLE
gen-certurl: Read SCT files from directory specified with -sctDir

### DIFF
--- a/go/signedexchange/README.md
+++ b/go/signedexchange/README.md
@@ -46,8 +46,8 @@ Here, we assume that you have an access to an HTTPS server capable of serving st
 
 1. Convert the PEM certificate to `application/cert-chain+cbor` format using `gen-certurl` tool.
     ```
-    # Fill in dummy data for OCSP/SCT, since the certificate is self-signed.
-    gen-certurl -pem cert.pem -ocsp <(echo ocsp) -sct <(echo sct) > cert.cbor
+    # Fill in dummy data for OCSP, since the certificate is self-signed.
+    gen-certurl -pem cert.pem -ocsp <(echo ocsp) > cert.cbor
     ```
 
 1. Host the `application/cert-chain+cbor` created in Step 3 on the HTTPS server. Configure the resource to be served with `Content-Type: application/cert-chain+cbor` HTTP header. The steps below assume the `cert.cbor` is hosted at `https://yourcdn.example.net/cert.cbor`, so substitute the URL to the actual URL in below steps.

--- a/go/signedexchange/certurl/sct.go
+++ b/go/signedexchange/certurl/sct.go
@@ -23,11 +23,16 @@ func SerializeSCTList(scts [][]byte) ([]byte, error) {
 	}
 
 	var buf bytes.Buffer
-	buf.Grow(total_length + 2) // +2 for length
-	binary.Write(&buf, binary.BigEndian, uint16(total_length))
+	if err := binary.Write(&buf, binary.BigEndian, uint16(total_length)); err != nil {
+		return nil, err
+	}
 	for _, sct := range scts {
-		binary.Write(&buf, binary.BigEndian, uint16(len(sct)))
-		buf.Write(sct)
+		if err := binary.Write(&buf, binary.BigEndian, uint16(len(sct))); err != nil {
+			return nil, err
+		}
+		if _, err := buf.Write(sct); err != nil {
+			return nil, err
+		}
 	}
 	return buf.Bytes(), nil
 }

--- a/go/signedexchange/certurl/sct.go
+++ b/go/signedexchange/certurl/sct.go
@@ -1,0 +1,33 @@
+package certurl
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+const maxSerializedSCTLength = 0xffff
+
+// Serializes a list of SignedCertificateTimestamps into a
+// SignedCertificateTimestampList (RFC6962 Section 3.3).
+func SerializeSCTList(scts [][]byte) ([]byte, error) {
+	total_length := 0
+	for _, sct := range scts {
+		if len(sct) > maxSerializedSCTLength {
+			return nil, fmt.Errorf("SCT too large")
+		}
+		total_length += len(sct) + 2 // +2 for length
+	}
+	if total_length > maxSerializedSCTLength {
+		return nil, fmt.Errorf("SCT list too large")
+	}
+
+	var buf bytes.Buffer
+	buf.Grow(total_length + 2) // +2 for length
+	binary.Write(&buf, binary.BigEndian, uint16(total_length))
+	for _, sct := range scts {
+		binary.Write(&buf, binary.BigEndian, uint16(len(sct)))
+		buf.Write(sct)
+	}
+	return buf.Bytes(), nil
+}

--- a/go/signedexchange/certurl/sct_test.go
+++ b/go/signedexchange/certurl/sct_test.go
@@ -1,0 +1,37 @@
+package certurl_test
+
+import (
+	"bytes"
+	"testing"
+
+	. "github.com/WICG/webpackage/go/signedexchange/certurl"
+)
+
+func TestCreateOCSPRequest(t *testing.T) {
+	expected := []byte{
+		0x00, 0x0a, // length
+		0x00, 0x03, 0x01, 0x02, 0x03, // length + first SCT
+		0x00, 0x03, 0x04, 0x05, 0x06, // length + second SCT
+	}
+	serialized, err := SerializeSCTList([][]byte{{1, 2, 3}, {4, 5, 6}})
+	if err != nil {
+		t.Errorf("SerializeSCTList failed: %v", err)
+		return
+	}
+	if !bytes.Equal(expected, serialized) {
+		t.Errorf("The SCTs expected to serialize to %v, actual %v", expected, serialized)
+	}
+}
+
+func TestCreateOCSPRequestTooLarge(t *testing.T) {
+	_, err := SerializeSCTList([][]byte{make([]byte, 65536)})
+	if err == nil {
+		t.Errorf("SerializeSCTList didn't fail with too large SCT")
+	}
+
+	// (32766 + 2) * 2 = 65536
+	_, err = SerializeSCTList([][]byte{make([]byte, 32766), make([]byte, 32766)})
+	if err == nil {
+		t.Errorf("SerializeSCTList didn't fail with too large SCT list")
+	}
+}


### PR DESCRIPTION
Instead of reading a serialized SignedCertificateTimestampList from a
file, read all `*.sct` files in a directory given by the `-sctDir` flag
and serialize them into SignedCertificateTimestampList.

This matches the way how [nginx-ct](https://github.com/grahamedgecombe/nginx-ct) and Apache's [mod_ssl_ct](https://httpd.apache.org/docs/trunk/mod/mod_ssl_ct.html) module work,
and allows users to use existing SCT generation tools.