### PR TITLE
Use Fetch's method of extracting a MIME type instead of MIMEsniff.

### DIFF
--- a/loading.bs
+++ b/loading.bs
@@ -420,7 +420,7 @@ result of the following steps:
 
 1. Let |mimeType| be the result of [=header list/extracting a MIME type=] from
     |response|'s [=response/header list=].
-1. If |mimeType| is undefined, return undefined.
+1. If |mimeType| is a failure, return undefined.
 1. If |mimeType|'s [=MIME type/essence=] is not `"application/signed-exchange"`,
     return undefined.
 1. Let |params| be |mimeType|'s [=MIME type/parameters=]

--- a/loading.bs
+++ b/loading.bs
@@ -642,11 +642,11 @@ returns the result of the following steps:
     : [=request/mode=]
     :: "`cors`"
 1. Let |certResponse| be the result of [=fetching=] |certRequest|.
-1. If |certResponse|'s [=response/status=] is not `200`, or [=header
-    list/extracting a MIME type=] from |certResponse|'s [=response/header list=]
-    does not return `"application/cert-chain+cbor"`, return a failure.
-
-    Note: This forbids the MIME type from including parameters.
+1. If |certResponse|'s [=response/status=] is not `200`, return a failure.
+1. Let |certMimeType| be the result of [=header list/extracting a MIME type=]
+    from |certResponse|'s [=response/header list=].
+1. If |certMimeType| is a failure or its [=MIME type/essence=] is not
+    `"application/cert-chain+cbor"`, return a failure.
 1. If |certResponse|'s [=response/body=] is null or that body's [=body/stream=]
     is null, return a failure.
 1. Let |bytes| be the result of [=ReadableStream/read all bytes|reading all

--- a/loading.bs
+++ b/loading.bs
@@ -645,6 +645,8 @@ returns the result of the following steps:
 1. If |certResponse|'s [=response/status=] is not `200`, or [=header
     list/extracting a MIME type=] from |certResponse|'s [=response/header list=]
     does not return `"application/cert-chain+cbor"`, return a failure.
+
+    Note: This forbids the MIME type from including parameters.
 1. If |certResponse|'s [=response/body=] is null or that body's [=body/stream=]
     is null, return a failure.
 1. Let |bytes| be the result of [=ReadableStream/read all bytes|reading all

--- a/loading.bs
+++ b/loading.bs
@@ -418,7 +418,8 @@ An exchange signature is a [=struct=] with the following items:
 The <dfn>signed exchange version</dfn> of a [=response=] |response| is the
 result of the following steps:
 
-1. Let |mimeType| be the [=supplied MIME type=] of |response|.
+1. Let |mimeType| be the result of [=header list/extracting a MIME type=] from
+    |response|'s [=response/header list=].
 1. If |mimeType| is undefined, return undefined.
 1. If |mimeType|'s [=MIME type/essence=] is not `"application/signed-exchange"`,
     return undefined.
@@ -641,9 +642,9 @@ returns the result of the following steps:
     : [=request/mode=]
     :: "`cors`"
 1. Let |certResponse| be the result of [=fetching=] |certRequest|.
-1. If |certResponse|'s [=response/status=] is not `200`, or the [=supplied MIME
-    type=] of |certResponse| is not `"application/cert-chain+cbor"`, return a
-    failure.
+1. If |certResponse|'s [=response/status=] is not `200`, or [=header
+    list/extracting a MIME type=] from |certResponse|'s [=response/header list=]
+    does not return `"application/cert-chain+cbor"`, return a failure.
 1. If |certResponse|'s [=response/body=] is null or that body's [=body/stream=]
     is null, return a failure.
 1. Let |bytes| be the result of [=ReadableStream/read all bytes|reading all


### PR DESCRIPTION
Thanks for the pointer, @annevk.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/webpackage/pull/359.html" title="Last updated on Jan 7, 2019, 9:12 PM UTC (51fc87c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webpackage/359/80005f0...jyasskin:51fc87c.html" title="Last updated on Jan 7, 2019, 9:12 PM UTC (51fc87c)">Diff</a>