### PR TITLE
go: Verify() shouldn't replace Payload

### DIFF
--- a/go/signedexchange/cmd/dump-signedexchange/main.go
+++ b/go/signedexchange/cmd/dump-signedexchange/main.go
@@ -70,7 +70,8 @@ func verify(e *signedexchange.Exchange) error {
 	}
 
 	verificationTime := time.Now()
-	if e.Verify(verificationTime, certFetcher, log.New(os.Stdout, "", 0)) {
+	if ok, decodedPayload := e.Verify(verificationTime, certFetcher, log.New(os.Stdout, "", 0)); ok {
+		e.Payload = decodedPayload
 		fmt.Println("The exchange has valid signature.")
 	}
 	return nil

--- a/go/signedexchange/cmd/dump-signedexchange/main.go
+++ b/go/signedexchange/cmd/dump-signedexchange/main.go
@@ -70,8 +70,7 @@ func verify(e *signedexchange.Exchange) error {
 	}
 
 	verificationTime := time.Now()
-	decodedPayload := e.Verify(verificationTime, certFetcher, log.New(os.Stdout, "", 0))
-	if decodedPayload != nil {
+	if decodedPayload, ok := e.Verify(verificationTime, certFetcher, log.New(os.Stdout, "", 0)); ok {
 		e.Payload = decodedPayload
 		fmt.Println("The exchange has valid signature.")
 	}

--- a/go/signedexchange/cmd/dump-signedexchange/main.go
+++ b/go/signedexchange/cmd/dump-signedexchange/main.go
@@ -70,7 +70,8 @@ func verify(e *signedexchange.Exchange) error {
 	}
 
 	verificationTime := time.Now()
-	if ok, decodedPayload := e.Verify(verificationTime, certFetcher, log.New(os.Stdout, "", 0)); ok {
+	decodedPayload := e.Verify(verificationTime, certFetcher, log.New(os.Stdout, "", 0))
+	if decodedPayload != nil {
 		e.Payload = decodedPayload
 		fmt.Println("The exchange has valid signature.")
 	}

--- a/go/signedexchange/signedexchange_test.go
+++ b/go/signedexchange/signedexchange_test.go
@@ -309,7 +309,7 @@ func TestVerify(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate
-		if !e.Verify(verificationTime, certFetcher, log.New(os.Stdout, "ERROR: ", 0)) {
+		if ok, _ := e.Verify(verificationTime, certFetcher, log.New(os.Stdout, "ERROR: ", 0)); !ok {
 			t.Errorf("Verification failed")
 		}
 	})
@@ -324,7 +324,7 @@ func TestVerifyNotYetValidExchange(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate.Add(-1 * time.Second)
-		if e.Verify(verificationTime, certFetcher, log.New(ioutil.Discard, "", 0)) {
+		if ok, _ := e.Verify(verificationTime, certFetcher, log.New(ioutil.Discard, "", 0)); ok {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -339,7 +339,7 @@ func TestVerifyExpiredExchange(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate.Add(1 * time.Hour).Add(1 * time.Second)
-		if e.Verify(verificationTime, certFetcher, log.New(ioutil.Discard, "", 0)) {
+		if ok, _ := e.Verify(verificationTime, certFetcher, log.New(ioutil.Discard, "", 0)); ok {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -355,7 +355,7 @@ func TestVerifyBadValidityUrl(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate
-		if e.Verify(verificationTime, certFetcher, log.New(ioutil.Discard, "", 0)) {
+		if ok, _ := e.Verify(verificationTime, certFetcher, log.New(ioutil.Discard, "", 0)); ok {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -371,7 +371,7 @@ func TestVerifyBadMethod(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate
-		if e.Verify(verificationTime, certFetcher, log.New(ioutil.Discard, "", 0)) {
+		if ok, _ := e.Verify(verificationTime, certFetcher, log.New(ioutil.Discard, "", 0)); ok {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -390,7 +390,7 @@ func TestVerifyStatefulRequestHeader(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate
-		if e.Verify(verificationTime, certFetcher, log.New(ioutil.Discard, "", 0)) {
+		if ok, _ := e.Verify(verificationTime, certFetcher, log.New(ioutil.Discard, "", 0)); ok {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -406,7 +406,7 @@ func TestVerifyStatefulResponseHeader(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate
-		if e.Verify(verificationTime, certFetcher, log.New(ioutil.Discard, "", 0)) {
+		if ok, _ := e.Verify(verificationTime, certFetcher, log.New(ioutil.Discard, "", 0)); ok {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -423,7 +423,7 @@ func TestVerifyBadSignature(t *testing.T) {
 		e.ResponseHeaders.Add("Etag", "0123")
 
 		verificationTime := signatureDate
-		if e.Verify(verificationTime, certFetcher, log.New(ioutil.Discard, "", 0)) {
+		if ok, _ := e.Verify(verificationTime, certFetcher, log.New(ioutil.Discard, "", 0)); ok {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -440,7 +440,7 @@ func TestVerifyNonCanonicalURL(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate
-		if !e.Verify(verificationTime, certFetcher, log.New(os.Stdout, "ERROR: ", 0)) {
+		if ok, _ := e.Verify(verificationTime, certFetcher, log.New(os.Stdout, "ERROR: ", 0)); !ok {
 			t.Errorf("Verification failed")
 		}
 	})

--- a/go/signedexchange/signedexchange_test.go
+++ b/go/signedexchange/signedexchange_test.go
@@ -312,7 +312,7 @@ func TestVerify(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate
-		if e.Verify(verificationTime, certFetcher, stdoutLogger) == nil {
+		if _, ok := e.Verify(verificationTime, certFetcher, stdoutLogger); !ok {
 			t.Errorf("Verification failed")
 		}
 	})
@@ -327,7 +327,7 @@ func TestVerifyNotYetValidExchange(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate.Add(-1 * time.Second)
-		if e.Verify(verificationTime, certFetcher, nullLogger) != nil {
+		if _, ok := e.Verify(verificationTime, certFetcher, nullLogger); ok {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -342,7 +342,7 @@ func TestVerifyExpiredExchange(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate.Add(1 * time.Hour).Add(1 * time.Second)
-		if e.Verify(verificationTime, certFetcher, nullLogger) != nil {
+		if _, ok := e.Verify(verificationTime, certFetcher, nullLogger); ok {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -358,7 +358,7 @@ func TestVerifyBadValidityUrl(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate
-		if e.Verify(verificationTime, certFetcher, nullLogger) != nil {
+		if _, ok := e.Verify(verificationTime, certFetcher, nullLogger); ok {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -374,7 +374,7 @@ func TestVerifyBadMethod(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate
-		if e.Verify(verificationTime, certFetcher, nullLogger) != nil {
+		if _, ok := e.Verify(verificationTime, certFetcher, nullLogger); ok {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -393,7 +393,7 @@ func TestVerifyStatefulRequestHeader(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate
-		if e.Verify(verificationTime, certFetcher, nullLogger) != nil {
+		if _, ok := e.Verify(verificationTime, certFetcher, nullLogger); ok {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -409,7 +409,7 @@ func TestVerifyStatefulResponseHeader(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate
-		if e.Verify(verificationTime, certFetcher, nullLogger) != nil {
+		if _, ok := e.Verify(verificationTime, certFetcher, nullLogger); ok {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -426,7 +426,7 @@ func TestVerifyBadSignature(t *testing.T) {
 		e.ResponseHeaders.Add("Etag", "0123")
 
 		verificationTime := signatureDate
-		if e.Verify(verificationTime, certFetcher, nullLogger) != nil {
+		if _, ok := e.Verify(verificationTime, certFetcher, nullLogger); ok {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -443,7 +443,7 @@ func TestVerifyNonCanonicalURL(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate
-		if e.Verify(verificationTime, certFetcher, stdoutLogger) == nil {
+		if _, ok := e.Verify(verificationTime, certFetcher, stdoutLogger); !ok {
 			t.Errorf("Verification failed")
 		}
 	})
@@ -461,11 +461,11 @@ func TestVerifyNonCacheable(t *testing.T) {
 		verificationTime := signatureDate
 		switch ver {
 		case version.Version1b1, version.Version1b2:
-			if e.Verify(verificationTime, certFetcher, stdoutLogger) == nil {
+			if _, ok := e.Verify(verificationTime, certFetcher, stdoutLogger); !ok {
 				t.Errorf("Verification should succeed")
 			}
 		default:
-			if e.Verify(verificationTime, certFetcher, nullLogger) != nil {
+			if _, ok := e.Verify(verificationTime, certFetcher, nullLogger); ok {
 				t.Errorf("Verification should fail")
 			}
 		}

--- a/go/signedexchange/signedexchange_test.go
+++ b/go/signedexchange/signedexchange_test.go
@@ -312,7 +312,7 @@ func TestVerify(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate
-		if ok, _ := e.Verify(verificationTime, certFetcher, stdoutLogger); !ok {
+		if e.Verify(verificationTime, certFetcher, stdoutLogger) == nil {
 			t.Errorf("Verification failed")
 		}
 	})
@@ -327,7 +327,7 @@ func TestVerifyNotYetValidExchange(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate.Add(-1 * time.Second)
-		if ok, _ := e.Verify(verificationTime, certFetcher, nullLogger); ok {
+		if e.Verify(verificationTime, certFetcher, nullLogger) != nil {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -342,7 +342,7 @@ func TestVerifyExpiredExchange(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate.Add(1 * time.Hour).Add(1 * time.Second)
-		if ok, _ := e.Verify(verificationTime, certFetcher, nullLogger); ok {
+		if e.Verify(verificationTime, certFetcher, nullLogger) != nil {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -358,7 +358,7 @@ func TestVerifyBadValidityUrl(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate
-		if ok, _ := e.Verify(verificationTime, certFetcher, nullLogger); ok {
+		if e.Verify(verificationTime, certFetcher, nullLogger) != nil {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -374,7 +374,7 @@ func TestVerifyBadMethod(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate
-		if ok, _ := e.Verify(verificationTime, certFetcher, nullLogger); ok {
+		if e.Verify(verificationTime, certFetcher, nullLogger) != nil {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -393,7 +393,7 @@ func TestVerifyStatefulRequestHeader(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate
-		if ok, _ := e.Verify(verificationTime, certFetcher, nullLogger); ok {
+		if e.Verify(verificationTime, certFetcher, nullLogger) != nil {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -409,7 +409,7 @@ func TestVerifyStatefulResponseHeader(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate
-		if ok, _ := e.Verify(verificationTime, certFetcher, nullLogger); ok {
+		if e.Verify(verificationTime, certFetcher, nullLogger) != nil {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -426,7 +426,7 @@ func TestVerifyBadSignature(t *testing.T) {
 		e.ResponseHeaders.Add("Etag", "0123")
 
 		verificationTime := signatureDate
-		if ok, _ := e.Verify(verificationTime, certFetcher, nullLogger); ok {
+		if e.Verify(verificationTime, certFetcher, nullLogger) != nil {
 			t.Errorf("Verification should fail")
 		}
 	})
@@ -443,7 +443,7 @@ func TestVerifyNonCanonicalURL(t *testing.T) {
 		certFetcher := func(_ string) ([]byte, error) { return c, nil }
 
 		verificationTime := signatureDate
-		if ok, _ := e.Verify(verificationTime, certFetcher, stdoutLogger); !ok {
+		if e.Verify(verificationTime, certFetcher, stdoutLogger) == nil {
 			t.Errorf("Verification failed")
 		}
 	})
@@ -461,11 +461,11 @@ func TestVerifyNonCacheable(t *testing.T) {
 		verificationTime := signatureDate
 		switch ver {
 		case version.Version1b1, version.Version1b2:
-			if ok, _ := e.Verify(verificationTime, certFetcher, stdoutLogger); !ok {
+			if e.Verify(verificationTime, certFetcher, stdoutLogger) == nil {
 				t.Errorf("Verification should succeed")
 			}
 		default:
-			if ok, _ := e.Verify(verificationTime, certFetcher, nullLogger); ok {
+			if e.Verify(verificationTime, certFetcher, nullLogger) != nil {
 				t.Errorf("Verification should fail")
 			}
 		}

--- a/go/signedexchange/verifier.go
+++ b/go/signedexchange/verifier.go
@@ -87,9 +87,9 @@ func DefaultCertFetcher(url string) ([]byte, error) {
 // Signature timestamps are checked against verificationTime.
 // Certificates for signatures are fetched using certFetcher.
 // Errors encountered during verification are logged to l.
-// On success, returns decoded payload bytes (can be an empty slice). Otherwise,
-// returns nil.
-func (e *Exchange) Verify(verificationTime time.Time, certFetcher CertFetcher, l *log.Logger) []byte {
+// If successful, it returns the decoded payload and true. otherwise it returns
+// nil and false.
+func (e *Exchange) Verify(verificationTime time.Time, certFetcher CertFetcher, l *log.Logger) ([]byte, bool) {
 	// draft-yasskin-http-origin-signed-responses.html#cross-origin-trust
 
 	// "The client MUST parse the Signature header into a list of signatures
@@ -97,7 +97,7 @@ func (e *Exchange) Verify(verificationTime time.Time, certFetcher CertFetcher, l
 	signatures, err := structuredheader.ParseParameterisedList(e.SignatureHeaderValue)
 	if err != nil {
 		l.Printf("Could not parse signature header: %v", err)
-		return nil
+		return nil, false
 	}
 	// "...and run the following algorithm for each signature, stopping at the
 	// first one that returns "valid". If any signature returns "valid", return
@@ -164,14 +164,9 @@ func (e *Exchange) Verify(verificationTime time.Time, certFetcher CertFetcher, l
 		// TODO: Implement Step 6 and 7 (certificate verification).
 
 		// Step 8: "Return "valid"."
-
-		// Make sure to return non-nil value, even if the payload is empty.
-		if decodedPayload == nil {
-			decodedPayload = make([]byte, 0)
-		}
-		return decodedPayload
+		return decodedPayload, true
 	}
-	return nil
+	return nil, false
 }
 
 // IsCacheable returns true if Exchange is cacheable by a shared cache

--- a/go/signedexchange/verifier.go
+++ b/go/signedexchange/verifier.go
@@ -85,6 +85,8 @@ func DefaultCertFetcher(url string) ([]byte, error) {
 // Signature timestamps are checked against verificationTime.
 // Certificates for signatures are fetched using certFetcher.
 // Errors encountered during verification are logged to l.
+// If successful, it returns true and the decoded payload. otherwise it returns
+// false and nil.
 func (e *Exchange) Verify(verificationTime time.Time, certFetcher CertFetcher, l *log.Logger) (bool, []byte) {
 	// draft-yasskin-http-origin-signed-responses.html#cross-origin-trust
 
@@ -161,6 +163,7 @@ func (e *Exchange) Verify(verificationTime time.Time, certFetcher CertFetcher, l
 
 // verifySignature verifies single signature, as described in
 // https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#signature-validity.
+// On success, returns a potentially-valid cert chain and decoded payload bytes.
 func verifySignature(e *Exchange, verificationTime time.Time, fetch CertFetcher, signature *Signature) (certurl.CertChain, []byte, error) {
 	// Step 1: Extract the signature fields
 	// |signature| is the parsed signature.


### PR DESCRIPTION
Before this patch, `e.Verify()` replaced `e.Payload` with mice-decoded
payload bytes. It's unintuitive that `Verify()` mutates the `Exchange`, so
this patch lets `Verify()` return the decoded payload in addition to
the boolean result.