### PR TITLE
gen-bundle: Drop pseudo headers in HAR

### DIFF
--- a/go/bundle/cmd/gen-bundle/main.go
+++ b/go/bundle/cmd/gen-bundle/main.go
@@ -43,6 +43,10 @@ func ReadHarFromFile(path string) (*hargo.Har, error) {
 func nvpToHeader(nvps []hargo.NVP, isStatefulHeader func(string) bool) (http.Header, error) {
 	h := make(http.Header)
 	for _, nvp := range nvps {
+		// Drop HTTP/2 pseudo headers.
+		if len(nvp.Name) > 0 && nvp.Name[0] == ':' {
+			continue
+		}
 		if isStatefulHeader(nvp.Name) {
 			log.Printf("Dropping banned header: %q", nvp.Name)
 			continue

--- a/go/bundle/cmd/gen-bundle/main.go
+++ b/go/bundle/cmd/gen-bundle/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/mrichman/hargo"
 
@@ -44,7 +45,7 @@ func nvpToHeader(nvps []hargo.NVP, isStatefulHeader func(string) bool) (http.Hea
 	h := make(http.Header)
 	for _, nvp := range nvps {
 		// Drop HTTP/2 pseudo headers.
-		if len(nvp.Name) > 0 && nvp.Name[0] == ':' {
+		if strings.HasPrefix(nvp.Name, ":") {
 			continue
 		}
 		if isStatefulHeader(nvp.Name) {


### PR DESCRIPTION
Chromium generates HAR that includes HTTP/2 pseudo headers in the
`request.headers` field. Drop them so that they don't conflict with
Bundled Exchanges' pseudo headers.