### PR TITLE
Add dump-certurl tool

### DIFF
--- a/go/signedexchange/certurl/sct.go
+++ b/go/signedexchange/certurl/sct.go
@@ -5,12 +5,20 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"encoding/base64"
 	"encoding/binary"
 	"fmt"
 	"golang.org/x/crypto/ocsp"
+	"io"
 )
 
 const maxSerializedSCTLength = 0xffff
+
+var (
+	// OIDs for embedded SCTs (Section 3.3 of RFC6962).
+	oidCertExtension = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 11129, 2, 4, 2}
+	oidOCSPExtension = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 11129, 2, 4, 5}
+)
 
 // SerializeSCTList serializes a list of SignedCertificateTimestamps into a
 // SignedCertificateTimestampList (RFC6962 Section 3.3).
@@ -44,19 +52,75 @@ func SerializeSCTList(scts [][]byte) ([]byte, error) {
 // HasEmbeddedSCT returns true if the certificate or the OCSP response have
 // embedded SCT list.
 func HasEmbeddedSCT(cert *x509.Certificate, ocsp_resp *ocsp.Response) bool {
-	// OIDs for embedded SCTs (Section 3.3 of RFC6962).
-	oidCertExtension := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 11129, 2, 4, 2}
-	oidOCSPExtension := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 11129, 2, 4, 5}
-
-	return (cert != nil && hasExtensionWithOID(cert.Extensions, oidCertExtension)) ||
-		(ocsp_resp != nil && hasExtensionWithOID(ocsp_resp.Extensions, oidOCSPExtension))
+	return (cert != nil && findExtensionWithOID(cert.Extensions, oidCertExtension) != nil) ||
+		(ocsp_resp != nil && findExtensionWithOID(ocsp_resp.Extensions, oidOCSPExtension) != nil)
 }
 
-func hasExtensionWithOID(extensions []pkix.Extension, oid asn1.ObjectIdentifier) bool {
+func findExtensionWithOID(extensions []pkix.Extension, oid asn1.ObjectIdentifier) *pkix.Extension {
 	for _, ext := range extensions {
 		if ext.Id.Equal(oid) {
-			return true
+			return &ext
 		}
 	}
-	return false
+	return nil
+}
+
+func prettyPrintSCTFromCert(w io.Writer, cert *x509.Certificate) {
+	prettyPrintSCTExtension(w, cert.Extensions, oidCertExtension)
+}
+
+func prettyPrintSCTFromOCSP(w io.Writer, ocspResp *ocsp.Response) {
+	prettyPrintSCTExtension(w, ocspResp.Extensions, oidOCSPExtension)
+}
+
+func prettyPrintSCTExtension(w io.Writer, extensions []pkix.Extension, oid asn1.ObjectIdentifier) {
+	ext := findExtensionWithOID(extensions, oid)
+	if ext == nil {
+		return
+	}
+	var sct []byte
+	if _, err := asn1.Unmarshal(ext.Value, &sct); err != nil {
+		fmt.Fprintln(w, "Error: Cannot parse SCT extension as ASN.1 OCTET STRING:", err)
+		return
+	}
+	fmt.Fprintln(w, "  Embedded SCT:")
+	prettyPrintSCT(w, sct)
+}
+
+func prettyPrintSCT(w io.Writer, SCTList []byte) {
+	buf := bytes.NewBuffer(SCTList)
+
+	var total_length uint16
+	if err := binary.Read(buf, binary.BigEndian, &total_length); err != nil {
+		fmt.Fprintln(w, "Error: Cannot parse length of SignedCertificateTimestampList:", err)
+		return
+	}
+	if int(total_length) != buf.Len() {
+		fmt.Fprintf(w, "Error: Unexpected length of SignedCertificateTimestampList. expected: %d, actual: %d\n", total_length, buf.Len())
+		return
+	}
+
+	for buf.Len() > 0 {
+		var length uint16
+		if err := binary.Read(buf, binary.BigEndian, &length); err != nil {
+			fmt.Fprintln(w, "Error: Cannot parse length of SerializedSCT:", err)
+			return
+		}
+		sct := buf.Next(int(length))
+		if int(length) != len(sct) {
+			fmt.Fprintf(w, "Error: Unexpected length of SerializedSCT. expected: %d, actual: %d\n", length, len(sct))
+			return
+		}
+
+		// sct[0] is the Version and sct[1:33] is the LogID of the SCT (Section 3.2 of RFC6962).
+		if len(sct) < 33 {
+			fmt.Fprintf(w, "Error: SCT too short (%d bytes)\n", len(sct))
+			return
+		}
+		if sct[0] != 0 {
+			fmt.Fprintf(w, "Error: Unknown version of SCT (%d)\n", sct[0])
+			return
+		}
+		fmt.Fprintln(w, "    LogID:", base64.StdEncoding.EncodeToString(sct[1:33]))
+	}
 }

--- a/go/signedexchange/cmd/dump-certurl/main.go
+++ b/go/signedexchange/cmd/dump-certurl/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"github.com/WICG/webpackage/go/signedexchange/certurl"
+)
+
+var (
+	flagInput = flag.String("i", "", "Cerrt-chain CBOR input file")
+)
+
+func run() error {
+	in := os.Stdin
+	if *flagInput != "" {
+		var err error
+		in, err = os.Open(*flagInput)
+		if err != nil {
+			return err
+		}
+		defer in.Close()
+	}
+
+	chain, err := certurl.ReadCertChain(in)
+	if err != nil {
+		return err
+	}
+	chain.PrettyPrint(os.Stdout)
+
+	return nil
+}
+
+func main() {
+	flag.Parse()
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
Example output:
```
Certificate #0:
  Subject: sxg.example.com
  Valid from: 2018-08-30 03:34:29 +0000 UTC
  Valid until: 2018-11-28 03:34:29 +0000 UTC
  Issuer: Let's Encrypt Authority X3
  Embedded SCT:
    LogID: VYHUwhaQNgFK6gubVzxT8MDkOHhwJQgXL6OqHQcT0ww=
    LogID: pFASaQVaFVReYhGrN7wQP2KuVXakXksXFEU+GyIQaiU=
Error: The main certificate does not have canSignHttpExchangesDraft extension
OCSP response:
  Status: 0 (good)
  ProducedAt: 2018-09-05 04:34:00 +0000 UTC
  ThisUpdate: 2018-09-05 04:00:00 +0000 UTC
  NextUpdate: 2018-09-12 04:00:00 +0000 UTC
Certificate #1:
  Subject: Let's Encrypt Authority X3
  Valid from: 2016-03-17 16:40:46 +0000 UTC
  Valid until: 2021-03-17 16:40:46 +0000 UTC
  Issuer: DST Root CA X3
```