### PR TITLE
gen-signedexchange: Add -nocheck flag

### DIFF
--- a/go/signedexchange/cmd/gen-signedexchange/main.go
+++ b/go/signedexchange/cmd/gen-signedexchange/main.go
@@ -47,7 +47,7 @@ var (
 	flagDumpHeadersCbor      = flag.String("dumpHeadersCbor", "", "Dump metadata and headers encoded as a canonical CBOR to a file for debugging.")
 	flagOutput               = flag.String("o", "out.sxg", "Signed exchange output file. If value is '-', sxg is written to stdout.")
 
-	flagSkipCheck = flag.Bool("skipcheck", false, "Do not reject invalid input arguments")
+	flagIgnoreErrors = flag.Bool("ignoreErrors", false, "Do not reject invalid input arguments")
 
 	flagRequestHeader  = headerArgs{}
 	flagResponseHeader = headerArgs{}
@@ -156,7 +156,7 @@ func run() error {
 	}
 
 	var e *signedexchange.Exchange
-	if *flagSkipCheck {
+	if *flagIgnoreErrors {
 		e = signedexchange.NewExchangeNoCheck(ver, *flagUri, *flagMethod, reqHeader, *flagResponseStatus, resHeader, payload)
 	} else {
 		parsedUrl, err := url.Parse(*flagUri)

--- a/go/signedexchange/cmd/gen-signedexchange/main.go
+++ b/go/signedexchange/cmd/gen-signedexchange/main.go
@@ -47,7 +47,7 @@ var (
 	flagDumpHeadersCbor      = flag.String("dumpHeadersCbor", "", "Dump metadata and headers encoded as a canonical CBOR to a file for debugging.")
 	flagOutput               = flag.String("o", "out.sxg", "Signed exchange output file. If value is '-', sxg is written to stdout.")
 
-	flagNoCheck = flag.Bool("nocheck", false, "Do not reject invalid input arguments")
+	flagSkipCheck = flag.Bool("skipcheck", false, "Do not reject invalid input arguments")
 
 	flagRequestHeader  = headerArgs{}
 	flagResponseHeader = headerArgs{}
@@ -156,7 +156,7 @@ func run() error {
 	}
 
 	var e *signedexchange.Exchange
-	if *flagNoCheck {
+	if *flagSkipCheck {
 		e = signedexchange.NewExchangeNoCheck(ver, *flagUri, *flagMethod, reqHeader, *flagResponseStatus, resHeader, payload)
 	} else {
 		parsedUrl, err := url.Parse(*flagUri)

--- a/go/signedexchange/cmd/gen-signedexchange/main.go
+++ b/go/signedexchange/cmd/gen-signedexchange/main.go
@@ -47,6 +47,8 @@ var (
 	flagDumpHeadersCbor      = flag.String("dumpHeadersCbor", "", "Dump metadata and headers encoded as a canonical CBOR to a file for debugging.")
 	flagOutput               = flag.String("o", "out.sxg", "Signed exchange output file. If value is '-', sxg is written to stdout.")
 
+	flagNoCheck = flag.Bool("nocheck", false, "Do not reject invalid input arguments")
+
 	flagRequestHeader  = headerArgs{}
 	flagResponseHeader = headerArgs{}
 )
@@ -138,11 +140,6 @@ func run() error {
 		defer f.Close()
 	}
 
-	parsedUrl, err := url.Parse(*flagUri)
-	if err != nil {
-		return fmt.Errorf("failed to parse URL %q. err: %v", *flagUri, err)
-	}
-
 	reqHeader := http.Header{}
 	for _, h := range flagRequestHeader {
 		chunks := strings.SplitN(h, ":", 2)
@@ -157,9 +154,19 @@ func run() error {
 	if resHeader.Get("content-type") == "" {
 		resHeader.Add("content-type", "text/html; charset=utf-8")
 	}
-	e, err := signedexchange.NewExchange(ver, parsedUrl, *flagMethod, reqHeader, *flagResponseStatus, resHeader, payload)
-	if err != nil {
-		return err
+
+	var e *signedexchange.Exchange
+	if *flagNoCheck {
+		e = signedexchange.NewExchangeNoCheck(ver, *flagUri, *flagMethod, reqHeader, *flagResponseStatus, resHeader, payload)
+	} else {
+		parsedUrl, err := url.Parse(*flagUri)
+		if err != nil {
+			return fmt.Errorf("failed to parse URL %q. err: %v", *flagUri, err)
+		}
+		e, err = signedexchange.NewExchange(ver, parsedUrl, *flagMethod, reqHeader, *flagResponseStatus, resHeader, payload)
+		if err != nil {
+			return err
+		}
 	}
 	if err := e.MiEncodePayload(*flagMIRecordSize); err != nil {
 		return err

--- a/go/signedexchange/signedexchange_test.go
+++ b/go/signedexchange/signedexchange_test.go
@@ -390,3 +390,18 @@ func TestVerifyBadSignature(t *testing.T) {
 		t.Errorf("Verification should fail")
 	}
 }
+
+func TestVerifyNonCanonicalURL(t *testing.T) {
+	e, s, c := createTestExchange(t)
+	// url.Parse() decodes "%73%78%67" to "sxg"
+	e.RequestURI = "https://example.com/%73%78%67"
+	if err := e.AddSignatureHeader(s); err != nil {
+		t.Fatal(err)
+	}
+	certFetcher := func(_ string) ([]byte, error) { return c, nil }
+
+	verificationTime := signatureDate
+	if !e.Verify(verificationTime, certFetcher, log.New(os.Stdout, "ERROR: ", 0)) {
+		t.Errorf("Verification failed")
+	}
+}

--- a/go/signedexchange/signer.go
+++ b/go/signedexchange/signer.go
@@ -156,7 +156,7 @@ func serializeSignedMessage(e *Exchange, certSha256 []byte, validityUrl string, 
 		buf.Write(expiresBytes)
 
 		// "8. The 8-byte big-endian encoding of the length in bytes of requestUrl, followed by the bytes of requestUrl." [spec text]
-		rurl := []byte(e.RequestURI.String())
+		rurl := []byte(e.RequestURI)
 		rurlLenBytes, _ := bigendian.EncodeBytesUint(int64(len(rurl)), 8)
 		buf.Write(rurlLenBytes)
 		buf.Write(rurl)

--- a/go/signedexchange/verifier.go
+++ b/go/signedexchange/verifier.go
@@ -111,7 +111,12 @@ func (e *Exchange) Verify(verificationTime time.Time, certFetcher CertFetcher, l
 			l.Printf("Cannot parse validity-url: %q", signature.ValidityUrl)
 			continue
 		}
-		if !isSameOrigin(validityUrl, e.RequestURI) {
+		requestURI, err := url.Parse(e.RequestURI)
+		if err != nil {
+			l.Printf("Cannot parse request URI: %q", e.RequestURI)
+			continue
+		}
+		if !isSameOrigin(validityUrl, requestURI) {
 			l.Printf("validity-url (%s) is not same-origin with request URL (%v)", signature.ValidityUrl, e.RequestURI)
 			continue
 		}


### PR DESCRIPTION
This flag lets gen-signedexchange skip some input validations. This is needed to create SXGs for web-platform-tests.

This also fixes a bug that Exchange.Verify() fails when `url.Parse(fallbackUrl).String() != fallbackUrl`. (Note: current Chromium impl has the same bug, see https://crbug.com/914247)