### PR TITLE
go/signedexchange: Refactor request method handling

### DIFF
--- a/go/signedexchange/cmd/gen-signedexchange/main.go
+++ b/go/signedexchange/cmd/gen-signedexchange/main.go
@@ -156,7 +156,7 @@ func run() error {
 	if resHeader.Get("content-type") == "" {
 		resHeader.Add("content-type", "text/html; charset=utf-8")
 	}
-	e, err := signedexchange.NewExchange(ver, parsedUrl, reqHeader, *flagResponseStatus, resHeader, payload)
+	e, err := signedexchange.NewExchange(ver, parsedUrl, "GET", reqHeader, *flagResponseStatus, resHeader, payload)
 	if err != nil {
 		return err
 	}

--- a/go/signedexchange/cmd/gen-signedexchange/main.go
+++ b/go/signedexchange/cmd/gen-signedexchange/main.go
@@ -30,6 +30,7 @@ func (h *headerArgs) Set(value string) error {
 }
 
 var (
+	flagMethod         = flag.String("method", http.MethodGet, "Request method")
 	flagUri            = flag.String("uri", "https://example.com/index.html", "The URI of the resource represented in the exchange")
 	flagVersion        = flag.String("version", "1b2", "The signedexchange version")
 	flagResponseStatus = flag.Int("status", 200, "The status of the response represented in the exchange")
@@ -156,7 +157,7 @@ func run() error {
 	if resHeader.Get("content-type") == "" {
 		resHeader.Add("content-type", "text/html; charset=utf-8")
 	}
-	e, err := signedexchange.NewExchange(ver, parsedUrl, http.MethodGet, reqHeader, *flagResponseStatus, resHeader, payload)
+	e, err := signedexchange.NewExchange(ver, parsedUrl, *flagMethod, reqHeader, *flagResponseStatus, resHeader, payload)
 	if err != nil {
 		return err
 	}

--- a/go/signedexchange/cmd/gen-signedexchange/main.go
+++ b/go/signedexchange/cmd/gen-signedexchange/main.go
@@ -156,7 +156,7 @@ func run() error {
 	if resHeader.Get("content-type") == "" {
 		resHeader.Add("content-type", "text/html; charset=utf-8")
 	}
-	e, err := signedexchange.NewExchange(ver, parsedUrl, "GET", reqHeader, *flagResponseStatus, resHeader, payload)
+	e, err := signedexchange.NewExchange(ver, parsedUrl, http.MethodGet, reqHeader, *flagResponseStatus, resHeader, payload)
 	if err != nil {
 		return err
 	}

--- a/go/signedexchange/signedexchange.go
+++ b/go/signedexchange/signedexchange.go
@@ -197,15 +197,15 @@ func (e *Exchange) encodeResponseMap(enc *cbor.Encoder) error {
 	return enc.EncodeMap(mes)
 }
 
-func encodeHeaders(encoder []*cbor.MapEntryEncoder, headers http.Header) []*cbor.MapEntryEncoder {
+func encodeHeaders(encs []*cbor.MapEntryEncoder, headers http.Header) []*cbor.MapEntryEncoder {
 	for name, value := range headers {
-		encoder = append(encoder,
+		encs = append(encs,
 			cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
 				keyE.EncodeByteString([]byte(strings.ToLower(name)))
 				valueE.EncodeByteString([]byte(normalizeHeaderValues(value)))
 			}))
 	}
-	return encoder
+	return encs
 }
 
 func (e *Exchange) decodeResponseMap(dec *cbor.Decoder) error {

--- a/go/signedexchange/signedexchange.go
+++ b/go/signedexchange/signedexchange.go
@@ -57,7 +57,7 @@ func NewExchange(ver version.Version, uri *url.URL, method string, requestHeader
 	if uri.Scheme != "https" {
 		return nil, fmt.Errorf("signedexchange: The request with non-https scheme %q URI can't be captured inside signed exchange.", uri.Scheme)
 	}
-	if method != "GET" && method != "HEAD" {
+	if method != http.MethodGet && method != http.MethodHead {
 		return nil, fmt.Errorf("signedexchange: invalid method %q", method)
 	}
 	for name := range requestHeaders {

--- a/go/signedexchange/signedexchange.go
+++ b/go/signedexchange/signedexchange.go
@@ -497,6 +497,7 @@ func (e *Exchange) DumpSignedMessage(w io.Writer, s *Signer) error {
 func (e *Exchange) PrettyPrintHeaders(w io.Writer) {
 	fmt.Fprintf(w, "format version: %s\n", e.Version)
 	fmt.Fprintln(w, "request:")
+	fmt.Fprintf(w, "  method: %s\n", e.RequestMethod)
 	fmt.Fprintf(w, "  uri: %s\n", e.RequestURI.String())
 	fmt.Fprintln(w, "  headers:")
 	for k := range e.RequestHeaders {

--- a/go/signedexchange/signedexchange_test.go
+++ b/go/signedexchange/signedexchange_test.go
@@ -75,7 +75,7 @@ func TestSignedExchange(t *testing.T) {
 	respHeader.Add("Foo", "Baz")
 
 	const ver = version.Version1b1
-	e, err := NewExchange(ver, u, "GET", reqHeader, 200, respHeader, []byte(payload))
+	e, err := NewExchange(ver, u, http.MethodGet, reqHeader, 200, respHeader, []byte(payload))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,7 +176,7 @@ func TestSignedExchangeStatefulHeader(t *testing.T) {
 	header.Add("Set-Cookie", "wow, such cookie")
 
 	const ver = version.Version1b1
-	if _, err := NewExchange(ver, u, "GET", nil, 200, header, []byte(payload)); err == nil {
+	if _, err := NewExchange(ver, u, http.MethodGet, nil, 200, header, []byte(payload)); err == nil {
 		t.Errorf("stateful header unexpectedly allowed in an exchange")
 	}
 
@@ -186,7 +186,7 @@ func TestSignedExchangeStatefulHeader(t *testing.T) {
 	header.Add("cOnTent-TyPe", "text/html; charset=utf-8")
 	header.Add("setProfile", "profile X")
 
-	if _, err := NewExchange(ver, u, "GET", nil, 200, header, []byte(payload)); err == nil {
+	if _, err := NewExchange(ver, u, http.MethodGet, nil, 200, header, []byte(payload)); err == nil {
 		t.Errorf("stateful header unexpectedly allowed in an exchange")
 	}
 }
@@ -194,7 +194,7 @@ func TestSignedExchangeStatefulHeader(t *testing.T) {
 func TestSignedExchangeNonHttps(t *testing.T) {
 	u, _ := url.Parse("http://example.com/")
 	const ver = version.Version1b1
-	if _, err := NewExchange(ver, u, "GET", nil, 200, http.Header{}, []byte(payload)); err == nil {
+	if _, err := NewExchange(ver, u, http.MethodGet, nil, 200, http.Header{}, []byte(payload)); err == nil {
 		t.Errorf("non-https resource URI unexpectedly allowed in an exchange")
 	}
 }
@@ -202,7 +202,7 @@ func TestSignedExchangeNonHttps(t *testing.T) {
 func TestSignedExchangeBannedCertUrlScheme(t *testing.T) {
 	u, _ := url.Parse("https://example.com/")
 	const ver = version.Version1b1
-	e, err := NewExchange(ver, u, "GET", nil, 200, http.Header{}, []byte(payload))
+	e, err := NewExchange(ver, u, http.MethodGet, nil, 200, http.Header{}, []byte(payload))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +235,7 @@ func TestVerify(t *testing.T) {
 	header.Add("Content-Type", "text/html; charset=utf-8")
 
 	const ver = version.Version1b2
-	e, err := NewExchange(ver, u, "GET", nil, 200, header, []byte(payload))
+	e, err := NewExchange(ver, u, http.MethodGet, nil, 200, header, []byte(payload))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/signedexchange/test-signedexchange-expected.txt
+++ b/go/signedexchange/test-signedexchange-expected.txt
@@ -1,1 +1,1 @@
-[map[":method":"GET" ":url":"https://example.com/"] map[":status":"200" "content-encoding":"mi-sha256-draft2" "content-type":"text/html; charset=utf-8" "foo":"Bar,Baz" "mi-draft2":"mi-sha256-draft2=DRyBGPb7CAW2ukzb9sT1S1ialssthiv6QW7Ks-Trg4Y"]]
+[map[":method":"GET" ":url":"https://example.com/" "accept":"*/*"] map[":status":"200" "content-encoding":"mi-sha256-draft2" "content-type":"text/html; charset=utf-8" "foo":"Bar,Baz" "mi-draft2":"mi-sha256-draft2=DRyBGPb7CAW2ukzb9sT1S1ialssthiv6QW7Ks-Trg4Y"]]

--- a/go/signedexchange/verifier.go
+++ b/go/signedexchange/verifier.go
@@ -134,9 +134,8 @@ func (e *Exchange) Verify(verificationTime time.Time, certFetcher CertFetcher, l
 		//         [RFC7231]) or not cacheable (Section 4.2.3 of [RFC7231]),
 		//         return "invalid"."
 		// Per [RFC7231], only GET and HEAD are safe and cacheable.
-		method := e.RequestHeaders.Get(":method")
-		if method != "GET" && method != "HEAD" {
-			l.Printf("Request method %q is not safe or not cacheable.", method)
+		if e.RequestMethod != "GET" && e.RequestMethod != "HEAD" {
+			l.Printf("Request method %q is not safe or not cacheable.", e.RequestMethod)
 			continue
 		}
 

--- a/go/signedexchange/verifier.go
+++ b/go/signedexchange/verifier.go
@@ -134,7 +134,7 @@ func (e *Exchange) Verify(verificationTime time.Time, certFetcher CertFetcher, l
 		//         [RFC7231]) or not cacheable (Section 4.2.3 of [RFC7231]),
 		//         return "invalid"."
 		// Per [RFC7231], only GET and HEAD are safe and cacheable.
-		if e.RequestMethod != "GET" && e.RequestMethod != "HEAD" {
+		if e.RequestMethod != http.MethodGet && e.RequestMethod != http.MethodHead {
 			l.Printf("Request method %q is not safe or not cacheable.", e.RequestMethod)
 			continue
 		}


### PR DESCRIPTION
- Add `RequestMethod` field to the `Exchange` struct
- `NewExchange()` takes `method` as a parameter
- Fix a bug that request headers were not encoded
- Function Renamings
  - {encode,decode}Request -> {encode,decode}RequestMap
  - {encode,decode}ResponseHeaders -> {encode,decode}ResponseMap