### PR TITLE
go/signedexchange: Rework TestSignedExchange

### DIFF
--- a/go/signedexchange/test-signedexchange-expected.txt
+++ b/go/signedexchange/test-signedexchange-expected.txt
@@ -1,1 +1,0 @@
-[map[":method":"GET" ":url":"https://example.com/" "accept":"*/*"] map[":status":"200" "content-encoding":"mi-sha256-draft2" "content-type":"text/html; charset=utf-8" "foo":"Bar,Baz" "mi-draft2":"mi-sha256-draft2=DRyBGPb7CAW2ukzb9sT1S1ialssthiv6QW7Ks-Trg4Y"]]

--- a/go/signedexchange/version/version.go
+++ b/go/signedexchange/version/version.go
@@ -15,6 +15,12 @@ const (
 
 const HeaderMagicBytesLen = 8
 
+var AllVersions = []Version {
+	Version1b1,
+	Version1b2,
+	Version1b3,
+}
+
 func Parse(str string) (Version, bool) {
 	switch Version(str) {
 	case Version1b1:


### PR DESCRIPTION
This is the most basic test case, but before this patch it only covered
the b1 format. Also, we did not have any tests for `ReadExchange()`.

After this patch, it tests all the supported format versions, by using
`ReadExchange()` to deserialize exchanges.