### PR TITLE
gen-certurl: Show warnings on possibly invalid input

### DIFF
--- a/go/signedexchange/README.md
+++ b/go/signedexchange/README.md
@@ -44,7 +44,7 @@ Here, we assume that you have an access to an HTTPS server capable of serving st
       -extfile <(echo -e "1.3.6.1.4.1.11129.2.1.22 = ASN1:NULL\nsubjectAltName=DNS:example.org")
     ```
 
-1. Convert the PEM certificate to `application/cert-chain+cbor` format using `gen-certurl` tool.
+1. Convert the PEM certificate to `application/cert-chain+cbor` format using `gen-certurl` tool. This command will show warnings about OCSP and SCT, but you can ignore them.
     ```
     # Fill in dummy data for OCSP, since the certificate is self-signed.
     gen-certurl -pem cert.pem -ocsp <(echo ocsp) > cert.cbor

--- a/go/signedexchange/certurl/sct.go
+++ b/go/signedexchange/certurl/sct.go
@@ -12,7 +12,7 @@ import (
 
 const maxSerializedSCTLength = 0xffff
 
-// Serializes a list of SignedCertificateTimestamps into a
+// SerializeSCTList serializes a list of SignedCertificateTimestamps into a
 // SignedCertificateTimestampList (RFC6962 Section 3.3).
 func SerializeSCTList(scts [][]byte) ([]byte, error) {
 	total_length := 0
@@ -41,7 +41,8 @@ func SerializeSCTList(scts [][]byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// Returns true if the certificate or the OCSP response have embedded SCT list.
+// HasEmbeddedSCT returns true if the certificate or the OCSP response have
+// embedded SCT list.
 func HasEmbeddedSCT(cert *x509.Certificate, ocsp_resp *ocsp.Response) bool {
 	// OIDs for embedded SCTs (Section 3.3 of RFC6962).
 	oidCertExtension := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 11129, 2, 4, 2}

--- a/go/signedexchange/cmd/gen-certurl/main.go
+++ b/go/signedexchange/cmd/gen-certurl/main.go
@@ -29,19 +29,19 @@ func run(pemFilePath, ocspFilePath, sctDirPath string) error {
 		return err
 	}
 
-	var ocsp_der []byte
+	var ocspDer []byte
 	if *ocspFilepath == "" {
-		ocsp_der, err = certurl.FetchOCSPResponse(certs)
+		ocspDer, err = certurl.FetchOCSPResponse(certs)
 		if err != nil {
 			return err
 		}
 	} else {
-		ocsp_der, err = ioutil.ReadFile(ocspFilePath)
+		ocspDer, err = ioutil.ReadFile(ocspFilePath)
 		if err != nil {
 			return err
 		}
 	}
-	parsed_ocsp, err := ocsp.ParseResponse(ocsp_der, nil)
+	parsedOcsp, err := ocsp.ParseResponse(ocspDer, nil)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Warning: ocsp is not a correct DER-encoded OCSP response.")
 	}
@@ -65,12 +65,12 @@ func run(pemFilePath, ocspFilePath, sctDirPath string) error {
 			return err
 		}
 	} else {
-		if !certurl.HasEmbeddedSCT(certs[0], parsed_ocsp) {
+		if !certurl.HasEmbeddedSCT(certs[0], parsedOcsp) {
 			fmt.Fprintln(os.Stderr, "Warning: Neither cert nor OCSP have embedded SCT list. Use -sctDir flag to add SCT from files.")
 		}
 	}
 
-	out, err := certurl.CreateCertChainCBOR(certs, ocsp_der, sctList)
+	out, err := certurl.CreateCertChainCBOR(certs, ocspDer, sctList)
 	if err != nil {
 		return err
 	}

--- a/go/signedexchange/cmd/gen-certurl/main.go
+++ b/go/signedexchange/cmd/gen-certurl/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"golang.org/x/crypto/ocsp"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
-	"golang.org/x/crypto/ocsp"
 
 	"github.com/WICG/webpackage/go/signedexchange"
 	"github.com/WICG/webpackage/go/signedexchange/certurl"
@@ -42,7 +43,7 @@ func run(pemFilePath, ocspFilePath, sctDirPath string) error {
 	}
 	parsed_ocsp, err := ocsp.ParseResponse(ocsp_der, nil)
 	if err != nil {
-		log.Println("Warning: ocsp is not a correct DER-encoded OCSP response.")
+		fmt.Fprintln(os.Stderr, "Warning: ocsp is not a correct DER-encoded OCSP response.")
 	}
 
 	var sctList []byte
@@ -65,7 +66,7 @@ func run(pemFilePath, ocspFilePath, sctDirPath string) error {
 		}
 	} else {
 		if !certurl.HasEmbeddedSCT(certs[0], parsed_ocsp) {
-			log.Println("Warning: Neither cert nor OCSP have embedded SCT list. Use -sctDir flag to add SCT from files.")
+			fmt.Fprintln(os.Stderr, "Warning: Neither cert nor OCSP have embedded SCT list. Use -sctDir flag to add SCT from files.")
 		}
 	}
 


### PR DESCRIPTION
Prints warning message when:
- OCSP data cannot be parsed as a DER-encoded OCSP response
- Cert and OCSP do not have embedded SCT, and `-sctDir` is not specified

Didn't make them error since these are OK if generated cert-chain is used for testing, with the `--ignore-certificate-errors-spki-list` Chromium flag.