### PR TITLE
signedexchange: Rename some functions

### DIFF
--- a/go/signedexchange/cmd/dump-signedexchange/main.go
+++ b/go/signedexchange/cmd/dump-signedexchange/main.go
@@ -23,7 +23,7 @@ func run() error {
 		defer in.Close()
 	}
 
-	e, err := signedexchange.ReadExchangeFile(in)
+	e, err := signedexchange.ReadExchange(in)
 	if err != nil {
 		return err
 	}

--- a/go/signedexchange/cmd/gen-signedexchange/main.go
+++ b/go/signedexchange/cmd/gen-signedexchange/main.go
@@ -155,7 +155,7 @@ func run() error {
 		return err
 	}
 
-	if err := signedexchange.WriteExchangeFile(f, e); err != nil {
+	if err := e.Write(f); err != nil {
 		return fmt.Errorf("failed to write exchange. err: %v", err)
 	}
 	return nil

--- a/go/signedexchange/signedexchange.go
+++ b/go/signedexchange/signedexchange.go
@@ -231,7 +231,7 @@ func (e *Exchange) decodeExchangeHeaders(dec *cbor.Decoder) error {
 }
 
 // draft-yasskin-http-origin-signed-responses.html#application-http-exchange
-func WriteExchangeFile(w io.Writer, e *Exchange) error {
+func (e *Exchange) Write(w io.Writer) error {
 	// Step 1. "The ASCII characters "sxg1" followed by a 0 byte, to serve as a file signature. This is redundant with the MIME type, and recipients that receive both MUST check that they match and stop parsing if they don't." [spec text]
 	// "Note: RFC EDITOR PLEASE DELETE THIS NOTE; The implementation of the final RFC MUST use this file signature, but implementations of drafts MUST NOT use it and MUST use another implementation-specific string beginning with "sxg1-" and ending with a 0 byte instead." [spec text]
 	if _, err := w.Write(HeaderMagicBytes); err != nil {

--- a/go/signedexchange/signedexchange.go
+++ b/go/signedexchange/signedexchange.go
@@ -283,7 +283,7 @@ func (e *Exchange) Write(w io.Writer) error {
 }
 
 // draft-yasskin-http-origin-signed-responses.html#application-http-exchange
-func ReadExchangeFile(r io.Reader) (*Exchange, error) {
+func ReadExchange(r io.Reader) (*Exchange, error) {
 	// Step 1. "The ASCII characters “sxg1” followed by a 0 byte, to serve as a file signature. This is redundant with the MIME type, and recipients that receive both MUST check that they match and stop parsing if they don’t." [spec text]
 	// "Note: RFC EDITOR PLEASE DELETE THIS NOTE; The implementation of the final RFC MUST use this file signature, but implementations of drafts MUST NOT use it and MUST use another implementation-specific string beginning with “sxg1-“ and ending with a 0 byte instead." [spec text]
 	magic := make([]byte, len(HeaderMagicBytes))

--- a/go/signedexchange/signedexchange_test.go
+++ b/go/signedexchange/signedexchange_test.go
@@ -174,7 +174,7 @@ func TestSignedExchange(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := WriteExchangeFile(&buf, e); err != nil {
+	if err := e.Write(&buf); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Change the function to a method to follow the same way as net/http.Request.Write.