### PR TITLE
gen-signedexchange: Verify generated exchange

### DIFF
--- a/go/signedexchange/cmd/gen-signedexchange/main.go
+++ b/go/signedexchange/cmd/gen-signedexchange/main.go
@@ -202,7 +202,7 @@ func run() error {
 			return certBuf.Bytes(), nil
 		}
 		var logBuf bytes.Buffer
-		if !e.Verify(date, certFetcher, log.New(&logBuf, "", 0)) {
+		if _, ok := e.Verify(date, certFetcher, log.New(&logBuf, "", 0)); !ok {
 			return fmt.Errorf("failed to verify generated exchange: %s", logBuf.String())
 		}
 	}

--- a/go/signedexchange/cmd/gen-signedexchange/main.go
+++ b/go/signedexchange/cmd/gen-signedexchange/main.go
@@ -186,15 +186,19 @@ func run() error {
 	}
 
 	if !*flagIgnoreErrors {
-		certChain, err := certurl.NewCertChain(certs, []byte("dummy"), nil)
-		if err != nil {
-			return err
-		}
-		var certBuf bytes.Buffer
-		if err := certChain.Write(&certBuf); err != nil {
-			return err
-		}
+		// Check if the generated exchange passes Verify().
+
+		// Create a cert fetcher for Verify() that returns `certs` in
+		// application/cert-chain+cbor format.
 		certFetcher := func(_ string) ([]byte, error) {
+			certChain, err := certurl.NewCertChain(certs, []byte("dummy"), nil)
+			if err != nil {
+				return nil, err
+			}
+			var certBuf bytes.Buffer
+			if err := certChain.Write(&certBuf); err != nil {
+				return nil, err
+			}
 			return certBuf.Bytes(), nil
 		}
 		var logBuf bytes.Buffer

--- a/go/signedexchange/signedexchange.go
+++ b/go/signedexchange/signedexchange.go
@@ -40,36 +40,7 @@ var (
 	keyStatus = []byte(":status")
 )
 
-func NewExchange(ver version.Version, uri *url.URL, method string, requestHeaders http.Header, status int, responseHeaders http.Header, payload []byte) (*Exchange, error) {
-	if uri.Scheme != "https" {
-		return nil, fmt.Errorf("signedexchange: The request with non-https scheme %q URI can't be captured inside signed exchange.", uri.Scheme)
-	}
-	if method != http.MethodGet && method != http.MethodHead {
-		return nil, fmt.Errorf("signedexchange: invalid method %q", method)
-	}
-	for name := range requestHeaders {
-		if IsStatefulRequestHeader(name) {
-			return nil, fmt.Errorf("signedexchange: stateful request header %q can't be captured inside signed exchange", name)
-		}
-	}
-	for name := range responseHeaders {
-		if IsStatefulResponseHeader(name) {
-			return nil, fmt.Errorf("signedexchange: stateful response header %q can't be captured inside signed exchange", name)
-		}
-	}
-
-	return &Exchange{
-		Version:         ver,
-		RequestURI:      uri.String(),
-		RequestMethod:   method,
-		ResponseStatus:  status,
-		RequestHeaders:  requestHeaders,
-		ResponseHeaders: responseHeaders,
-		Payload:         payload,
-	}, nil
-}
-
-func NewExchangeNoCheck(ver version.Version, uri string, method string, requestHeaders http.Header, status int, responseHeaders http.Header, payload []byte) *Exchange {
+func NewExchange(ver version.Version, uri string, method string, requestHeaders http.Header, status int, responseHeaders http.Header, payload []byte) *Exchange {
 	return &Exchange{
 		Version:         ver,
 		RequestURI:      uri,

--- a/go/signedexchange/signedexchange_test.go
+++ b/go/signedexchange/signedexchange_test.go
@@ -121,9 +121,6 @@ func TestSignedExchange(t *testing.T) {
 		respHeader.Add("Foo", "Baz")
 
 		e := NewExchange(ver, requestUrl, http.MethodGet, reqHeader, 200, respHeader, []byte(payload))
-		if err != nil {
-			t.Fatal(err)
-		}
 		if err := e.MiEncodePayload(16); err != nil {
 			t.Fatal(err)
 		}

--- a/go/signedexchange/signedexchange_test.go
+++ b/go/signedexchange/signedexchange_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 const (
+	requestUrl = "https://example.com/"
+
 	payload  = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`
 	pemCerts = `-----BEGIN CERTIFICATE-----
 MIIBhjCCAS2gAwIBAgIJAOhR3xtYd5QsMAoGCCqGSM49BAMCMDIxFDASBgNVBAMM
@@ -76,7 +78,6 @@ func TestSignedExchange(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	requestUrl, _ := url.Parse("https://example.com/")
 	certUrl, _ := url.Parse("https://example.com/cert.msg")
 	validityUrl, _ := url.Parse("https://example.com/resource.validity")
 
@@ -116,7 +117,7 @@ func TestSignedExchange(t *testing.T) {
 		respHeader.Add("Foo", "Bar")
 		respHeader.Add("Foo", "Baz")
 
-		e, err := NewExchange(ver, requestUrl, http.MethodGet, reqHeader, 200, respHeader, []byte(payload))
+		e := NewExchange(ver, requestUrl, http.MethodGet, reqHeader, 200, respHeader, []byte(payload))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -151,7 +152,7 @@ func TestSignedExchange(t *testing.T) {
 			t.Errorf("Unexpected version: got %v, want %v", got.Version, ver)
 		}
 
-		if got.RequestURI != requestUrl.String() {
+		if got.RequestURI != requestUrl {
 			t.Errorf("Unexpected request URL: %q", got.RequestURI)
 		}
 
@@ -189,46 +190,9 @@ func TestSignedExchange(t *testing.T) {
 	})
 }
 
-func TestSignedExchangeStatefulHeader(t *testing.T) {
-	testForEachVersion(t, func(ver version.Version, t *testing.T) {
-		u, _ := url.Parse("https://example.com/")
-		header := http.Header{}
-		header.Add("Content-Type", "text/html; charset=utf-8")
-		// Set-Cookie is a stateful header and not available.
-		header.Add("Set-Cookie", "wow, such cookie")
-
-		if _, err := NewExchange(ver, u, http.MethodGet, nil, 200, header, []byte(payload)); err == nil {
-			t.Errorf("stateful header unexpectedly allowed in an exchange")
-		}
-
-		// Header names are case-insensitive.
-		u, _ = url.Parse("https://example.com/")
-		header = http.Header{}
-		header.Add("cOnTent-TyPe", "text/html; charset=utf-8")
-		header.Add("setProfile", "profile X")
-
-		if _, err := NewExchange(ver, u, http.MethodGet, nil, 200, header, []byte(payload)); err == nil {
-			t.Errorf("stateful header unexpectedly allowed in an exchange")
-		}
-	})
-}
-
-func TestSignedExchangeNonHttps(t *testing.T) {
-	testForEachVersion(t, func(ver version.Version, t *testing.T) {
-		u, _ := url.Parse("http://example.com/")
-		if _, err := NewExchange(ver, u, http.MethodGet, nil, 200, http.Header{}, []byte(payload)); err == nil {
-			t.Errorf("non-https resource URI unexpectedly allowed in an exchange")
-		}
-	})
-}
-
 func TestSignedExchangeBannedCertUrlScheme(t *testing.T) {
 	testForEachVersion(t, func(ver version.Version, t *testing.T) {
-		u, _ := url.Parse("https://example.com/")
-		e, err := NewExchange(ver, u, http.MethodGet, nil, 200, http.Header{}, []byte(payload))
-		if err != nil {
-			t.Fatal(err)
-		}
+		e := NewExchange(ver, requestUrl, http.MethodGet, nil, 200, http.Header{}, []byte(payload))
 		if err := e.MiEncodePayload(16); err != nil {
 			t.Fatal(err)
 		}
@@ -254,14 +218,10 @@ func TestSignedExchangeBannedCertUrlScheme(t *testing.T) {
 }
 
 func createTestExchange(ver version.Version, t *testing.T) (e *Exchange, s *Signer, certBytes []byte) {
-	u, _ := url.Parse("https://example.com/")
 	header := http.Header{}
 	header.Add("Content-Type", "text/html; charset=utf-8")
 
-	e, err := NewExchange(ver, u, http.MethodGet, nil, 200, header, []byte(payload))
-	if err != nil {
-		t.Fatal(err)
-	}
+	e = NewExchange(ver, requestUrl, http.MethodGet, nil, 200, header, []byte(payload))
 	if err := e.MiEncodePayload(16); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This patch lets gen-signedexchange validate the generated exchange
using `Verify()`, when `-ignoreErrors` flag is not specified.

Breaking change: Now `signedexchange.NewExchange` takes request URL as a
string (not a `*url.URL`), and does not return an error.