### PR TITLE
README.md: Link to go/signedexchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,4 @@ https://github.com/martinthomson/i-d-template/blob/master/doc/SETUP.md.
 
 Install this with `go install github.com/WICG/webpackage/go/signedexchange/cmd/gen-signedexchange`.
 
-This tool is not yet documented well, but you can refer to
-[README](https://cs.chromium.org/chromium/src/content/test/data/htxg/README)
-in Chromium's code repository to see how to generate necessary files for
-testing.
+See [go/signedexchange](go/signedexchange) for the usage of the tool.


### PR DESCRIPTION
Now go/signedexchange/README.md would be more useful than Chromium's README.