### PR TITLE
Add Structured Headers parser

### DIFF
--- a/go/signedexchange/structuredheader/parser.go
+++ b/go/signedexchange/structuredheader/parser.go
@@ -129,7 +129,7 @@ func (p *parser) parseItem() (interface{}, error) {
 	// OWS for items. https://github.com/httpwg/http-extensions/issues/703
 
 	if p.isEmpty() {
-		return nil, errors.New("Item expected, got EOS")
+		return nil, errors.New("item expected, got EOS")
 	}
 	c := p.input[0]
 	if c == '-' || isDigit(c) {
@@ -145,16 +145,16 @@ func (p *parser) parseItem() (interface{}, error) {
 	if isLCAlpha(c) {
 		return p.parseIdentifier()
 	}
-	return nil, fmt.Errorf("Item expected, got '%c'", c)
+	return nil, fmt.Errorf("item expected, got '%c'", c)
 }
 
 // http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#parse-number
 func (p *parser) parseNumber() (int64, error) {
 	if p.isEmpty() {
-		return 0, errors.New("Number expected, got EOS")
+		return 0, errors.New("number expected, got EOS")
 	}
 	if p.input[0] != '-' && !isDigit(p.input[0]) {
-		return 0, fmt.Errorf("Number expected, got '%c'", p.input[0])
+		return 0, fmt.Errorf("number expected, got '%c'", p.input[0])
 	}
 	// TODO: Support Floats.
 	i := 1
@@ -172,7 +172,7 @@ func (p *parser) parseNumber() (int64, error) {
 // http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#parse-string
 func (p *parser) parseString() (string, error) {
 	if p.isEmpty() {
-		return "", errors.New("String expected, got EOS")
+		return "", errors.New("string expected, got EOS")
 	}
 	if !p.consumeChar('"') {
 		return "", fmt.Errorf("'\"' expected, got '%c'", p.input[0])
@@ -204,10 +204,10 @@ func (p *parser) parseString() (string, error) {
 // http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#parse-identifier
 func (p *parser) parseIdentifier() (Identifier, error) {
 	if p.isEmpty() {
-		return "", errors.New("Identifier expected, got EOS")
+		return "", errors.New("identifier expected, got EOS")
 	}
 	if !isLCAlpha(p.input[0]) {
-		return "", fmt.Errorf("Identifier expected, got '%c'", p.input[0])
+		return "", fmt.Errorf("identifier expected, got '%c'", p.input[0])
 	}
 	i := 0
 	for i < len(p.input) && isIdent(p.input[i]) {
@@ -220,7 +220,7 @@ func (p *parser) parseIdentifier() (Identifier, error) {
 // http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#parse-binary
 func (p *parser) parseByteSequence() ([]byte, error) {
 	if p.isEmpty() {
-		return nil, errors.New("Byte Sequence expected, got EOS")
+		return nil, errors.New("byte sequence expected, got EOS")
 	}
 	if !p.consumeChar('*') {
 		return nil, fmt.Errorf("'*' expected, got '%c'", p.input[0])

--- a/go/signedexchange/structuredheader/parser.go
+++ b/go/signedexchange/structuredheader/parser.go
@@ -1,0 +1,259 @@
+// Package structuredheader parses Structured Headers for HTTP
+// (https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html).
+package structuredheader
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#identifier
+type Identifier string
+
+// http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#param
+type ParameterisedList []*ParameterisedIdentifier
+type ParameterisedIdentifier struct {
+	Label  Identifier
+	Params Parameters
+}
+
+// Parameter represents a set of parameters in a Parameterised Identifier.
+// The interface{} value is one of these:
+//
+//	int64      for Numbers
+//	string     for Strings
+//	Identifier for Identifiers
+//	[]byte     for Byte Sequences
+//	nil        for parameters with no value
+type Parameters map[Identifier]interface{}
+
+type parser struct {
+	input string
+}
+
+func (p *parser) discardLeadingOWS() {
+	p.input = strings.TrimLeft(p.input, " \t")
+}
+
+func (p *parser) isEmpty() bool {
+	return len(p.input) == 0
+}
+
+func (p *parser) getChar() byte {
+	c := p.input[0]
+	p.input = p.input[1:]
+	return c
+}
+
+func (p *parser) getString(n int) string {
+	s := p.input[:n]
+	p.input = p.input[n:]
+	return s
+}
+
+func (p *parser) consumeChar(c byte) bool {
+	if len(p.input) > 0 && p.input[0] == c {
+		p.input = p.input[1:]
+		return true
+	}
+	return false
+}
+
+// http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#parse-param-list
+func ParseParameterisedList(input string) (ParameterisedList, error) {
+	p := &parser{input}
+	// In the spec, this is done in the Step 1 of the top-level parsing algorithm.
+	// http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#text-parse
+	p.discardLeadingOWS()
+
+	var items ParameterisedList
+	for !p.isEmpty() {
+		item, err := p.parseParameterisedIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+		p.discardLeadingOWS()
+		if p.isEmpty() {
+			return items, nil
+		}
+		if !p.consumeChar(',') {
+			return nil, fmt.Errorf("COMMA expacted, got '%c'", input[0])
+		}
+		p.discardLeadingOWS()
+	}
+	return nil, errors.New("Unexpected end of input; Parameterised Identifier expected")
+}
+
+// http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#parse-param-id
+func (p *parser) parseParameterisedIdentifier() (*ParameterisedIdentifier, error) {
+	primary_identifier, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	parameters := make(Parameters)
+	for {
+		// This is not in the spec algorithm but ABNF allows OWS here.
+		// https://github.com/httpwg/http-extensions/issues/703
+		p.discardLeadingOWS()
+
+		if !p.consumeChar(';') {
+			break
+		}
+		p.discardLeadingOWS()
+		param_name, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := parameters[param_name]; ok {
+			return nil, fmt.Errorf("duplicated parameter '%s'", param_name)
+		}
+		var param_value interface{}
+		if p.consumeChar('=') {
+			param_value, err = p.parseItem()
+			if err != nil {
+				return nil, err
+			}
+		}
+		parameters[param_name] = param_value
+	}
+	return &ParameterisedIdentifier{primary_identifier, parameters}, nil
+}
+
+// http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#parse-item
+func (p *parser) parseItem() (interface{}, error) {
+	// The spec algorithm has "Discard OWS" here but ABNF doesn't permit leading
+	// OWS for items. https://github.com/httpwg/http-extensions/issues/703
+
+	if p.isEmpty() {
+		return nil, errors.New("Item expected, got EOS")
+	}
+	c := p.input[0]
+	if c == '-' || isDigit(c) {
+		return p.parseNumber()
+	}
+	if c == '"' {
+		return p.parseString()
+	}
+	if c == '*' {
+		return p.parseByteSequence()
+	}
+	// TODO: Support Booleans.
+	if isLCAlpha(c) {
+		return p.parseIdentifier()
+	}
+	return nil, fmt.Errorf("Item expected, got '%c'", c)
+}
+
+// http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#parse-number
+func (p *parser) parseNumber() (int64, error) {
+	if p.isEmpty() {
+		return 0, errors.New("Number expected, got EOS")
+	}
+	if p.input[0] != '-' && !isDigit(p.input[0]) {
+		return 0, fmt.Errorf("Number expected, got '%c'", p.input[0])
+	}
+	// TODO: Support Floats.
+	i := 1
+	for i < len(p.input) && isDigit(p.input[i]) {
+		i++
+	}
+	s := p.getString(i)
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("Couldn't parse %q as number: %v", s, err)
+	}
+	return n, nil
+}
+
+// http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#parse-string
+func (p *parser) parseString() (string, error) {
+	if p.isEmpty() {
+		return "", errors.New("String expected, got EOS")
+	}
+	if !p.consumeChar('"') {
+		return "", fmt.Errorf("DQUOTE expected, got '%c'", p.input[0])
+	}
+
+	var b strings.Builder
+	for !p.isEmpty() {
+		c := p.getChar()
+		if c == '\\' {
+			if p.isEmpty() {
+				break
+			}
+			c = p.getChar()
+			if c != '"' && c != '\\' {
+				return "", fmt.Errorf("Invalid escape \\%c", c)
+			}
+			b.WriteByte(c)
+		} else if c == '"' {
+			return b.String(), nil
+		} else if c < ' ' || c > '~' {
+			return "", fmt.Errorf("Invalid character \\x%02x", c)
+		} else {
+			b.WriteByte(c)
+		}
+	}
+	return "", errors.New("Missing closing DQUOTE")
+}
+
+// http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#parse-identifier
+func (p *parser) parseIdentifier() (Identifier, error) {
+	if p.isEmpty() {
+		return "", errors.New("Identifier expected, got EOS")
+	}
+	if !isLCAlpha(p.input[0]) {
+		return "", fmt.Errorf("Identifier expected, got '%c'", p.input[0])
+	}
+	i := 0
+	for i < len(p.input) && isIdent(p.input[i]) {
+		i++
+	}
+	id := Identifier(p.getString(i))
+	return id, nil
+}
+
+// http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#parse-binary
+func (p *parser) parseByteSequence() ([]byte, error) {
+	if p.isEmpty() {
+		return nil, errors.New("Byte Sequence expected, got EOS")
+	}
+	if !p.consumeChar('*') {
+		return nil, fmt.Errorf("'*' expected, got '%c'", p.input[0])
+	}
+	len := strings.IndexByte(p.input, '*')
+	if len < 0 {
+		return nil, errors.New("Missing closing '*'")
+	}
+	s := p.getString(len)
+	enc := base64.StdEncoding
+	if len%4 != 0 {
+		// Allow unpadded encoding.
+		enc = base64.RawStdEncoding
+	}
+	data, err := enc.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't decode base64 %q: %v", s, err)
+	}
+	if !p.consumeChar('*') {
+		panic("cannot happen")
+	}
+	return data, nil
+}
+
+func isDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}
+
+func isLCAlpha(c byte) bool {
+	return c >= 'a' && c <= 'z'
+}
+
+// isIdent returns true if c is allowed in subsequent characters of Identifiers.
+func isIdent(c byte) bool {
+	return isLCAlpha(c) || isDigit(c) || c == '_' || c == '-' || c == '*' || c == '/'
+}

--- a/go/signedexchange/structuredheader/parser.go
+++ b/go/signedexchange/structuredheader/parser.go
@@ -14,7 +14,7 @@ import (
 type Identifier string
 
 // http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#param
-type ParameterisedList []*ParameterisedIdentifier
+type ParameterisedList []ParameterisedIdentifier
 type ParameterisedIdentifier struct {
 	Label  Identifier
 	Params Parameters
@@ -89,10 +89,10 @@ func ParseParameterisedList(input string) (ParameterisedList, error) {
 }
 
 // http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#parse-param-id
-func (p *parser) parseParameterisedIdentifier() (*ParameterisedIdentifier, error) {
+func (p *parser) parseParameterisedIdentifier() (ParameterisedIdentifier, error) {
 	primary_identifier, err := p.parseIdentifier()
 	if err != nil {
-		return nil, err
+		return ParameterisedIdentifier{}, err
 	}
 	parameters := make(Parameters)
 	for {
@@ -106,21 +106,21 @@ func (p *parser) parseParameterisedIdentifier() (*ParameterisedIdentifier, error
 		p.discardLeadingOWS()
 		param_name, err := p.parseIdentifier()
 		if err != nil {
-			return nil, err
+			return ParameterisedIdentifier{}, err
 		}
 		if _, ok := parameters[param_name]; ok {
-			return nil, fmt.Errorf("structuredheader: duplicated parameter '%s'", param_name)
+			return ParameterisedIdentifier{}, fmt.Errorf("structuredheader: duplicated parameter '%s'", param_name)
 		}
 		var param_value interface{}
 		if p.consumeChar('=') {
 			param_value, err = p.parseItem()
 			if err != nil {
-				return nil, err
+				return ParameterisedIdentifier{}, err
 			}
 		}
 		parameters[param_name] = param_value
 	}
-	return &ParameterisedIdentifier{primary_identifier, parameters}, nil
+	return ParameterisedIdentifier{primary_identifier, parameters}, nil
 }
 
 // http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#parse-item

--- a/go/signedexchange/structuredheader/parser.go
+++ b/go/signedexchange/structuredheader/parser.go
@@ -20,7 +20,7 @@ type ParameterisedIdentifier struct {
 	Params Parameters
 }
 
-// Parameter represents a set of parameters in a Parameterised Identifier.
+// Parameters represents a set of parameters in a Parameterised Identifier.
 // The interface{} value is one of these:
 //
 //	int64      for Numbers

--- a/go/signedexchange/structuredheader/parser.go
+++ b/go/signedexchange/structuredheader/parser.go
@@ -81,11 +81,11 @@ func ParseParameterisedList(input string) (ParameterisedList, error) {
 			return items, nil
 		}
 		if !p.consumeChar(',') {
-			return nil, fmt.Errorf("COMMA expacted, got '%c'", input[0])
+			return nil, fmt.Errorf("',' expacted, got '%c'", input[0])
 		}
 		p.discardLeadingOWS()
 	}
-	return nil, errors.New("Unexpected end of input; Parameterised Identifier expected")
+	return nil, errors.New("unexpected end of input; Parameterised Identifier expected")
 }
 
 // http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#parse-param-id
@@ -164,7 +164,7 @@ func (p *parser) parseNumber() (int64, error) {
 	s := p.getString(i)
 	n, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("Couldn't parse %q as number: %v", s, err)
+		return 0, fmt.Errorf("couldn't parse %q as number: %v", s, err)
 	}
 	return n, nil
 }
@@ -175,7 +175,7 @@ func (p *parser) parseString() (string, error) {
 		return "", errors.New("String expected, got EOS")
 	}
 	if !p.consumeChar('"') {
-		return "", fmt.Errorf("DQUOTE expected, got '%c'", p.input[0])
+		return "", fmt.Errorf("'\"' expected, got '%c'", p.input[0])
 	}
 
 	var b strings.Builder
@@ -187,18 +187,18 @@ func (p *parser) parseString() (string, error) {
 			}
 			c = p.getChar()
 			if c != '"' && c != '\\' {
-				return "", fmt.Errorf("Invalid escape \\%c", c)
+				return "", fmt.Errorf("invalid escape \\%c", c)
 			}
 			b.WriteByte(c)
 		} else if c == '"' {
 			return b.String(), nil
 		} else if c < ' ' || c > '~' {
-			return "", fmt.Errorf("Invalid character \\x%02x", c)
+			return "", fmt.Errorf("invalid character \\x%02x", c)
 		} else {
 			b.WriteByte(c)
 		}
 	}
-	return "", errors.New("Missing closing DQUOTE")
+	return "", errors.New("missing closing '\"'")
 }
 
 // http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#parse-identifier
@@ -227,7 +227,7 @@ func (p *parser) parseByteSequence() ([]byte, error) {
 	}
 	len := strings.IndexByte(p.input, '*')
 	if len < 0 {
-		return nil, errors.New("Missing closing '*'")
+		return nil, errors.New("missing closing '*'")
 	}
 	s := p.getString(len)
 	enc := base64.StdEncoding
@@ -237,7 +237,7 @@ func (p *parser) parseByteSequence() ([]byte, error) {
 	}
 	data, err := enc.DecodeString(s)
 	if err != nil {
-		return nil, fmt.Errorf("Couldn't decode base64 %q: %v", s, err)
+		return nil, fmt.Errorf("couldn't decode base64 %q: %v", s, err)
 	}
 	if !p.consumeChar('*') {
 		panic("cannot happen")

--- a/go/signedexchange/structuredheader/parser_test.go
+++ b/go/signedexchange/structuredheader/parser_test.go
@@ -215,7 +215,7 @@ func TestParseParameterisedIdentifier(t *testing.T) {
 			if err != nil {
 				t.Errorf("parseParameterisedIdentifier(%q) unexpectedly failed: %v", c.input, err)
 			}
-			if !reflect.DeepEqual(r, c.expected) {
+			if !reflect.DeepEqual(r, *c.expected) {
 				t.Errorf("parseParameterisedIdentifier(%q): got %v, want %v", c.input, r, c.expected)
 			}
 			if p.input != c.rest {
@@ -233,16 +233,16 @@ func TestParseParameterisedList(t *testing.T) {
 		expected ParameterisedList
 	}{
 		{"", nil},
-		{"item1;n=123", ParameterisedList{&ParameterisedIdentifier{"item1", Parameters{"n": int64(123)}}}},
+		{"item1;n=123", ParameterisedList{{"item1", Parameters{"n": int64(123)}}}},
 		{"item1;n=123,", nil},
 		{",item1;n=123", nil},
 		{"item1;n=123,item2,item3;n=456", ParameterisedList{
-			&ParameterisedIdentifier{"item1", Parameters{"n": int64(123)}},
-			&ParameterisedIdentifier{"item2", Parameters{}},
-			&ParameterisedIdentifier{"item3", Parameters{"n": int64(456)}}}},
+			{"item1", Parameters{"n": int64(123)}},
+			{"item2", Parameters{}},
+			{"item3", Parameters{"n": int64(456)}}}},
 		{" \t item1 , item2;n=123 ", ParameterisedList{
-			&ParameterisedIdentifier{"item1", Parameters{}},
-			&ParameterisedIdentifier{"item2", Parameters{"n": int64(123)}}}},
+			{"item1", Parameters{}},
+			{"item2", Parameters{"n": int64(123)}}}},
 	}
 	for _, c := range cases {
 		r, err := ParseParameterisedList(c.input)

--- a/go/signedexchange/structuredheader/parser_test.go
+++ b/go/signedexchange/structuredheader/parser_test.go
@@ -1,0 +1,260 @@
+package structuredheader
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestParseNumber(t *testing.T) {
+	cases := []struct {
+		input         string
+		shouldSucceed bool
+		expected      int64
+		rest          string
+	}{
+		{"", false, 0, ""},
+		{"42", true, 42, ""},
+		{"-42", true, -42, ""},
+		{"42rest", true, 42, "rest"},
+		{"--2", false, 0, ""},
+		{"-", false, 0, ""},
+		{"4-2", true, 4, "-2"},
+		{" 42", false, 0, ""},
+		{" 42", false, 0, ""},
+		{"0", true, 0, ""},
+		{"-0", true, 0, ""},
+		{"9223372036854775807", true, 9223372036854775807, ""},   // int64 max
+		{"-9223372036854775808", true, -9223372036854775808, ""}, // int64 min
+		{"9223372036854775808", false, 0, ""},                    // int64 max + 1
+		{"-9223372036854775809", false, 0, ""},                   // int64 min - 1
+	}
+	for _, c := range cases {
+		p := &parser{c.input}
+		n, err := p.parseNumber()
+		if c.shouldSucceed {
+			if err != nil {
+				t.Errorf("parseNumber(%q) unexpectedly failed: %v", c.input, err)
+			}
+			if n != c.expected {
+				t.Errorf("parseNumber(%q): got %v, want %v", c.input, n, c.expected)
+			}
+			if p.input != c.rest {
+				t.Errorf("parseNumber(%q): remaining input was %q, should be %q", c.input, p.input, c.rest)
+			}
+		} else if err == nil {
+			t.Errorf("parseNumber(%q) did not fail", c.input)
+		}
+	}
+}
+
+func TestParseString(t *testing.T) {
+	cases := []struct {
+		input         string
+		shouldSucceed bool
+		expected      string
+		rest          string
+	}{
+		{``, false, "", ""},
+		{`"`, false, "", ""},
+		{`""`, true, "", ""},
+		{`"abc"`, true, "abc", ""},
+		{`"abc`, false, "", ""},
+		{`abc"`, false, "", ""},
+		{`"abc"def`, true, "abc", "def"},
+		{`"abc\"def"`, true, "abc\"def", ""},
+		{`"abc\\def"`, true, "abc\\def", ""},
+		{`"abc\`, false, "", ""},
+		{`"abc\"`, false, "", ""},
+		{`"\n"`, false, "", ""},
+		{"\"\u2318\"", false, "", ""},
+	}
+	for _, c := range cases {
+		p := &parser{c.input}
+		s, err := p.parseString()
+		if c.shouldSucceed {
+			if err != nil {
+				t.Errorf("parseString(%q) unexpectedly failed: %v", c.input, err)
+			}
+			if s != c.expected {
+				t.Errorf("parseString(%q): got %v, want %v", c.input, s, c.expected)
+			}
+			if p.input != c.rest {
+				t.Errorf("parseString(%q): remaining input was %q, should be %q", c.input, p.input, c.rest)
+			}
+		} else if err == nil {
+			t.Errorf("parseString(%q) did not fail", c.input)
+		}
+	}
+}
+
+func TestParseIdentifier(t *testing.T) {
+	cases := []struct {
+		input         string
+		shouldSucceed bool
+		expected      Identifier
+		rest          string
+	}{
+		{"", false, "", ""},
+		{"a", true, "a", ""},
+		{"foo", true, "foo", ""},
+		{"Foo", false, "", ""},
+		{"foo123", true, "foo123", ""},
+		{"1foo", false, "", ""},
+		{"foo_-*/", true, "foo_-*/", ""},
+		{"foo=bar", true, "foo", "=bar"},
+		{"_foo", false, "", ""},
+	}
+	for _, c := range cases {
+		p := &parser{c.input}
+		id, err := p.parseIdentifier()
+		if c.shouldSucceed {
+			if err != nil {
+				t.Errorf("parseIdentifier(%q) unexpectedly failed: %v", c.input, err)
+			}
+			if id != c.expected {
+				t.Errorf("parseIdentifier(%q): got %v, want %v", c.input, id, c.expected)
+			}
+			if p.input != c.rest {
+				t.Errorf("parseIdentifier(%q): remaining input was %q, should be %q", c.input, p.input, c.rest)
+			}
+		} else if err == nil {
+			t.Errorf("parseIdentifier(%q) did not fail", c.input)
+		}
+	}
+}
+
+func TestParseByteSequence(t *testing.T) {
+	cases := []struct {
+		input         string
+		shouldSucceed bool
+		expected      []byte
+		rest          string
+	}{
+		{"", false, nil, ""},
+		{"*", false, nil, ""},
+		{"**", true, []byte{}, ""},
+		{"*Zm9v*", true, []byte("foo"), ""},
+		{"*Zm9v", false, nil, ""},
+		{"*Zm9v**", true, []byte("foo"), "*"},
+		{"*Zm9_*", false, nil, ""},
+		{"*aG9nZQ==*", true, []byte("hoge"), ""},
+		{"*aG9nZQ*", true, []byte("hoge"), ""},
+		{"*aG9nZQ=*", false, nil, ""},
+	}
+	for _, c := range cases {
+		p := &parser{c.input}
+		b, err := p.parseByteSequence()
+		if c.shouldSucceed {
+			if err != nil {
+				t.Errorf("parseByteSequence(%q) unexpectedly failed: %v", c.input, err)
+			}
+			if !bytes.Equal(b, c.expected) {
+				t.Errorf("parseByteSequence(%q): got %v, want %v", c.input, b, c.expected)
+			}
+			if p.input != c.rest {
+				t.Errorf("parseByteSequence(%q): remaining input was %q, should be %q", c.input, p.input, c.rest)
+			}
+		} else if err == nil {
+			t.Errorf("parseByteSequence(%q) did not fail", c.input)
+		}
+	}
+}
+
+func TestParseItem(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected interface{}
+		rest     string
+	}{
+		{"", nil, ""},
+		{"42", int64(42), ""},
+		{"foo", Identifier("foo"), ""},
+		{`" foo "`, " foo ", ""},
+		{"*Zm9v*;", []byte("foo"), ";"},
+	}
+	for _, c := range cases {
+		p := &parser{c.input}
+		r, err := p.parseItem()
+		if c.expected != nil {
+			if err != nil {
+				t.Errorf("parseItem(%q) unexpectedly failed: %v", c.input, err)
+			}
+			if !reflect.DeepEqual(r, c.expected) {
+				t.Errorf("parseItem(%q): got %v, want %v", c.input, r, c.expected)
+			}
+			if p.input != c.rest {
+				t.Errorf("parseItem(%q): remaining input was %q, should be %q", c.input, p.input, c.rest)
+			}
+		} else if err == nil {
+			t.Errorf("parseItem(%q) did not fail", c.input)
+		}
+	}
+}
+
+func TestParseParameterisedIdentifier(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected *ParameterisedIdentifier
+		rest     string
+	}{
+		{"", nil, ""},
+		{"label", &ParameterisedIdentifier{"label", Parameters{}}, ""},
+		{";foo", nil, ""},
+		{"label;foo", &ParameterisedIdentifier{"label", Parameters{"foo": nil}}, ""},
+		{"label;foo=bar;n=42", &ParameterisedIdentifier{"label", Parameters{"foo": Identifier("bar"), "n": int64(42)}}, ""},
+		{"label;n=123;", nil, ""},
+		{"label ; n=123 ; m=42", &ParameterisedIdentifier{"label", Parameters{"n": int64(123), "m": int64(42)}}, ""},
+		{"label;n =123", &ParameterisedIdentifier{"label", Parameters{"n": nil}}, "=123"},
+		{"label;n= 123", nil, ""},
+	}
+	for _, c := range cases {
+		p := &parser{c.input}
+		r, err := p.parseParameterisedIdentifier()
+		if c.expected != nil {
+			if err != nil {
+				t.Errorf("parseParameterisedIdentifier(%q) unexpectedly failed: %v", c.input, err)
+			}
+			if !reflect.DeepEqual(r, c.expected) {
+				t.Errorf("parseParameterisedIdentifier(%q): got %v, want %v", c.input, r, c.expected)
+			}
+			if p.input != c.rest {
+				t.Errorf("parseParameterisedIdentifier(%q): remaining input was %q, should be %q", c.input, p.input, c.rest)
+			}
+		} else if err == nil {
+			t.Errorf("parseParameterisedIdentifier(%q) did not fail", c.input)
+		}
+	}
+}
+
+func TestParseParameterisedList(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected ParameterisedList
+	}{
+		{"", nil},
+		{"item1;n=123", ParameterisedList{&ParameterisedIdentifier{"item1", Parameters{"n": int64(123)}}}},
+		{"item1;n=123,", nil},
+		{",item1;n=123", nil},
+		{"item1;n=123,item2,item3;n=456", ParameterisedList{
+			&ParameterisedIdentifier{"item1", Parameters{"n": int64(123)}},
+			&ParameterisedIdentifier{"item2", Parameters{}},
+			&ParameterisedIdentifier{"item3", Parameters{"n": int64(456)}}}},
+		{" \t item1 , item2;n=123 ", ParameterisedList{
+			&ParameterisedIdentifier{"item1", Parameters{}},
+			&ParameterisedIdentifier{"item2", Parameters{"n": int64(123)}}}},
+	}
+	for _, c := range cases {
+		r, err := ParseParameterisedList(c.input)
+		if c.expected != nil {
+			if err != nil {
+				t.Errorf("ParseParameterisedList(%q) unexpectedly failed: %v", c.input, err)
+			}
+			if !reflect.DeepEqual(r, c.expected) {
+				t.Errorf("ParseParameterisedList(%q): got %v, want %v", c.input, r, c.expected)
+			}
+		} else if err == nil {
+			t.Errorf("ParseParameterisedList(%q) did not fail", c.input)
+		}
+	}
+}


### PR DESCRIPTION
This is part of #319 and will be used to parse `signature` header.