### PR TITLE
gen-bundle: Add checks to prevent creating invalid bundles

### DIFF
--- a/go/bundle/cmd/gen-bundle/main.go
+++ b/go/bundle/cmd/gen-bundle/main.go
@@ -101,6 +101,15 @@ func fromHar(harPath string) error {
 			return fmt.Errorf("Failed to extract body from response content for the request %q. err: %v", e.Request.URL, err)
 		}
 
+		if e.Request.Method != "GET" {
+			log.Printf("Dropping the entry: non-GET request method (%s)", e.Request.Method)
+			continue
+		}
+		if http.StatusText(e.Response.Status) == "" {
+			log.Printf("Dropping the entry: unknown response status (%d)", e.Response.Status)
+			continue
+		}
+
 		e := &bundle.Exchange{
 			Request: bundle.Request{
 				URL:    parsedUrl,

--- a/go/bundle/cmd/gen-bundle/main.go
+++ b/go/bundle/cmd/gen-bundle/main.go
@@ -101,7 +101,7 @@ func fromHar(harPath string) error {
 			return fmt.Errorf("Failed to extract body from response content for the request %q. err: %v", e.Request.URL, err)
 		}
 
-		if e.Request.Method != "GET" {
+		if e.Request.Method != http.MethodGet {
 			log.Printf("Dropping the entry: non-GET request method (%s)", e.Request.Method)
 			continue
 		}

--- a/go/bundle/cmd/gen-bundle/main.go
+++ b/go/bundle/cmd/gen-bundle/main.go
@@ -105,8 +105,8 @@ func fromHar(harPath string) error {
 			log.Printf("Dropping the entry: non-GET request method (%s)", e.Request.Method)
 			continue
 		}
-		if http.StatusText(e.Response.Status) == "" {
-			log.Printf("Dropping the entry: unknown response status (%d)", e.Response.Status)
+		if e.Response.Status < 100 || e.Response.Status > 999 {
+			log.Printf("Dropping the entry: invalid response status (%d)", e.Response.Status)
 			continue
 		}
 


### PR DESCRIPTION
Drop the HAR entry if:
- Request method is not GET.
- Status code is not valid. Chromium puts status code 0 if the request
  failed with a network error.