### PR TITLE
Strictly UTF-8 decode the fallback URL

### DIFF
--- a/loading.bs
+++ b/loading.bs
@@ -414,6 +414,9 @@ the result of the following steps:
 1. Let |fallbackUrlBytes| be the result of [=read buffer/reading=]
     |fallbackUrlLength| bytes from |stream|.
 1. If |fallbackUrlBytes| is a failure, return it.
+1. Let |fallbackUrl| be the result of [=UTF-8 decode without BOM or fail=] on
+    |fallbackUrlBytes|.
+1. If |fallbackUrl| is a failure, return it.
 1. If the result of running the [=URL parser=] on |fallbackUrl| is a failure, if
     it has a non-null [=url/fragment=], or if its [=url/scheme=] is something
     other than `"https"`, return a failure.


### PR DESCRIPTION
Bikeshed warned that I'd never defined |fallbackUrl|, but I missed it
before going on parental leave. Do y'all see any problems with picking this conversion from bytes to a string?

@irori, we ought to test this with a couple bad fallback URLs, say one starting with a BOM, and one with an invalid sequence that the UTF-8 decoder might convert to U+FFFD. Would you be willing to add those tests?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/webpackage/pull/346.html" title="Last updated on Dec 1, 2018, 12:31 AM GMT (121ecb1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webpackage/346/2eddf31...jyasskin:121ecb1.html" title="Last updated on Dec 1, 2018, 12:31 AM GMT (121ecb1)">Diff</a>