### PR TITLE
Remove longlived impl diffs

### DIFF
--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -470,7 +470,7 @@ to retrieve an updated OCSP from the original server.
    yet), then return "invalid". If the selected header field provides integrity
    guarantees weaker than SHA-256, return "invalid". If validating integrity
    using the selected header field requires the client to process records larger
-   than TBD bytes, return "invalid". Clients MUST implement at least the `MI`
+   than 16384 bytes, return "invalid". Clients MUST implement at least the `MI`
    ({{!I-D.thomson-http-mice}}) header field with its `mi-sha256` content
    encoding.
 1. Set `publicKey` and `signing-alg` depending on which key fields are present:
@@ -1073,10 +1073,10 @@ This content type consists of the concatenation of the following items:
    MUST use this file signature, but implementations of drafts MUST NOT use it
    and MUST use another implementation-specific string beginning with "sxg1-" and
    ending with a 0 byte instead.
-1. 3 bytes storing a big-endian integer `sigLength`. If this is larger
-   than TBD, parsing MUST fail.
+1. 3 bytes storing a big-endian integer `sigLength`. If this is larger than
+   16384 (16*1024), parsing MUST fail.
 1. 3 bytes storing a big-endian integer `headerLength`. If this is larger than
-   TBD, parsing MUST fail.
+   524288 (512*1024), parsing MUST fail.
 1. `sigLength` bytes holding the `Signature` header field's value
    ({{signature-header}}).
 1. `headerLength` bytes holding the signed headers, the canonical serialization
@@ -1777,11 +1777,11 @@ data up to a certain size, it can avoid the complexity of spooling large files
 to disk.
 
 To allow the network layer to verify signed exchanges using a bounded amount of
-memory, {{application-signed-exchange}} requires the signature and headers to be
-less than TBD bytes long, and {{signature-validity}} requires that the MI record
-size be less than TBD bytes. This allows the network layer to validate a bounded
-chunk at a time, and pass that chunk on to a renderer, and then forget about
-that chunk before processing the next one.
+memory, {{application-signed-exchange}} requires the signature to be less than
+16kB and the headers to be less than 512kB, and {{signature-validity}} requires
+that the MI record size be less than 16kB. This allows the network layer to
+validate a bounded chunk at a time, and pass that chunk on to a renderer, and
+then forget about that chunk before processing the next one.
 
 The `Digest` header field from {{!RFC3230}} requires the network layer to buffer
 the entire response body, so it's disallowed.
@@ -1872,6 +1872,7 @@ RFC EDITOR PLEASE DELETE THIS SECTION.
 draft-05
 
 * Define absolute URLs, and limit the schemes each instance can use.
+* Fill in TBD size limits.
 
 draft-04
 

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -1397,7 +1397,9 @@ Required parameters:
   Note: RFC EDITOR PLEASE DELETE THIS NOTE; Implementations of drafts of this
   specification MUST NOT use simple integers to describe their versions, and
   MUST instead define implementation-specific strings to identify which draft is
-  implemented.
+  implemented. The newest version of
+  {{?I-D.yasskin-httpbis-origin-signed-exchanges-impl}} describes the meaning of
+  one such string.
 
 Optional parameters:  N/A
 
@@ -1888,6 +1890,8 @@ draft-05
 * Define absolute URLs, and limit the schemes each instance can use.
 * Fill in TBD size limits.
 * Update to mice-03 including the Digest header.
+* Refer to draft-yasskin-httpbis-origin-signed-exchanges-impl for draft version
+  numbers.
 
 draft-04
 

--- a/draft-yasskin-wpack-bundled-exchanges.md
+++ b/draft-yasskin-wpack-bundled-exchanges.md
@@ -240,7 +240,7 @@ steps, taking the `stream` as input.
    bytestring header from `stream` ({{parse-bytestring}}). If this is an error,
    return that error.
 
-1. If `sectionLengthsLength` is TBD or greater, return an error.
+1. If `sectionLengthsLength` is 8192 (8*1024) or greater, return an error.
 
 1. Let `sectionLengthsBytes` be the result of reading `sectionLengthsLength`
    bytes from `stream`. If `sectionLengthsBytes` is an error, return that error.
@@ -494,7 +494,7 @@ as returned by {{semantics-load-metadata}}.
 1. Let `headerLength` be the result of getting the length of a CBOR bytestring
    header from `stream` ({{parse-bytestring}}). If `headerLength` is an error,
    return that error.
-1. If `headerLength` is TBD or greater, return an error.
+1. If `headerLength` is 524288 (512*1024) or greater, return an error.
 1. Let `headerCbor` be the result of reading `headerLength` bytes from `stream`
    and parsing a CBOR item from them matching the `headers` CDDL rule. If either
    the read or parse returns an error, return that error.


### PR DESCRIPTION
Fix #197. 

@kinu, does this look good enough? [mice-03](https://tools.ietf.org/html/draft-thomson-http-mice-03) is now published.

signed-responses: [Preview](https://jyasskin.github.io/webpackage/remove-longlived-impl-diffs/draft-yasskin-http-origin-signed-responses.html), [Diff](https://tools.ietf.org/rfcdiff?url1=https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.txt&url2=https://jyasskin.github.io/webpackage/remove-longlived-impl-diffs/draft-yasskin-http-origin-signed-responses.txt)

bundled-exchanges: [Preview](https://jyasskin.github.io/webpackage/remove-longlived-impl-diffs/draft-yasskin-wpack-bundled-exchanges.html), [Diff](https://tools.ietf.org/rfcdiff?url1=https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.txt&url2=https://jyasskin.github.io/webpackage/remove-longlived-impl-diffs/draft-yasskin-wpack-bundled-exchanges.txt)