### PR TITLE
Increase the header size limit to 512kB.

### DIFF
--- a/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
+++ b/draft-yasskin-httpbis-origin-signed-exchanges-impl.md
@@ -901,7 +901,7 @@ This content type consists of the concatenation of the following items:
 1. 3 bytes storing a big-endian integer `sigLength`. If this is larger
    than 16kB, parsing MUST fail.
 1. 3 bytes storing a big-endian integer `headerLength`. If this is larger than
-   16kB, parsing MUST fail.
+   512kB, parsing MUST fail.
 1. `sigLength` bytes holding the `Signature` header field's value
    ({{signature-header}}).
 1. `headerLength` bytes holding the signed headers, the canonical serialization


### PR DESCRIPTION
This is twice Chromium's limit for the request or response headers,
since both are included in the signed exchange headers block.