### PR TITLE
go: [b3] omit request map

### DIFF
--- a/go/signedexchange/signedexchange.go
+++ b/go/signedexchange/signedexchange.go
@@ -3,7 +3,6 @@ package signedexchange
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -117,8 +116,8 @@ func (e *Exchange) AddSignatureHeader(s *Signer) error {
 }
 
 func (e *Exchange) encodeRequestMap(enc *cbor.Encoder) error {
-	if e.Version == version.Version1b3 {
-		return errors.New("signedexchange: b3 doesn't have request map.")
+	if e.Version != version.Version1b1 && e.Version != version.Version1b2 {
+		panic("signedexchange: b3 and beyond don't have request map.")
 	}
 
 	mes := []*cbor.MapEntryEncoder{
@@ -271,6 +270,8 @@ func (e *Exchange) decodeExchangeHeaders(dec *cbor.Decoder) error {
 		if err := e.decodeRequestMap(dec); err != nil {
 			return err
 		}
+	} else {
+		e.RequestMethod = http.MethodGet
 	}
 	if err := e.decodeResponseMap(dec); err != nil {
 		return err

--- a/go/signedexchange/signedexchange.go
+++ b/go/signedexchange/signedexchange.go
@@ -3,6 +3,7 @@ package signedexchange
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -116,6 +117,10 @@ func (e *Exchange) AddSignatureHeader(s *Signer) error {
 }
 
 func (e *Exchange) encodeRequestMap(enc *cbor.Encoder) error {
+	if e.Version == version.Version1b3 {
+		return errors.New("signedexchange: b3 doesn't have request map.")
+	}
+
 	mes := []*cbor.MapEntryEncoder{
 		cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
 			keyE.EncodeByteString(keyMethod)
@@ -235,11 +240,13 @@ func (e *Exchange) decodeResponseMap(dec *cbor.Decoder) error {
 
 // draft-yasskin-http-origin-signed-responses.html#rfc.section.3.4
 func (e *Exchange) encodeExchangeHeaders(enc *cbor.Encoder) error {
-	if err := enc.EncodeArrayHeader(2); err != nil {
-		return fmt.Errorf("signedexchange: failed to encode top-level array header: %v", err)
-	}
-	if err := e.encodeRequestMap(enc); err != nil {
-		return err
+	if e.Version == version.Version1b1 || e.Version == version.Version1b2 {
+		if err := enc.EncodeArrayHeader(2); err != nil {
+			return fmt.Errorf("signedexchange: failed to encode top-level array header: %v", err)
+		}
+		if err := e.encodeRequestMap(enc); err != nil {
+			return err
+		}
 	}
 	if err := e.encodeResponseMap(enc); err != nil {
 		return err
@@ -253,15 +260,17 @@ func (e *Exchange) DumpExchangeHeaders(w io.Writer) error {
 }
 
 func (e *Exchange) decodeExchangeHeaders(dec *cbor.Decoder) error {
-	n, err := dec.DecodeArrayHeader()
-	if err != nil {
-		return fmt.Errorf("signedexchange: failed to decode top-level array header: %v", err)
-	}
-	if n != 2 {
-		return fmt.Errorf("singedexchange: length of header array must be 2 but %d", n)
-	}
-	if err := e.decodeRequestMap(dec); err != nil {
-		return err
+	if e.Version == version.Version1b1 || e.Version == version.Version1b2 {
+		n, err := dec.DecodeArrayHeader()
+		if err != nil {
+			return fmt.Errorf("signedexchange: failed to decode top-level array header: %v", err)
+		}
+		if n != 2 {
+			return fmt.Errorf("singedexchange: length of header array must be 2 but %d", n)
+		}
+		if err := e.decodeRequestMap(dec); err != nil {
+			return err
+		}
 	}
 	if err := e.decodeResponseMap(dec); err != nil {
 		return err
@@ -270,8 +279,8 @@ func (e *Exchange) decodeExchangeHeaders(dec *cbor.Decoder) error {
 }
 
 func (e *Exchange) Write(w io.Writer) error {
-	headerBuf := &bytes.Buffer{}
-	if err := e.DumpExchangeHeaders(headerBuf); err != nil {
+	var headerBuf bytes.Buffer
+	if err := e.DumpExchangeHeaders(&headerBuf); err != nil {
 		return err
 	}
 	headerLength := headerBuf.Len()
@@ -310,7 +319,7 @@ func (e *Exchange) Write(w io.Writer) error {
 		}
 
 		// Step 5. "headerLength bytes holding the signed headers, the canonical serialization (Section 3.4) of the CBOR representation of the request and response headers of the exchange represented by the application/signed-exchange resource (Section 3.2), excluding the Signature header field." [spec text]
-		if _, err := io.Copy(w, headerBuf); err != nil {
+		if _, err := io.Copy(w, &headerBuf); err != nil {
 			return err
 		}
 
@@ -378,7 +387,7 @@ func (e *Exchange) Write(w io.Writer) error {
 		}
 
 		// "7. headerLength bytes holding signedHeaders, the canonical serialization (Section 3.4) of the CBOR representation of the request and response headers of the exchange represented by the application/signed-exchange resource (Section 3.2), excluding the Signature header field." [spec text]
-		if _, err := io.Copy(w, headerBuf); err != nil {
+		if _, err := io.Copy(w, &headerBuf); err != nil {
 			return err
 		}
 

--- a/go/signedexchange/signedexchange_test.go
+++ b/go/signedexchange/signedexchange_test.go
@@ -97,7 +97,7 @@ func TestSignedExchange(t *testing.T) {
 	expectedSignatureHeader := map[version.Version]string{
 		version.Version1b1: "label; sig=*MEYCIQCbay5VbkR9mi4pnwDAJamuf7Fj1CWnEnJt6Uxm7YeqiwIhAL8JISyzF5sDhtUaEbNCE6vgv2NIKCkONzLgwL23UL6P*; validity-url=\"https://example.com/resource.validity\"; integrity=\"mi-draft2\"; cert-url=\"https://example.com/cert.msg\"; cert-sha256=*eLWHusI0YcDcHSG5nkYbyZddE2sidVyhx6iSYoJ+SFc=*; date=1517418800; expires=1517422400",
 		version.Version1b2: "label; sig=*MEUCIHNiDRQncQpVxW2x+woinMUTY8nuSQfi0mbJ5J6x7FZyAiEAgh6FH6PdncNCK8GHTwN3wfUUUFdjVswNi1PfIgCOwHk=*; validity-url=\"https://example.com/resource.validity\"; integrity=\"digest/mi-sha256-03\"; cert-url=\"https://example.com/cert.msg\"; cert-sha256=*eLWHusI0YcDcHSG5nkYbyZddE2sidVyhx6iSYoJ+SFc=*; date=1517418800; expires=1517422400",
-		version.Version1b3: "label; sig=*MEUCIQC1Tfv5a+tC6aiW8XudbYqsnnOo08c0rhLJENfC41Tz1AIgK1tJAuOgi74JOe7phub3LTxskRtco5SYVG41A/1M/z0=*; validity-url=\"https://example.com/resource.validity\"; integrity=\"digest/mi-sha256-03\"; cert-url=\"https://example.com/cert.msg\"; cert-sha256=*eLWHusI0YcDcHSG5nkYbyZddE2sidVyhx6iSYoJ+SFc=*; date=1517418800; expires=1517422400",
+		version.Version1b3: "label; sig=*MEUCIEQPK0UKPm9/XP5Jko2V72vTrGlBqB9HHoOzhJmVPflmAiEAwCSBw98NhUhFGJaxL6ITT+QZBBeO7TCLAiHn1apY6Es=*; validity-url=\"https://example.com/resource.validity\"; integrity=\"digest/mi-sha256-03\"; cert-url=\"https://example.com/cert.msg\"; cert-sha256=*eLWHusI0YcDcHSG5nkYbyZddE2sidVyhx6iSYoJ+SFc=*; date=1517418800; expires=1517422400",
 	}
 
 	for _, ver := range version.AllVersions {
@@ -153,8 +153,15 @@ func TestSignedExchange(t *testing.T) {
 			t.Errorf("Unexpected request method: %q", got.RequestMethod)
 		}
 
-		if !reflect.DeepEqual(got.RequestHeaders, reqHeader) {
-			t.Errorf("Unexpected request headers: %v", got.RequestHeaders)
+		if ver == version.Version1b1 || ver == version.Version1b2 {
+			if !reflect.DeepEqual(got.RequestHeaders, reqHeader) {
+				t.Errorf("Unexpected request headers: %v", got.RequestHeaders)
+			}
+		} else {
+			emptyHeader := http.Header{}
+			if !reflect.DeepEqual(got.RequestHeaders, emptyHeader) {
+				t.Errorf("Unexpected request headers: %v", got.RequestHeaders)
+			}
 		}
 
 		if got.ResponseStatus != 200 {


### PR DESCRIPTION
This commit updates the CBOR representation of the exchange headers to
only contain response map.