### PR TITLE
Add signedexchange/version

### DIFF
--- a/go/signedexchange/version/version.go
+++ b/go/signedexchange/version/version.go
@@ -1,0 +1,8 @@
+package version
+
+type Version string
+
+const (
+	Version1b1 Version = "1b1"
+	Version1b2 Version = "1b2"
+)


### PR DESCRIPTION
This PR introduces `Version` type to represent spec versions. This is needed to be a new package since this is referenced from multiple packages not only `signedexchange` but also `mice`.