### PR TITLE
Add signature verifier to signingalgorithm.go

### DIFF
--- a/go/signedexchange/internal/signingalgorithm/signingalgorithm.go
+++ b/go/signedexchange/internal/signingalgorithm/signingalgorithm.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"encoding/asn1"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -20,11 +21,11 @@ type ecdsaSigningAlgorithm struct {
 	rand    io.Reader
 }
 
-func (e *ecdsaSigningAlgorithm) Sign(m []byte) ([]byte, error) {
-	type ecdsaSigValue struct {
-		R, S *big.Int
-	}
+type ecdsaSigValue struct {
+	R, S *big.Int
+}
 
+func (e *ecdsaSigningAlgorithm) Sign(m []byte) ([]byte, error) {
 	hash := e.hash.New()
 	hash.Write(m)
 	r, s, err := ecdsa.Sign(e.rand, e.privKey, hash.Sum(nil))
@@ -46,5 +47,44 @@ func SigningAlgorithmForPrivateKey(pk crypto.PrivateKey, rand io.Reader) (Signin
 			return nil, fmt.Errorf("signedexchange: unknown ECDSA curve: %s", name)
 		}
 	}
-	return nil, fmt.Errorf("signedexchange: unknown public key type: %T", pk)
+	return nil, fmt.Errorf("signedexchange: unknown private key type: %T", pk)
+}
+
+type Verifier interface {
+	Verify(msg, sig []byte) (bool, error)
+}
+
+type ecdsaVerifier struct {
+	pubKey *ecdsa.PublicKey
+	hash   crypto.Hash
+}
+
+func (e *ecdsaVerifier) Verify(msg, sig []byte) (bool, error) {
+	var v ecdsaSigValue
+	rest, err := asn1.Unmarshal(sig, &v)
+	if err != nil {
+		return false, fmt.Errorf("failed to ASN.1 decode the signature: %v", err)
+	}
+	if len(rest) > 0 {
+		return false, errors.New("extra data at the signature end")
+	}
+
+	hash := e.hash.New()
+	hash.Write(msg)
+	return ecdsa.Verify(e.pubKey, hash.Sum(nil), v.R, v.S), nil
+}
+
+func VerifierForPublicKey(k crypto.PublicKey) (Verifier, error) {
+	switch k := k.(type) {
+	case *ecdsa.PublicKey:
+		switch name := k.Params().Name; name {
+		case elliptic.P256().Params().Name:
+			return &ecdsaVerifier{k, crypto.SHA256}, nil
+		case elliptic.P384().Params().Name:
+			return &ecdsaVerifier{k, crypto.SHA384}, nil
+		default:
+			return nil, fmt.Errorf("unknown ECDSA curve: %s", name)
+		}
+	}
+	return nil, fmt.Errorf("unknown public key type: %T", k)
 }

--- a/go/signedexchange/internal/signingalgorithm/signingalgorithm.go
+++ b/go/signedexchange/internal/signingalgorithm/signingalgorithm.go
@@ -23,6 +23,7 @@ type ecdsaSigningAlgorithm struct {
 	rand    io.Reader
 }
 
+// Ecdsa-Sig-Value structure in Section 2.2.3 of RFC 3279.
 type ecdsaSigValue struct {
 	R, S *big.Int
 }
@@ -46,10 +47,10 @@ func SigningAlgorithmForPrivateKey(pk crypto.PrivateKey, rand io.Reader) (Signin
 		case elliptic.P384().Params().Name:
 			return &ecdsaSigningAlgorithm{pk, crypto.SHA384, rand}, nil
 		default:
-			return nil, fmt.Errorf("signedexchange: unknown ECDSA curve: %s", name)
+			return nil, fmt.Errorf("signingalgorithm: unknown ECDSA curve: %s", name)
 		}
 	}
-	return nil, fmt.Errorf("signedexchange: unknown private key type: %T", pk)
+	return nil, fmt.Errorf("signingalgorithm: unknown private key type: %T", pk)
 }
 
 type Verifier interface {
@@ -65,10 +66,10 @@ func (e *ecdsaVerifier) Verify(msg, sig []byte) (bool, error) {
 	var v ecdsaSigValue
 	rest, err := asn1.Unmarshal(sig, &v)
 	if err != nil {
-		return false, fmt.Errorf("failed to ASN.1 decode the signature: %v", err)
+		return false, fmt.Errorf("signingalgorithm: failed to ASN.1 decode the signature: %v", err)
 	}
 	if len(rest) > 0 {
-		return false, errors.New("extra data at the signature end")
+		return false, errors.New("signingalgorithm: extra data at the signature end")
 	}
 
 	hash := e.hash.New()
@@ -85,8 +86,8 @@ func VerifierForPublicKey(k crypto.PublicKey) (Verifier, error) {
 		case elliptic.P384().Params().Name:
 			return &ecdsaVerifier{k, crypto.SHA384}, nil
 		default:
-			return nil, fmt.Errorf("unknown ECDSA curve: %s", name)
+			return nil, fmt.Errorf("signingalgorithm: unknown ECDSA curve: %s", name)
 		}
 	}
-	return nil, fmt.Errorf("unknown public key type: %T", k)
+	return nil, fmt.Errorf("signingalgorithm: unknown public key type: %T", k)
 }

--- a/go/signedexchange/internal/signingalgorithm/signingalgorithm.go
+++ b/go/signedexchange/internal/signingalgorithm/signingalgorithm.go
@@ -4,6 +4,8 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	_ "crypto/sha256"
+	_ "crypto/sha512"
 	"encoding/asn1"
 	"errors"
 	"fmt"

--- a/go/signedexchange/internal/signingalgorithm/signingalgorithm_test.go
+++ b/go/signedexchange/internal/signingalgorithm/signingalgorithm_test.go
@@ -1,4 +1,4 @@
-package signedexchange_test
+package signingalgorithm_test
 
 import (
 	"crypto/rand"
@@ -6,7 +6,7 @@ import (
 	"crypto/elliptic"
 	"testing"
 
-	"github.com/WICG/webpackage/go/signedexchange/internal/signingalgorithm"
+	. "github.com/WICG/webpackage/go/signedexchange/internal/signingalgorithm"
 )
 
 func TestSignVerify_ECDSA_P256_SHA256(t *testing.T) {
@@ -16,7 +16,7 @@ func TestSignVerify_ECDSA_P256_SHA256(t *testing.T) {
 		return
 	}
 
-	alg, err := signingalgorithm.SigningAlgorithmForPrivateKey(pk, rand.Reader)
+	alg, err := SigningAlgorithmForPrivateKey(pk, rand.Reader)
 	if err != nil {
 		t.Fatalf("Failed to pick signing algorithm for ecdsa private key: %v", err)
 		return
@@ -29,7 +29,7 @@ func TestSignVerify_ECDSA_P256_SHA256(t *testing.T) {
 		return
 	}
 
-	verifier, err := signingalgorithm.VerifierForPublicKey(pk.Public())
+	verifier, err := VerifierForPublicKey(pk.Public())
 	if err != nil {
 		t.Fatalf("Failed to pick verifier for ecdsa public key: %v", err)
 		return

--- a/go/signedexchange/signer_test.go
+++ b/go/signedexchange/signer_test.go
@@ -4,9 +4,6 @@ import (
 	"crypto/rand"
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	"crypto/sha256"
-	"encoding/asn1"
-	"math/big"
 	"testing"
 
 	"github.com/WICG/webpackage/go/signedexchange/internal/signingalgorithm"
@@ -15,31 +12,43 @@ import (
 func TestSignVerify_ECDSA_P256_SHA256(t *testing.T) {
 	pk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		t.Errorf("Failed to generate ecdsa private key: %v", err)
+		t.Fatalf("Failed to generate ecdsa private key: %v", err)
 		return
 	}
 
 	alg, err := signingalgorithm.SigningAlgorithmForPrivateKey(pk, rand.Reader)
 	if err != nil {
-		t.Errorf("Failed to pick signing algorithm for ecdsa private key: %v", err)
+		t.Fatalf("Failed to pick signing algorithm for ecdsa private key: %v", err)
 		return
 	}
 
 	msg := []byte("foobar")
 	sig, err := alg.Sign(msg)
 	if err != nil {
-		t.Errorf("Failed to sign: %v", err)
+		t.Fatalf("Failed to sign: %v", err)
 		return
 	}
 
-	var v struct {R, S *big.Int}
-	if _, err := asn1.Unmarshal(sig, &v); err != nil {
-		t.Errorf("asn1.Unmarshal failed: %v", err)
+	verifier, err := signingalgorithm.VerifierForPublicKey(pk.Public())
+	if err != nil {
+		t.Fatalf("Failed to pick verifier for ecdsa public key: %v", err)
+		return
 	}
 
-	hashed := sha256.Sum256(msg)
-	if !ecdsa.Verify(&pk.PublicKey, hashed[:], v.R, v.S) {
-		t.Errorf("Failed to verify")
-		return
+	ok, err := verifier.Verify(msg, sig)
+	if err != nil {
+		t.Errorf("Verification failed: %v", err)
+	}
+	if !ok {
+		t.Error("Unexpected verification failure")
+	}
+
+	msg[0] = 'q'
+	ok, err = verifier.Verify(msg, sig)
+	if err != nil {
+		t.Errorf("Verification failed: %v", err)
+	}
+	if ok {
+		t.Error("Unexpected verification success")
 	}
 }


### PR DESCRIPTION
This also moves signer_test.go to signingalgorithm_test.go, as it only uses `signingalgorithm` package.