### PR TITLE
go/signedexchange: Run signedexchange tests against all supported versions

### DIFF
--- a/go/signedexchange/verifier.go
+++ b/go/signedexchange/verifier.go
@@ -238,7 +238,7 @@ func verifyPayload(e *Exchange, signature *Signature) ([]byte, error) {
 	case version.Version1b1:
 		enc = mice.Draft02Encoding
 		integrityStr = "mi-draft2"
-	case version.Version1b2:
+	case version.Version1b2, version.Version1b3:
 		enc = mice.Draft03Encoding
 		integrityStr = "digest/" + enc.ContentEncoding()
 	default:


### PR DESCRIPTION
This patch turns all existing tests in signedexchange_test.go
into grouped tests parameterized by format version.