### PR TITLE
go: Initial b3 support

### DIFF
--- a/go/signedexchange/signer.go
+++ b/go/signedexchange/signer.go
@@ -26,6 +26,8 @@ func contextString(v version.Version) string {
 		return "HTTP Exchange 1 b1"
 	case version.Version1b2:
 		return "HTTP Exchange 1 b2"
+	case version.Version1b3:
+		return "HTTP Exchange 1 b3"
 	default:
 		panic("not reached")
 	}
@@ -117,7 +119,7 @@ func serializeSignedMessage(e *Exchange, certSha256 []byte, validityUrl string, 
 		}
 		return buf.Bytes(), nil
 
-	case version.Version1b2:
+	case version.Version1b2, version.Version1b3:
 		// draft-yasskin-http-origin-signed-responses.html#signature-validity
 
 		// "Let message be the concatenation of the following byte strings. This matches the [I-D.ietf-tls-tls13] format to avoid cross-protocol attacks if anyone uses the same key in a TLS certificate and an exchange-signing certificate." [spec text]
@@ -213,7 +215,7 @@ func (s *Signer) signatureHeaderValue(e *Exchange) (string, error) {
 	switch e.Version {
 	case version.Version1b1:
 		integrityStr = "mi-draft2"
-	case version.Version1b2:
+	case version.Version1b2, version.Version1b3:
 		integrityStr = "digest/mi-sha256-03"
 	default:
 		panic("not reached")

--- a/go/signedexchange/version/version.go
+++ b/go/signedexchange/version/version.go
@@ -1,11 +1,19 @@
 package version
 
+import (
+	"bytes"
+	"fmt"
+)
+
 type Version string
 
 const (
 	Version1b1 Version = "1b1"
 	Version1b2 Version = "1b2"
+	Version1b3 Version = "1b3"
 )
+
+const HeaderMagicBytesLen = 8
 
 func Parse(str string) (Version, bool) {
 	switch Version(str) {
@@ -13,6 +21,33 @@ func Parse(str string) (Version, bool) {
 		return Version1b1, true
 	case Version1b2:
 		return Version1b2, true
+	case Version1b3:
+		return Version1b3, true
 	}
 	return "", false
+}
+
+func (v Version) HeaderMagicBytes() []byte {
+	switch v {
+	case Version1b1:
+		return []byte("sxg1-b1\x00")
+	case Version1b2:
+		return []byte("sxg1-b2\x00")
+	case Version1b3:
+		return []byte("sxg1-b3\x00")
+	default:
+		panic("not reached")
+	}
+}
+
+func FromMagicBytes(bs []byte) (Version, error) {
+	if bytes.Equal(bs, Version1b1.HeaderMagicBytes()) {
+		return Version1b1, nil
+	} else if bytes.Equal(bs, Version1b2.HeaderMagicBytes()) {
+		return Version1b2, nil
+	} else if bytes.Equal(bs, Version1b3.HeaderMagicBytes()) {
+		return Version1b3, nil
+	} else {
+		return Version(""), fmt.Errorf("singedexchange: unknown magic bytes: %v", bs)
+	}
 }


### PR DESCRIPTION
Start adding support for #350

The output is identical to `b2` but the magic bytes for now.