### PR TITLE
Restrict the browser's request's method to GET or HEAD.

### DIFF
--- a/loading.bs
+++ b/loading.bs
@@ -858,6 +858,13 @@ To <dfn lt="reading a body|read a body">read a body</dfn> from a [=read buffer=]
 A [=request=] |browserRequest| <dfn>matches the stored request</dfn>
 |storedRequest| if the following steps return "match":
 
+1. If |browserRequest|'s [=request/method=] is not `` `GET` `` or `` `HEAD` ``,
+    return "mismatch".
+
+    Note: The |browserRequest|'s method can be something other than `` `GET` ``
+    if a Service Worker intercepts the redirect and modifies the request before
+    re-fetching it.
+
 1. If |browserRequest|'s [=request/url=] is not [=url/equal=] to
     |storedRequest|'s [=request/url=], return "mismatch".
 


### PR DESCRIPTION
Since this is after a 303 redirect, I think the method can only be something else if a service worker messes with things, but we should prevent service workers from getting us into a weird state.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/webpackage/pull/361.html" title="Last updated on Jan 3, 2019, 9:28 PM UTC (e33e03f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webpackage/361/8f7d57c...jyasskin:e33e03f.html" title="Last updated on Jan 3, 2019, 9:28 PM UTC (e33e03f)">Diff</a>