### PR TITLE
Introduce signed exchange report for distributors

### DIFF
--- a/loading.bs
+++ b/loading.bs
@@ -146,9 +146,6 @@ spec: http-dig-alg; urlPrefix: https://www.iana.org/assignments/http-dig-alg/htt
 spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf
     type: dfn
         text: SHA-256; url: #
-spec: network-error-logging; urlPrefix: https://w3c.github.io/network-error-logging/#
-    type: dfn
-        text: deliver a network report ; url: deliver-a-network-report
 </pre>
 <pre class='link-defaults'>
 spec:fetch; type:dfn; for:/; text:response
@@ -1115,8 +1112,10 @@ result, the UA MUST:
 
 1. Set |report body|'s `"phase"` to `"sxg"`.
 
-1. Set |report body|'s `"type"` to the result of concatenating a string `"sxg."`
-     and the |report|'s [=signed exchange report/result=].
+1. If the |report|'s [=signed exchange report/result=] is
+    "[=signed exchange report/ok=]", set |report body|'s `"type"` to `"ok"`.
+    Otherwise, set |report body|'s `"type"` to the result of concatenating a
+    string `"sxg."` and the |report|'s [=signed exchange report/result=].
 
 1. If |report body|'s `"sxg"`'s `"cert_url"`'s [=url/scheme=] is not `"data"`
     and |report|'s [=signed exchange report/result=] is

--- a/loading.bs
+++ b/loading.bs
@@ -146,6 +146,9 @@ spec: http-dig-alg; urlPrefix: https://www.iana.org/assignments/http-dig-alg/htt
 spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf
     type: dfn
         text: SHA-256; url: #
+spec: network-error-logging; urlPrefix: https://w3c.github.io/network-error-logging/#
+    type: dfn
+        text: generate a network error report ; url: generate-a-network-error-report
 </pre>
 <pre class='link-defaults'>
 spec:fetch; type:dfn; for:/; text:response
@@ -287,10 +290,10 @@ add the following steps:
                 is [=ReadableStream/closed=] or [=ReadableStream/errored=].
             1. If |parsedExchange|'s [=response/body=]'s [=body/stream=] is
                 [=ReadableStream/closed=], set |report|'s
-                [=signed exchange report/result=] to "`ok`".
+                [=signed exchange report/result=] to `"ok"`.
             1. If |parsedExchange|'s [=response/body=]'s [=body/stream=] is
                 [=ReadableStream/errored=], set |report|'s
-                [=signed exchange report/result=] to "`mi_error`".
+                [=signed exchange report/result=] to `"mi_error"`.
             1. Run [=queuing signed exchange report=] with |report|.
         1. Set |actualResponse|'s [=status=] to `303`.
         1. [=header list/Set=] |actualResponse|'s `` `Location` `` header to
@@ -417,11 +420,14 @@ A signed exchange report is a [=struct=] with the following items:
 : <dfn>inner URL</dfn>
 :: A logical [=URL=] of the signed exchange.
 : <dfn>cert URL</dfn>
-:: A [=URL=] of the first "cert-url" parameter of signed exchange.
+:: A [=URL=] of the first "`cert-url`" parameter of signed exchange.
 : <dfn>server IP</dfn>
-:: The IP address of the server from which the user agent recieved the signed exchange, if available. Otherwise, an empty string.
+:: The IP address of the server from which the user agent recieved the signed
+       exchange, if available. Otherwise, an empty string.
 : <dfn>cert server IP</dfn>
-:: The IP address of the server from which the user agent recieved the certidicate of the signed exchange, if available. Otherwise, an empty string.
+:: The IP address of the server from which the user agent recieved the
+       certificate of the signed exchange, if available. Otherwise, an empty
+       string.
 
 </dl>
 
@@ -503,8 +509,8 @@ This section defines how to load the formats defined in
 
 <dfn>Parsing a signed exchange</dfn> of version |version| from a [=response=]
 |response| with a [=signed exchange report=] |report| in the context of an
-[=environment settings object=] |client|returns the result of the following
-steps:
+[=environment settings object=] |client| returns an [=exchange=] or a string
+which indicates an error returned by the following steps:
 
 1. Assert: This algorithm is running [=in parallel=].
 1. Assert: The [=signed exchange version=] of |response| is, if |version| is
@@ -518,19 +524,19 @@ steps:
 1. Set |report|'s [=signed exchange report/inner URL=] to |response|'s
     [=response/URL=].
 1. If |response|'s [=response/URL=]'s [=url/origin=] is not a [=potentially
-    trustworthy origin=], return "`non_secure_origin`".
+    trustworthy origin=], return `"non_secure_origin"`.
 
     Note: This ensures that the privacy properties of retrieving an HTTPS
     resource via a signed exchange are no worse than retrieving it via TLS.
 
 1. Let |bodyStream| be |response|'s [=response/body=]'s [=body/stream=].
-1. If |bodyStream| is null, return "`parse_error`".
+1. If |bodyStream| is null, return `"parse_error"`.
 1. Let |stream| be a [=new read buffer=] for |bodyStream|.
 1. Let (|magic|, |requestUrlBytes|, |requestUrl|) be the result of [=parsing the
     invariant prefix=] from |stream|. If returns a failure, return
-    "`parse_error`".
+    `"parse_error"`.
 1. If |magic| is not the following value, depending on |version|, return
-    "`parse_error`":
+    `"parse_error"`:
     <dl class="switch">
     : `b2`
     :: `` `sxg1-b2\0` ``
@@ -545,25 +551,24 @@ steps:
 1. Let |encodedHeaderLength| be the result of [=read buffer/reading=] 3 bytes
     from |stream|.
 1. If |encodedSigLength| or |encodedHeaderLength| is a failure, return
-    "`parse_error`".
+    `"parse_error"`.
 1. Let |sigLength| be the result of decoding |encodedSigLength| as a big-endian
     integer.
 1. Let |headerLength| be the result of decoding |encodedHeaderLength| as a
     big-endian integer.
-1. If |sigLength| > 16384 or |headerLength| > 524288, return
-    "`parse_error`".
+1. If |sigLength| > 16384 or |headerLength| > 524288, return `"parse_error"`.
 1. Let |signature| be the result of [=read buffer/reading=] |sigLength| bytes
     from |stream|.
-1. If |signature| is a failure, return "`parse_error`".
+1. If |signature| is a failure, return `"parse_error"`.
 1. Let |parsedSignature| be the result of [=parsing the Signature header field=]
     |signature| with |report| in the context of |client|.
-1. If |parsedSignature| is not a [=exchange signature=], return it.
+1. If |parsedSignature| is not an [=exchange signature=], return it.
 1. Let |headerBytes| be the result of [=read buffer/reading=] |headerLength|
     bytes from |stream|.
-1. If |headerBytes| is a failure, return "`parse_error`".
+1. If |headerBytes| is a failure, return `"parse_error"`.
 1. If |parsedSignature| [=exchange signature/is not valid=] for |headerBytes|
     and |requestUrlBytes|, and signed exchange version |version|, return
-    "`signature_verification_error`".
+    `"signature_verification_error"`.
 1. Let |parsedExchange| be, if |version| is:
     <dl class="switch">
     : `b2`
@@ -573,20 +578,20 @@ steps:
     :: the result of [=parsing b3 CBOR headers=] given |headerBytes| and
         |requestUrl|.
 1. If |parsedSignature| [=exchange signature/does not establish cross-origin
-    trust=] for |parsedExchange|, return "`cert_verification_error`".
+    trust=] for |parsedExchange|, return `"cert_verification_error"`.
 1. Set |parsedExchange|'s [=exchange/response=]'s [=response/HTTPS state=] to
     either "`deprecated`" or "`modern`".
 
     Note: See <a spec="fetch">HTTP-network fetch</a> for details of this choice.
 1. If |parsedExchange|'s [=exchange/response=]'s [=response/status=] is a
     [=redirect status=] or the [=signed exchange version=] of |parsedExchange|'s
-    [=exchange/response=] is not undefined, return "`parse_error`".
+    [=exchange/response=] is not undefined, return `"parse_error"`.
 
     Note: This might simplify the UA's implementation, since it doesn't have to
     handle nested signed exchanges.
 1. [=Read a body=] from |stream| into |parsedExchange|'s [=exchange/response=]
     using |parsedSignature| to check its integrity. If this is a failure, return
-    "`mi_error`".
+    `"mi_error"`.
 
     Note: Typically this body’s stream is still being enqueued to after
     returning.
@@ -625,20 +630,20 @@ a failure or the triple of a [=byte sequence=] |magic|, [=byte sequence=]
 
 <dfn>Parsing the Signature header field</dfn> |signatureString| with a
 [=signed exchange report=] |report| in the context of an
-[=environment settings object=] |client| returns the [=exchange signature=] or
-failure returned by the following steps:
+[=environment settings object=] |client| returns an [=exchange signature=] or
+a string which indicates an error returned by the following steps:
 
 1. Assert: This algorithm is running [=in parallel=].
 1. If |signatureString| contains any bytes that aren't [=ASCII bytes=], return
-    "`parse_error`".
+    `"parse_error"`.
 1. Let |parsed| be the result of [=Parsing HTTP1 Header Fields into Structured
     Headers=] given an <var ignore>input_string</var> of the [=ASCII decoding=]
     of |signatureString| and a <var ignore>header_type</var> of "param-list".
-1. If |parsed| has more than one element, return "`parse_error`".
+1. If |parsed| has more than one element, return `"parse_error"`.
 
     Note: This limitation of current implementations will go away in the future.
 1. If any of the parameters of |parsed|[0] listed here doesn't have the
-    associated type, return "`parse_error`":
+    associated type, return `"parse_error"`:
 
     : Byte sequence
     :: "sig", "cert-sha256"
@@ -657,7 +662,7 @@ failure returned by the following steps:
 1. Set |report|'s [=signed exchange report/cert URL=] to |certUrl|.
 1. If |certUrl| is a failure, if it has a non-null [=url/fragment=], or if its
     [=url/scheme=] is something other than `"https"` or `"data"`, return
-    "`parse_error`".
+    `"parse_error"`.
 1. Set |result|'s [=exchange signature/certSha256=] to the "cert-sha256"
     parameter of |parsed|[0].
 1. Set |result|'s [=exchange signature/validityUrlBytes=] to the [=ASCII
@@ -665,7 +670,8 @@ failure returned by the following steps:
 1. Let |validityUrl| be the result of running the [=URL parser=] on the
     "validity-url" parameter of |parsed|[0]..
 1. If |validityUrl| is a failure, if it has a non-null [=url/fragment=], or if
-    its [=url/scheme=] is something other than `"https"`, return "`parse_error`".
+    its [=url/scheme=] is something other than `"https"`, return
+    `"parse_error"`.
 1. Set |result|'s [=exchange signature/validityUrl=] to |validityUrl|.
 1. Set |result|'s [=exchange signature/date=] to the "date" parameter of
     |parsed|[0].
@@ -673,9 +679,9 @@ failure returned by the following steps:
     parameter of |parsed|[0].
 1. If |result|'s [=exchange signature/expiration time=] or |result|'s [=exchange
     signature/date=] is less than 0 or greater than 2<sup>63</sup>-1, return
-    "`parse_error`".
+    `"parse_error"`.
 1. If |result|'s [=exchange signature/expiration time=] &lt;= |result|'s
-    [=exchange signature/date=], return "`parse_error`".
+    [=exchange signature/date=], return `"parse_error"`.
 1. Set |result|'s [=exchange signature/certificate chain=] to the result of
     [=handling the certificate reference=] |certUrl| with a hash of |result|'s
     [=exchange signature/certSha256=] and |report| in the context of |client|.
@@ -686,8 +692,8 @@ failure returned by the following steps:
 
 <dfn>Handling the certificate reference</dfn> |certUrl| with the SHA-256 hash
 |certSha256| and a [=signed exchange report=] |report|, in the context of an
-[=environment settings object=] |client|, returns the result of the following
-steps:
+[=environment settings object=] |client|, returns a [=certificate chain=] or a
+string which indicates an error returned by the following steps:
 
 1. Assert: This algorithm is running [=in parallel=].
 1. Let |certRequest| be a new [=request=] with the following items:
@@ -707,25 +713,25 @@ steps:
     of the server to which the user agent recieved the |certResponse|, if
     available.
 1. If |certResponse|'s [=response/status=] is not `200`, return
-    "`cert_fetch_error`".
+    `"cert_fetch_error"`.
 1. Let |certMimeType| be the result of [=header list/extracting a MIME type=]
     from |certResponse|'s [=response/header list=].
 1. If |certMimeType| is a failure or its [=MIME type/essence=] is not
-    `"application/cert-chain+cbor"`, return "`cert_fetch_error`".
+    `"application/cert-chain+cbor"`, return `"cert_fetch_error"`.
 1. If |certResponse|'s [=response/body=] is null or that body's [=body/stream=]
-    is null, return "`cert_parse_error`".
+    is null, return `"cert_parse_error"`.
 1. Let |bytes| be the result of [=ReadableStream/read all bytes|reading all
     bytes=] from |certResponse|'s [=response/body=]'s [=body/stream=] with a
     [=ReadableStream/get a reader|new reader=] over the same stream.
 1. Wait for |bytes| to settle.
-1. If |bytes| was rejected, return "`cert_parse_error`".
+1. If |bytes| was rejected, return `"cert_parse_error"`.
 1. Let |chain| be the [=certificate chain=] produced by parsing |bytes|' value
     using the [=cert-chain CDDL=]. If |bytes|'s value doesn't match this CDDL or
-    isn't [=canonically-encoded CBOR=], return "`cert_parse_error`".
+    isn't [=canonically-encoded CBOR=], return `"cert_parse_error"`.
 1. Assert: |chain| has at least one [=list/item=].
 1. If the [=SHA-256=] hash of |chain|'s [=certificate chain/leaf=]'s [=augmented
     certificate/certificate=] is not equal to |certSha256|, return
-    "`signature_verification_error`".
+    `"signature_verification_error"`.
 1. Return |chain|.
 
 <h3 algorithm id="the-signed-message">The signed message</h3>
@@ -1051,25 +1057,26 @@ A [=request=] |browserRequest| <dfn>matches the stored exchange</dfn>
 
 1. Let |additional body| be a new ECMAScript object with the following properties:
 
-    * outer_url: |report|'s [=signed exchange report/outer request=]'s [=request/url=].
+    * outer_url: |report|'s [=signed exchange report/outer request=]'s
+          [=request/url=].
     * inner_url: |report|'s [=signed exchange report/inner URL=].
     * cert_url: |report|'s [=signed exchange report/cert URL=].
     * elapsed_time: the elapsed number of milliseconds between the start of
         |report|'s [=signed exchange report/outer request=] fetch and when this
         algorithm is called.
-    * phase: "sxg".
-    * type: the result of concatenating a string "sxg." and the |report|'s
+    * phase: `"sxg"`.
+    * type: the result of concatenating a string `"sxg."` and the |report|'s
         [=signed exchange report/result=].
 
-1. If |additional body|'s "type" is not "sxg.ok" and |report|'s
+1. If |additional body|'s `"type"` is not `"sxg.ok"` and |report|'s
     [=signed exchange report/cert server IP=] is not empty and is different from
     |report|'s [=signed exchange report/cert server IP=]:
 
-    1. Set |additional body|'s "type" to "sxg.failed".
-    1. Set |additional body|'s "elapsed_time" to 0.
+    1. Set |additional body|'s `"type"` to `"sxg.failed"`.
+    1. Set |additional body|'s `"elapsed_time"` to 0.
 
-1. <a href="https://w3c.github.io/network-error-logging/#generate-a-network-error-report">Generate a network error report</a>
-    with |report|'s [=signed exchange report/outer request=], and |report|'s
+1. [=Generate a network error report=]</a> with |report|'s
+    [=signed exchange report/outer request=], and |report|'s
     [=signed exchange report/outer response=] and |additional body|.
 
 ## Stream algorithms ## {#stream-algs}

--- a/loading.bs
+++ b/loading.bs
@@ -1069,12 +1069,16 @@ A [=request=] |browserRequest| <dfn>matches the stored exchange</dfn>
     * type: the result of concatenating a string `"sxg."` and the |report|'s
         [=signed exchange report/result=].
 
-1. If |additional body|'s `"type"` is not `"sxg.ok"` and |report|'s
-    [=signed exchange report/cert server IP=] is not empty and is different from
-    |report|'s [=signed exchange report/cert server IP=]:
+1. If |additional body|'s `"type"` is not `"sxg.ok"` and |additional body|'s
+    `"cert_url"`'s [=url/scheme=] is not `"data"`:
 
-    1. Set |additional body|'s `"type"` to `"sxg.failed"`.
-    1. Set |additional body|'s `"elapsed_time"` to 0.
+    1. If |additional body|'s `"outer_url"`'s [=url/origin=] is different from
+        |additional body|'s `"cert_url"`'s [=url/origin=] or |report|'s
+        [=signed exchange report/server IP=] is different from  |report|'s
+        [=signed exchange report/cert server IP=]:
+
+        1. Set |additional body|'s `"type"` to `"sxg.failed"`.
+        1. Set |additional body|'s `"elapsed_time"` to 0.
 
 1. [=Generate a network error report=]</a> with |report|'s
     [=signed exchange report/outer request=], and |report|'s

--- a/loading.bs
+++ b/loading.bs
@@ -267,10 +267,31 @@ add the following steps:
 
     : `"b2"` or `"b3"`
     ::
+        1. Let |report| be a new [=signed exchange report=] struct.
+        1. Set |report|'s [=signed exchange report/outer request=] to |request|.
+        1. Set |report|'s [=signed exchange report/outer response=] to |actualResponse|.
+        1. Set |report|'s [=signed exchange report/server IP=] to the IP address
+            of the server to which the user agent recieved the |actualResponse|,
+            if available.
         1. Let |parsedExchange| be the result of [=parsing a signed
             exchange=] of version `b2` or `b3`, respectively, from
-            |actualResponse| in the context of |request|'s [=request/client=].
-        1. If |parsedExchange| is a failure, return a [=network error=].
+            |actualResponse| with |report| in the context of |request|'s
+            [=request/client=].
+        1. If |parsedExchange| is not an [=exchange=]:
+            1. Set |report|'s [=signed exchange report/result=] to
+                |parsedExchange|.
+            1. Run [=queuing signed exchange report=] with |report|.
+            1. Return a [=network error=].
+        1. [=In parallel=]:
+            1. Wait until |parsedExchange|'s [=response/body=]'s [=body/stream=]
+                is [=ReadableStream/closed=] or [=ReadableStream/errored=].
+            1. If |parsedExchange|'s [=response/body=]'s [=body/stream=] is
+                [=ReadableStream/closed=], set |report|'s
+                [=signed exchange report/result=] to "`ok`".
+            1. If |parsedExchange|'s [=response/body=]'s [=body/stream=] is
+                [=ReadableStream/errored=], set |report|'s
+                [=signed exchange report/result=] to "`mi_error`".
+            1. Run [=queuing signed exchange report=] with |report|.
         1. Set |actualResponse|'s [=status=] to `303`.
         1. [=header list/Set=] |actualResponse|'s `` `Location` `` header to
             the [=ASCII encoding=] of the [=URL serializer|serialization=]
@@ -381,6 +402,29 @@ for="certificate">extensions</dfn> map ([=Certificate Extensions=]) from OIDs to
 A <dfn>certificate chain</dfn> is a [=list=] of [=augmented certificates=], of
 which the first [=list/item=] is the <dfn for="certificate chain">leaf</dfn>.
 
+<h3 dfn-type=dfn export>Signed Exchange report</h3>
+
+A signed exchange report is a [=struct=] with the following items:
+
+<dl dfn-for="signed exchange report">
+: <dfn>result</dfn>
+:: A result of loading signed exchange.
+: <dfn>outer request</dfn>
+:: A [=request=] which the user agent sent to the server to load the signed exchange.
+: <dfn>outer response</dfn>
+:: A [=response=] which the user agent recieved from the server.
+
+: <dfn>inner URL</dfn>
+:: A logical [=URL=] of the signed exchange.
+: <dfn>cert URL</dfn>
+:: A [=URL=] of the first "cert-url" parameter of signed exchange.
+: <dfn>server IP</dfn>
+:: The IP address of the server from which the user agent recieved the signed exchange, if available. Otherwise, an empty string.
+: <dfn>cert server IP</dfn>
+:: The IP address of the server from which the user agent recieved the certidicate of the signed exchange, if available. Otherwise, an empty string.
+
+</dl>
+
 <h3 dfn-type=dfn export>Exchange Signature</h3>
 
 An exchange signature is a [=struct=] with the following items:
@@ -458,8 +502,9 @@ This section defines how to load the formats defined in
 [[draft-yasskin-httpbis-origin-signed-exchanges-impl-03]].
 
 <dfn>Parsing a signed exchange</dfn> of version |version| from a [=response=]
-|response| in the context of an [=environment settings object=] |client| returns
-the result of the following steps:
+|response| with a [=signed exchange report=] |report| in the context of an
+[=environment settings object=] |client|returns the result of the following
+steps:
 
 1. Assert: This algorithm is running [=in parallel=].
 1. Assert: The [=signed exchange version=] of |response| is, if |version| is
@@ -470,18 +515,22 @@ the result of the following steps:
     :: `"b3"`
 
     </dl>
+1. Set |report|'s [=signed exchange report/inner URL=] to |response|'s
+    [=response/URL=].
 1. If |response|'s [=response/URL=]'s [=url/origin=] is not a [=potentially
-    trustworthy origin=], return failure.
+    trustworthy origin=], return "`non_secure_origin`".
 
     Note: This ensures that the privacy properties of retrieving an HTTPS
     resource via a signed exchange are no worse than retrieving it via TLS.
 
 1. Let |bodyStream| be |response|'s [=response/body=]'s [=body/stream=].
-1. If |bodyStream| is null, return failure.
+1. If |bodyStream| is null, return "`parse_error`".
 1. Let |stream| be a [=new read buffer=] for |bodyStream|.
 1. Let (|magic|, |requestUrlBytes|, |requestUrl|) be the result of [=parsing the
-    invariant prefix=] from |stream|. If returns a failure, return that failure.
-1. If |magic| is not the following value, depending on |version|, return a failure:
+    invariant prefix=] from |stream|. If returns a failure, return
+    "`parse_error`".
+1. If |magic| is not the following value, depending on |version|, return
+    "`parse_error`":
     <dl class="switch">
     : `b2`
     :: `` `sxg1-b2\0` ``
@@ -495,24 +544,26 @@ the result of the following steps:
     |stream|.
 1. Let |encodedHeaderLength| be the result of [=read buffer/reading=] 3 bytes
     from |stream|.
-1. If |encodedSigLength| or |encodedHeaderLength| is a failure, return a
-    failure.
+1. If |encodedSigLength| or |encodedHeaderLength| is a failure, return
+    "`parse_error`".
 1. Let |sigLength| be the result of decoding |encodedSigLength| as a big-endian
     integer.
 1. Let |headerLength| be the result of decoding |encodedHeaderLength| as a
     big-endian integer.
-1. If |sigLength| > 16384 or |headerLength| > 524288, return a failure.
+1. If |sigLength| > 16384 or |headerLength| > 524288, return
+    "`parse_error`".
 1. Let |signature| be the result of [=read buffer/reading=] |sigLength| bytes
     from |stream|.
-1. If |signature| is a failure, return it.
+1. If |signature| is a failure, return "`parse_error`".
 1. Let |parsedSignature| be the result of [=parsing the Signature header field=]
-    |signature| in the context of |client|.
-1. If |parsedSignature| is a failure, return it.
+    |signature| with |report| in the context of |client|.
+1. If |parsedSignature| is not a [=exchange signature=], return it.
 1. Let |headerBytes| be the result of [=read buffer/reading=] |headerLength|
     bytes from |stream|.
-1. If |headerBytes| is a failure, return it.
+1. If |headerBytes| is a failure, return "`parse_error`".
 1. If |parsedSignature| [=exchange signature/is not valid=] for |headerBytes|
-    and |requestUrlBytes|, and signed exchange version |version|, return a failure.
+    and |requestUrlBytes|, and signed exchange version |version|, return
+    "`signature_verification_error`".
 1. Let |parsedExchange| be, if |version| is:
     <dl class="switch">
     : `b2`
@@ -522,20 +573,20 @@ the result of the following steps:
     :: the result of [=parsing b3 CBOR headers=] given |headerBytes| and
         |requestUrl|.
 1. If |parsedSignature| [=exchange signature/does not establish cross-origin
-    trust=] for |parsedExchange|, return a failure.
+    trust=] for |parsedExchange|, return "`cert_verification_error`".
 1. Set |parsedExchange|'s [=exchange/response=]'s [=response/HTTPS state=] to
     either "`deprecated`" or "`modern`".
 
     Note: See <a spec="fetch">HTTP-network fetch</a> for details of this choice.
 1. If |parsedExchange|'s [=exchange/response=]'s [=response/status=] is a
     [=redirect status=] or the [=signed exchange version=] of |parsedExchange|'s
-    [=exchange/response=] is not undefined, return a failure.
+    [=exchange/response=] is not undefined, return "`parse_error`".
 
     Note: This might simplify the UA's implementation, since it doesn't have to
     handle nested signed exchanges.
 1. [=Read a body=] from |stream| into |parsedExchange|'s [=exchange/response=]
     using |parsedSignature| to check its integrity. If this is a failure, return
-    the failure.
+    "`mi_error`".
 
     Note: Typically this body’s stream is still being enqueued to after
     returning.
@@ -572,21 +623,22 @@ a failure or the triple of a [=byte sequence=] |magic|, [=byte sequence=]
 
 <h3 algorithm id="parsing-signature">Parsing a Signature Header Field</h3>
 
-<dfn>Parsing the Signature header field</dfn> |signatureString| in the context
-of an [=environment settings object=] |client| returns the [=exchange
-signature=] or failure returned by the following steps:
+<dfn>Parsing the Signature header field</dfn> |signatureString| with a
+[=signed exchange report=] |report| in the context of an
+[=environment settings object=] |client| returns the [=exchange signature=] or
+failure returned by the following steps:
 
 1. Assert: This algorithm is running [=in parallel=].
-1. If |signatureString| contains any bytes that aren't [=ASCII bytes=], return a
-    failure.
+1. If |signatureString| contains any bytes that aren't [=ASCII bytes=], return
+    "`parse_error`".
 1. Let |parsed| be the result of [=Parsing HTTP1 Header Fields into Structured
     Headers=] given an <var ignore>input_string</var> of the [=ASCII decoding=]
     of |signatureString| and a <var ignore>header_type</var> of "param-list".
-1. If |parsed| has more than one element, return a failure.
+1. If |parsed| has more than one element, return "`parse_error`".
 
     Note: This limitation of current implementations will go away in the future.
 1. If any of the parameters of |parsed|[0] listed here doesn't have the
-    associated type, return a failure:
+    associated type, return "`parse_error`":
 
     : Byte sequence
     :: "sig", "cert-sha256"
@@ -602,9 +654,10 @@ signature=] or failure returned by the following steps:
     (`/`).
 1. Let |certUrl| be the result of running the [=URL parser=] on the "cert-url"
     parameter of |parsed|[0].
+1. Set |report|'s [=signed exchange report/cert URL=] to |certUrl|.
 1. If |certUrl| is a failure, if it has a non-null [=url/fragment=], or if its
-    [=url/scheme=] is something other than `"https"` or `"data"`, return a
-    failure.
+    [=url/scheme=] is something other than `"https"` or `"data"`, return
+    "`parse_error`".
 1. Set |result|'s [=exchange signature/certSha256=] to the "cert-sha256"
     parameter of |parsed|[0].
 1. Set |result|'s [=exchange signature/validityUrlBytes=] to the [=ASCII
@@ -612,28 +665,29 @@ signature=] or failure returned by the following steps:
 1. Let |validityUrl| be the result of running the [=URL parser=] on the
     "validity-url" parameter of |parsed|[0]..
 1. If |validityUrl| is a failure, if it has a non-null [=url/fragment=], or if
-    its [=url/scheme=] is something other than `"https"`, return a failure.
+    its [=url/scheme=] is something other than `"https"`, return "`parse_error`".
 1. Set |result|'s [=exchange signature/validityUrl=] to |validityUrl|.
 1. Set |result|'s [=exchange signature/date=] to the "date" parameter of
     |parsed|[0].
 1. Set |result|'s [=exchange signature/expiration time=] to the "expires"
     parameter of |parsed|[0].
 1. If |result|'s [=exchange signature/expiration time=] or |result|'s [=exchange
-    signature/date=] is less than 0 or greater than 2<sup>63</sup>-1, return a
-    failure.
+    signature/date=] is less than 0 or greater than 2<sup>63</sup>-1, return
+    "`parse_error`".
 1. If |result|'s [=exchange signature/expiration time=] &lt;= |result|'s
-    [=exchange signature/date=], return a failure.
+    [=exchange signature/date=], return "`parse_error`".
 1. Set |result|'s [=exchange signature/certificate chain=] to the result of
     [=handling the certificate reference=] |certUrl| with a hash of |result|'s
-    [=exchange signature/certSha256=] in the context of |client|. If this is a
-    failure, return it.
+    [=exchange signature/certSha256=] and |report| in the context of |client|.
+    If this is not a [=certificate chain=], return it.
 1. Return |result|.
 
 <h4 algorithm id="handling-cert-url">Handling the certificate reference</h4>
 
 <dfn>Handling the certificate reference</dfn> |certUrl| with the SHA-256 hash
-|certSha256|, in the context of an [=environment settings object=] |client|,
-returns the result of the following steps:
+|certSha256| and a [=signed exchange report=] |report|, in the context of an
+[=environment settings object=] |client|, returns the result of the following
+steps:
 
 1. Assert: This algorithm is running [=in parallel=].
 1. Let |certRequest| be a new [=request=] with the following items:
@@ -649,24 +703,29 @@ returns the result of the following steps:
     : [=request/mode=]
     :: "`cors`"
 1. Let |certResponse| be the result of [=fetching=] |certRequest|.
-1. If |certResponse|'s [=response/status=] is not `200`, return a failure.
+1. Set |report|'s [=signed exchange report/cert server IP=] to the IP address
+    of the server to which the user agent recieved the |certResponse|, if
+    available.
+1. If |certResponse|'s [=response/status=] is not `200`, return
+    "`cert_fetch_error`".
 1. Let |certMimeType| be the result of [=header list/extracting a MIME type=]
     from |certResponse|'s [=response/header list=].
 1. If |certMimeType| is a failure or its [=MIME type/essence=] is not
-    `"application/cert-chain+cbor"`, return a failure.
+    `"application/cert-chain+cbor"`, return "`cert_fetch_error`".
 1. If |certResponse|'s [=response/body=] is null or that body's [=body/stream=]
-    is null, return a failure.
+    is null, return "`cert_parse_error`".
 1. Let |bytes| be the result of [=ReadableStream/read all bytes|reading all
     bytes=] from |certResponse|'s [=response/body=]'s [=body/stream=] with a
     [=ReadableStream/get a reader|new reader=] over the same stream.
 1. Wait for |bytes| to settle.
-1. If |bytes| was rejected, return a failure.
+1. If |bytes| was rejected, return "`cert_parse_error`".
 1. Let |chain| be the [=certificate chain=] produced by parsing |bytes|' value
     using the [=cert-chain CDDL=]. If |bytes|'s value doesn't match this CDDL or
-    isn't [=canonically-encoded CBOR=], return a failure.
+    isn't [=canonically-encoded CBOR=], return "`cert_parse_error`".
 1. Assert: |chain| has at least one [=list/item=].
 1. If the [=SHA-256=] hash of |chain|'s [=certificate chain/leaf=]'s [=augmented
-    certificate/certificate=] is not equal to |certSha256|, return a failure.
+    certificate/certificate=] is not equal to |certSha256|, return
+    "`signature_verification_error`".
 1. Return |chain|.
 
 <h3 algorithm id="the-signed-message">The signed message</h3>
@@ -985,6 +1044,33 @@ A [=request=] |browserRequest| <dfn>matches the stored exchange</dfn>
     Issue(httpwg/http-extensions#744): This depends on the [=Variants Cache
     Behavior=] returning a list of lists.
 1. Return "match".
+
+<h3 algorithm id="queue-report">Queuing signed exchange report</h3>
+
+<dfn>Queuing signed exchange report</dfn> |report| is the following steps:
+
+1. Let |additional body| be a new ECMAScript object with the following properties:
+
+    * outer_url: |report|'s [=signed exchange report/outer request=]'s [=request/url=].
+    * inner_url: |report|'s [=signed exchange report/inner URL=].
+    * cert_url: |report|'s [=signed exchange report/cert URL=].
+    * elapsed_time: the elapsed number of milliseconds between the start of
+        |report|'s [=signed exchange report/outer request=] fetch and when this
+        algorithm is called.
+    * phase: "sxg".
+    * type: the result of concatenating a string "sxg." and the |report|'s
+        [=signed exchange report/result=].
+
+1. If |additional body|'s "type" is not "sxg.ok" and |report|'s
+    [=signed exchange report/cert server IP=] is not empty and is different from
+    |report|'s [=signed exchange report/cert server IP=]:
+
+    1. Set |additional body|'s "type" to "sxg.failed".
+    1. Set |additional body|'s "elapsed_time" to 0.
+
+1. <a href="https://w3c.github.io/network-error-logging/#generate-a-network-error-report">Generate a network error report</a>
+    with |report|'s [=signed exchange report/outer request=], and |report|'s
+    [=signed exchange report/outer response=] and |additional body|.
 
 ## Stream algorithms ## {#stream-algs}
 

--- a/loading.bs
+++ b/loading.bs
@@ -149,7 +149,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
 spec: network-error-logging; urlPrefix: https://w3c.github.io/network-error-logging/#
     type: dfn
         text: generate a network error report ; url: generate-a-network-error-report
-        text: AdditionalReportBody ; url: dom-additionalreportbody
+        text: deliver a network report ; url: deliver-a-network-report
 </pre>
 <pre class='link-defaults'>
 spec:fetch; type:dfn; for:/; text:response
@@ -1055,34 +1055,39 @@ A [=request=] |browserRequest| <dfn>matches the stored exchange</dfn>
 
 <dfn>Queuing signed exchange report</dfn> |report| is the following steps:
 
-1. Let |additional body| be a new [=AdditionalReportBody=] object with the
-    following properties:
+1. Let |report body| and |policy| be the result of
+    [=generate a network error report=]</a> with |report|'s
+    [=signed exchange report/outer request=]. If the result is null, abort
+    these steps.
+
+1. If |report body|'s `"type"` is `"dns.address_changed"`, abort these steps.
+
+1. Add a new property `"sxg"` to |report body| with a new ECMAScript object with
+     the following properties:
 
     * outer_url: |report|'s [=signed exchange report/outer request=]'s
           [=request/url=].
     * inner_url: |report|'s [=signed exchange report/inner URL=].
     * cert_url: |report|'s [=signed exchange report/cert URL=].
-    * elapsed_time: the elapsed number of milliseconds between the start of
-        |report|'s [=signed exchange report/outer request=] fetch and when this
-        algorithm is called.
-    * phase: `"sxg"`.
-    * type: the result of concatenating a string `"sxg."` and the |report|'s
-        [=signed exchange report/result=].
 
-1. If |additional body|'s `"type"` is not `"sxg.ok"` and |additional body|'s
+1. Set |report body|'s `"phase"` to `"sxg"`.
+
+1. Set |report body|'s `"type"` to the result of concatenating a string `"sxg."`
+     and the |report|'s [=signed exchange report/result=].
+
+1. If |report body|'s `"type"` is not `"sxg.ok"` and |report body|'s `"sxg"`'s
     `"cert_url"`'s [=url/scheme=] is not `"data"`:
 
-    1. If |additional body|'s `"outer_url"`'s [=url/origin=] is different from
-        |additional body|'s `"cert_url"`'s [=url/origin=] or |report|'s
-        [=signed exchange report/server IP=] is different from  |report|'s
-        [=signed exchange report/cert server IP=]:
+    1. If |report body|'s `"sxg"`'s `"outer_url"`'s [=url/origin=] is different
+        from |report body|'s `"sxg"`'s `"cert_url"`'s [=url/origin=] or
+        |report|'s [=signed exchange report/server IP=] is different from
+        |report|'s [=signed exchange report/cert server IP=]:
 
-        1. Set |additional body|'s `"type"` to `"sxg.failed"`.
-        1. Set |additional body|'s `"elapsed_time"` to 0.
+        1. Set |report body|'s `"type"` to `"sxg.failed"`.
+        1. Set |report body|'s `"elapsed_time"` to 0.
 
-1. [=Generate a network error report=]</a> with |report|'s
-    [=signed exchange report/outer request=], and |report|'s
-    [=signed exchange report/outer response=] and |additional body|.
+1. [=Deliver a network report=]</a> with |report body| and |policy| and
+    |report|'s [=signed exchange report/outer request=].
 
 ## Stream algorithms ## {#stream-algs}
 

--- a/loading.bs
+++ b/loading.bs
@@ -399,7 +399,7 @@ A signed exchange report is a [=struct=] with the following items:
 : <dfn>result</dfn>
 :: The result string of loading signed exchange. This must be unset or one of
     "<dfn>`ok`</dfn>", "<dfn>`mi_error`</dfn>",
-    "<dfn>`non_secure_origin`</dfn>", "<dfn>`parse_error`</dfn>",
+    "<dfn>`non_secure_distributor`</dfn>", "<dfn>`parse_error`</dfn>",
     "<dfn>`invalid_integrity_header`</dfn>",
     "<dfn>`signature_verification_error`</dfn>",
     "<dfn>`cert_verification_error`</dfn>", "<dfn>`cert_fetch_error`</dfn>",
@@ -412,14 +412,14 @@ A signed exchange report is a [=struct=] with the following items:
 :: The logical [=URL=] of the signed exchange, if available. Otherwise, an empty
     string.
 : <dfn>cert URL list</dfn>
-:: The list of [=URL=] which first element is the first "`cert-url`" parameter
-    of signed exchange, if available. Otherwise, an empty list.
+:: The list of [=URLs=] in "`cert-url`" parameters for the signed exchange's
+    signatures, if available. Otherwise, an empty list.
 : <dfn>server IP</dfn>
 :: The IP address of the server from which the user agent received the signed
     exchange, if available. Otherwise, an empty string.
 : <dfn>cert server IP list</dfn>
-:: The list of IP address of the server from which the user agent received the
-    certificate of the signed exchange, if available. Otherwise, an empty list.
+:: The list of IP addresses of the servers from which the user agent received
+    the certificates listed in [=signed exchange report/cert URL list=].
 
 </dl>
 
@@ -501,8 +501,9 @@ This section defines how to load the formats defined in
 
 <dfn>Parsing a signed exchange</dfn> of version |version| from a [=response=]
 |response| in the context of an [=environment settings object=] |client|,
-reporting to a [=signed exchange report=] |report| returns an [=exchange=] or a
-string which indicates an error  as described by the following steps:
+reporting to a [=signed exchange report=] |report|, returns an [=exchange=] or a
+string which indicates a [=signed exchange report/result=] as described by the
+following steps
 
 1. Assert: This algorithm is running [=in parallel=].
 1. Assert: The [=signed exchange version=] of |response| is, if |version| is
@@ -514,7 +515,8 @@ string which indicates an error  as described by the following steps:
 
     </dl>
 1. If |response|'s [=response/URL=]'s [=url/origin=] is not a [=potentially
-    trustworthy origin=], return "[=signed exchange report/non_secure_origin=]".
+    trustworthy origin=], return
+    "[=signed exchange report/non_secure_distributor=]".
 
     Note: This ensures that the privacy properties of retrieving an HTTPS
     resource via a signed exchange are no worse than retrieving it via TLS.
@@ -584,9 +586,9 @@ string which indicates an error  as described by the following steps:
 
     Note: This might simplify the UA's implementation, since it doesn't have to
     handle nested signed exchanges.
-1. Run [=read a body=] from |stream| into |parsedExchange|'s
+1. [=Read a body=] from |stream| into |parsedExchange|'s
     [=exchange/response=] using |parsedSignature| to check its integrity. If
-    this returns an error, return it.
+    this returns an error string, return it.
 
     Note: Typically this body’s stream is still being enqueued to after
     returning.
@@ -626,8 +628,9 @@ steps:
 
 <dfn>Parsing the Signature header field</dfn> |signatureString| in the context
 of an [=environment settings object=] |client|, reporting to a
-[=signed exchange report=] |report| returns an [=exchange signature=] or
-a string which indicates an error, as described by the following steps:
+[=signed exchange report=] |report|, returns an [=exchange signature=] or
+a string which indicates a [=signed exchange report/result=], as described by
+the following steps:
 
 1. Assert: This algorithm is running [=in parallel=].
 1. If |signatureString| contains any bytes that aren't [=ASCII bytes=], return
@@ -688,10 +691,10 @@ a string which indicates an error, as described by the following steps:
 <h4 algorithm id="handling-cert-url">Handling the certificate reference</h4>
 
 <dfn>Handling the certificate reference</dfn> |certUrl| with the SHA-256 hash
-|certSha256| in the context of an[=environment settings object=] |client|
+|certSha256| in the context of an [=environment settings object=] |client|,
 reporting to a [=signed exchange report=] |report|, returns a
-[=certificate chain=] or a string which indicates an error, as described by the
-following steps:
+[=certificate chain=] or a string which indicates a
+[=signed exchange report/result=], as described by the following steps:
 
 1. Assert: This algorithm is running [=in parallel=].
 1. Let |certRequest| be a new [=request=] with the following items:
@@ -1094,7 +1097,7 @@ result, the UA MUST:
 1. If |report body|'s `"type"` is `"dns.address_changed"`, abort these steps.
 
     Note: This means that the NEL report was downgraded because the IP addresses
-    of the server and the |policy| don't match. In this case, UA have called
+    of the server and the |policy| don't match. In this case, the UA has called
     [=deliver a network report=] algorithm with the error report while handling
     the response. So we don't need to send the same error report while
     processing the response as a signed exchange.

--- a/loading.bs
+++ b/loading.bs
@@ -149,6 +149,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
 spec: network-error-logging; urlPrefix: https://w3c.github.io/network-error-logging/#
     type: dfn
         text: generate a network error report ; url: generate-a-network-error-report
+        text: AdditionalReportBody ; url: dom-additionalreportbody
 </pre>
 <pre class='link-defaults'>
 spec:fetch; type:dfn; for:/; text:response
@@ -1054,7 +1055,8 @@ A [=request=] |browserRequest| <dfn>matches the stored exchange</dfn>
 
 <dfn>Queuing signed exchange report</dfn> |report| is the following steps:
 
-1. Let |additional body| be a new ECMAScript object with the following properties:
+1. Let |additional body| be a new [=AdditionalReportBody=] object with the
+    following properties:
 
     * outer_url: |report|'s [=signed exchange report/outer request=]'s
           [=request/url=].

--- a/loading.bs
+++ b/loading.bs
@@ -271,31 +271,17 @@ add the following steps:
 
     : `"b2"` or `"b3"`
     ::
-        1. Let |report| be a new [=signed exchange report=] struct.
-        1. Set |report|'s [=signed exchange report/outer request=] to |request|.
-        1. Set |report|'s [=signed exchange report/outer response=] to |actualResponse|.
-        1. Set |report|'s [=signed exchange report/server IP=] to the IP address
-            of the server to which the user agent recieved the |actualResponse|,
-            if available.
+        1. Let |report| be the result of [=create a new signed exchange report=]
+            with |request| and |actualResponse|.
         1. Let |parsedExchange| be the result of [=parsing a signed
             exchange=] of version `b2` or `b3`, respectively, from
-            |actualResponse| with |report| in the context of |request|'s
-            [=request/client=].
-        1. If |parsedExchange| is not an [=exchange=]:
-            1. Set |report|'s [=signed exchange report/result=] to
-                |parsedExchange|.
-            1. Run [=queuing signed exchange report=] with |report|.
-            1. Return a [=network error=].
-        1. [=In parallel=]:
-            1. Wait until |parsedExchange|'s [=response/body=]'s [=body/stream=]
-                is [=ReadableStream/closed=] or [=ReadableStream/errored=].
-            1. If |parsedExchange|'s [=response/body=]'s [=body/stream=] is
-                [=ReadableStream/closed=], set |report|'s
-                [=signed exchange report/result=] to `"ok"`.
-            1. If |parsedExchange|'s [=response/body=]'s [=body/stream=] is
-                [=ReadableStream/errored=], set |report|'s
-                [=signed exchange report/result=] to `"mi_error"`.
-            1. Run [=queuing signed exchange report=] with |report|.
+            |actualResponse| in the context of |request|'s [=request/client=],
+            reporting to |report|.
+        1. If |parsedExchange| is not an [=exchange=], run
+            [=queue a signed exchange report=] |report| and
+            |parsedExchange| as the result, and return a [=network error=].
+        1. [=In parallel=], [=wait and queue a report for=] |parsedExchange| and
+            |report|.
         1. Set |actualResponse|'s [=status=] to `303`.
         1. [=header list/Set=] |actualResponse|'s `` `Location` `` header to
             the [=ASCII encoding=] of the [=URL serializer|serialization=]
@@ -412,23 +398,29 @@ A signed exchange report is a [=struct=] with the following items:
 
 <dl dfn-for="signed exchange report">
 : <dfn>result</dfn>
-:: A result of loading signed exchange.
+:: The result string of loading signed exchange. This must be one of an empty
+    string, "<dfn>`ok`</dfn>", "<dfn>`mi_error`</dfn>",
+    "<dfn>`non_secure_origin`</dfn>", "<dfn>`parse_error`</dfn>",
+    "<dfn>`invalid_integrity_header`</dfn>",
+    "<dfn>`signature_verification_error`</dfn>",
+    "<dfn>`cert_verification_error`</dfn>", "<dfn>`cert_fetch_error`</dfn>",
+    "<dfn>`cert_parse_error`</dfn>",
 : <dfn>outer request</dfn>
-:: A [=request=] which the user agent sent to the server to load the signed exchange.
+:: The [=request=] which the user agent sent to the server to load the signed exchange.
 : <dfn>outer response</dfn>
-:: A [=response=] which the user agent recieved from the server.
-
+:: The [=response=] which the user agent received from the server.
 : <dfn>inner URL</dfn>
-:: A logical [=URL=] of the signed exchange.
-: <dfn>cert URL</dfn>
-:: A [=URL=] of the first "`cert-url`" parameter of signed exchange.
+:: The logical [=URL=] of the signed exchange, if available. Otherwise, an empty
+    string.
+: <dfn>cert URL list</dfn>
+:: The list of [=URL=] of the first "`cert-url`" parameter of signed exchange,
+    if available. Otherwise, an empty list.
 : <dfn>server IP</dfn>
-:: The IP address of the server from which the user agent recieved the signed
-       exchange, if available. Otherwise, an empty string.
-: <dfn>cert server IP</dfn>
-:: The IP address of the server from which the user agent recieved the
-       certificate of the signed exchange, if available. Otherwise, an empty
-       string.
+:: The IP address of the server from which the user agent received the signed
+    exchange, if available. Otherwise, an empty string.
+: <dfn>cert server IP list</dfn>
+:: The list of IP address of the server from which the user agent received the
+    certificate of the signed exchange, if available. Otherwise, an empty list.
 
 </dl>
 
@@ -509,9 +501,9 @@ This section defines how to load the formats defined in
 [[draft-yasskin-httpbis-origin-signed-exchanges-impl-03]].
 
 <dfn>Parsing a signed exchange</dfn> of version |version| from a [=response=]
-|response| with a [=signed exchange report=] |report| in the context of an
-[=environment settings object=] |client| returns an [=exchange=] or a string
-which indicates an error returned by the following steps:
+|response| in the context of an [=environment settings object=] |client|,
+reporting to a [=signed exchange report=] |report| returns an [=exchange=] or a
+string which indicates an error returned by the following steps:
 
 1. Assert: This algorithm is running [=in parallel=].
 1. Assert: The [=signed exchange version=] of |response| is, if |version| is
@@ -523,20 +515,20 @@ which indicates an error returned by the following steps:
 
     </dl>
 1. If |response|'s [=response/URL=]'s [=url/origin=] is not a [=potentially
-    trustworthy origin=], return `"non_secure_origin"`.
+    trustworthy origin=], return "[=signed exchange report/non_secure_origin=]".
 
     Note: This ensures that the privacy properties of retrieving an HTTPS
     resource via a signed exchange are no worse than retrieving it via TLS.
 
 1. Let |bodyStream| be |response|'s [=response/body=]'s [=body/stream=].
-1. If |bodyStream| is null, return `"parse_error"`.
+1. If |bodyStream| is null, return "[=signed exchange report/parse_error=]".
 1. Let |stream| be a [=new read buffer=] for |bodyStream|.
 1. Let (|magic|, |requestUrlBytes|, |requestUrl|) be the result of [=parsing the
     invariant prefix=] from |stream|. If returns a failure, return
-    `"parse_error"`.
+    "[=signed exchange report/parse_error=]".
 1. Set |report|'s [=signed exchange report/inner URL=] to |requestUrl|.
 1. If |magic| is not the following value, depending on |version|, return
-    `"parse_error"`:
+    "[=signed exchange report/parse_error=]":
     <dl class="switch">
     : `b2`
     :: `` `sxg1-b2\0` ``
@@ -551,24 +543,26 @@ which indicates an error returned by the following steps:
 1. Let |encodedHeaderLength| be the result of [=read buffer/reading=] 3 bytes
     from |stream|.
 1. If |encodedSigLength| or |encodedHeaderLength| is a failure, return
-    `"parse_error"`.
+    "[=signed exchange report/parse_error=]".
 1. Let |sigLength| be the result of decoding |encodedSigLength| as a big-endian
     integer.
 1. Let |headerLength| be the result of decoding |encodedHeaderLength| as a
     big-endian integer.
-1. If |sigLength| > 16384 or |headerLength| > 524288, return `"parse_error"`.
+1. If |sigLength| > 16384 or |headerLength| > 524288, return
+    "[=signed exchange report/parse_error=]".
 1. Let |signature| be the result of [=read buffer/reading=] |sigLength| bytes
     from |stream|.
-1. If |signature| is a failure, return `"parse_error"`.
+1. If |signature| is a failure, return "[=signed exchange report/parse_error=]".
 1. Let |parsedSignature| be the result of [=parsing the Signature header field=]
-    |signature| with |report| in the context of |client|.
+    |signature| in the context of |client| reporting to with |report|.
 1. If |parsedSignature| is not an [=exchange signature=], return it.
 1. Let |headerBytes| be the result of [=read buffer/reading=] |headerLength|
     bytes from |stream|.
-1. If |headerBytes| is a failure, return `"parse_error"`.
+1. If |headerBytes| is a failure, return
+    "[=signed exchange report/parse_error=]".
 1. If |parsedSignature| [=exchange signature/is not valid=] for |headerBytes|
     and |requestUrlBytes|, and signed exchange version |version|, return
-    `"signature_verification_error"`.
+    "[=signed exchange report/signature_verification_error=]".
 1. Let |parsedExchange| be, if |version| is:
     <dl class="switch">
     : `b2`
@@ -578,20 +572,22 @@ which indicates an error returned by the following steps:
     :: the result of [=parsing b3 CBOR headers=] given |headerBytes| and
         |requestUrl|.
 1. If |parsedSignature| [=exchange signature/does not establish cross-origin
-    trust=] for |parsedExchange|, return `"cert_verification_error"`.
+    trust=] for |parsedExchange|, return
+    "[=signed exchange report/cert_verification_error=]".
 1. Set |parsedExchange|'s [=exchange/response=]'s [=response/HTTPS state=] to
     either "`deprecated`" or "`modern`".
 
     Note: See <a spec="fetch">HTTP-network fetch</a> for details of this choice.
 1. If |parsedExchange|'s [=exchange/response=]'s [=response/status=] is a
     [=redirect status=] or the [=signed exchange version=] of |parsedExchange|'s
-    [=exchange/response=] is not undefined, return `"parse_error"`.
+    [=exchange/response=] is not undefined, return
+    "[=signed exchange report/parse_error=]".
 
     Note: This might simplify the UA's implementation, since it doesn't have to
     handle nested signed exchanges.
-1. [=Read a body=] from |stream| into |parsedExchange|'s [=exchange/response=]
-    using |parsedSignature| to check its integrity. If this is a failure, return
-    `"mi_error"`.
+1. Run [=read a body=] from |stream| into |parsedExchange|'s
+    [=exchange/response=] using |parsedSignature| to check its integrity. If
+    this returns an error, return it.
 
     Note: Typically this body’s stream is still being enqueued to after
     returning.
@@ -604,7 +600,8 @@ section.
 
 <dfn>Parsing the invariant prefix</dfn> from a [=read buffer=] |stream| returns
 a failure or the triple of a [=byte sequence=] |magic|, [=byte sequence=]
-|fallbackUrlBytes|, and [=URL=] |fallbackUrl| returned by the following steps:
+|fallbackUrlBytes|, and [=URL=] |fallbackUrl|, as described by the following
+steps:
 
 1. Assert: This algorithm is running [=in parallel=].
 1. Let |magic| be the result of [=read buffer/reading=] 8 bytes from |stream|.
@@ -628,22 +625,22 @@ a failure or the triple of a [=byte sequence=] |magic|, [=byte sequence=]
 
 <h3 algorithm id="parsing-signature">Parsing a Signature Header Field</h3>
 
-<dfn>Parsing the Signature header field</dfn> |signatureString| with a
-[=signed exchange report=] |report| in the context of an
-[=environment settings object=] |client| returns an [=exchange signature=] or
-a string which indicates an error returned by the following steps:
+<dfn>Parsing the Signature header field</dfn> |signatureString| in the context
+of an [=environment settings object=] |client|, reporting to a
+[=signed exchange report=] |report| returns an [=exchange signature=] or
+a string which indicates an error, as described by the following steps:
 
 1. Assert: This algorithm is running [=in parallel=].
 1. If |signatureString| contains any bytes that aren't [=ASCII bytes=], return
-    `"parse_error"`.
+    "[=signed exchange report/parse_error=]".
 1. Let |parsed| be the result of [=Parsing HTTP1 Header Fields into Structured
     Headers=] given an <var ignore>input_string</var> of the [=ASCII decoding=]
     of |signatureString| and a <var ignore>header_type</var> of "param-list".
-1. If |parsed| has more than one element, return `"parse_error"`.
+1. If |parsed| has more than one element, "[=signed exchange report/parse_error=]".
 
     Note: This limitation of current implementations will go away in the future.
 1. If any of the parameters of |parsed|[0] listed here doesn't have the
-    associated type, return `"parse_error"`:
+    associated type, "[=signed exchange report/parse_error=]".
 
     : Byte sequence
     :: "sig", "cert-sha256"
@@ -659,10 +656,10 @@ a string which indicates an error returned by the following steps:
     (`/`).
 1. Let |certUrl| be the result of running the [=URL parser=] on the "cert-url"
     parameter of |parsed|[0].
-1. Set |report|'s [=signed exchange report/cert URL=] to |certUrl|.
+1. Append |certUrl| to |report|'s [=signed exchange report/cert URL list=].
 1. If |certUrl| is a failure, if it has a non-null [=url/fragment=], or if its
     [=url/scheme=] is something other than `"https"` or `"data"`, return
-    `"parse_error"`.
+    "[=signed exchange report/parse_error=]".
 1. Set |result|'s [=exchange signature/certSha256=] to the "cert-sha256"
     parameter of |parsed|[0].
 1. Set |result|'s [=exchange signature/validityUrlBytes=] to the [=ASCII
@@ -671,7 +668,7 @@ a string which indicates an error returned by the following steps:
     "validity-url" parameter of |parsed|[0]..
 1. If |validityUrl| is a failure, if it has a non-null [=url/fragment=], or if
     its [=url/scheme=] is something other than `"https"`, return
-    `"parse_error"`.
+    "[=signed exchange report/parse_error=]".
 1. Set |result|'s [=exchange signature/validityUrl=] to |validityUrl|.
 1. Set |result|'s [=exchange signature/date=] to the "date" parameter of
     |parsed|[0].
@@ -679,9 +676,10 @@ a string which indicates an error returned by the following steps:
     parameter of |parsed|[0].
 1. If |result|'s [=exchange signature/expiration time=] or |result|'s [=exchange
     signature/date=] is less than 0 or greater than 2<sup>63</sup>-1, return
-    `"parse_error"`.
+    "[=signed exchange report/parse_error=]".
 1. If |result|'s [=exchange signature/expiration time=] &lt;= |result|'s
-    [=exchange signature/date=], return `"parse_error"`.
+    [=exchange signature/date=], return
+    "[=signed exchange report/parse_error=]".
 1. Set |result|'s [=exchange signature/certificate chain=] to the result of
     [=handling the certificate reference=] |certUrl| with a hash of |result|'s
     [=exchange signature/certSha256=] and |report| in the context of |client|.
@@ -691,9 +689,10 @@ a string which indicates an error returned by the following steps:
 <h4 algorithm id="handling-cert-url">Handling the certificate reference</h4>
 
 <dfn>Handling the certificate reference</dfn> |certUrl| with the SHA-256 hash
-|certSha256| and a [=signed exchange report=] |report|, in the context of an
-[=environment settings object=] |client|, returns a [=certificate chain=] or a
-string which indicates an error returned by the following steps:
+|certSha256| in the context of an[=environment settings object=] |client|
+reporting to a [=signed exchange report=] |report|, returns a
+[=certificate chain=] or a string which indicates an error, as described by the
+following steps:
 
 1. Assert: This algorithm is running [=in parallel=].
 1. Let |certRequest| be a new [=request=] with the following items:
@@ -709,29 +708,31 @@ string which indicates an error returned by the following steps:
     : [=request/mode=]
     :: "`cors`"
 1. Let |certResponse| be the result of [=fetching=] |certRequest|.
-1. Set |report|'s [=signed exchange report/cert server IP=] to the IP address
-    of the server to which the user agent recieved the |certResponse|, if
-    available.
+1. Append the IP address of the server from which the user agent received the
+    |certResponse| to |report|'s [=signed exchange report/cert server IP list=],
+    if available.
 1. If |certResponse|'s [=response/status=] is not `200`, return
-    `"cert_fetch_error"`.
+    "[=signed exchange report/cert_fetch_error=]".
 1. Let |certMimeType| be the result of [=header list/extracting a MIME type=]
     from |certResponse|'s [=response/header list=].
 1. If |certMimeType| is a failure or its [=MIME type/essence=] is not
-    `"application/cert-chain+cbor"`, return `"cert_fetch_error"`.
+    `"application/cert-chain+cbor"`, return
+    "[=signed exchange report/cert_fetch_error=]".
 1. If |certResponse|'s [=response/body=] is null or that body's [=body/stream=]
-    is null, return `"cert_parse_error"`.
+    is null, return "[=signed exchange report/cert_parse_error=]".
 1. Let |bytes| be the result of [=ReadableStream/read all bytes|reading all
     bytes=] from |certResponse|'s [=response/body=]'s [=body/stream=] with a
     [=ReadableStream/get a reader|new reader=] over the same stream.
 1. Wait for |bytes| to settle.
-1. If |bytes| was rejected, return `"cert_parse_error"`.
+1. If |bytes| was rejected, return "[=signed exchange report/cert_parse_error=]".
 1. Let |chain| be the [=certificate chain=] produced by parsing |bytes|' value
     using the [=cert-chain CDDL=]. If |bytes|'s value doesn't match this CDDL or
-    isn't [=canonically-encoded CBOR=], return `"cert_parse_error"`.
+    isn't [=canonically-encoded CBOR=], return
+     "[=signed exchange report/cert_parse_error=]".
 1. Assert: |chain| has at least one [=list/item=].
 1. If the [=SHA-256=] hash of |chain|'s [=certificate chain/leaf=]'s [=augmented
     certificate/certificate=] is not equal to |certSha256|, return
-    `"signature_verification_error"`.
+     "[=signed exchange report/signature_verification_error=]".
 1. Return |chain|.
 
 <h3 algorithm id="the-signed-message">The signed message</h3>
@@ -970,17 +971,20 @@ To <dfn lt="reading a body|read a body">read a body</dfn> from a [=read buffer=]
             `<encoded digest output>`.
 
         1. Let |mi| be the element of |instance-digests| that starts with
-            `"mi-sha256-03="`. If there is no such element, return a failure.
+            `"mi-sha256-03="`. If there is no such element, return an error
+            string "[=signed exchange report/invalid_integrity_header=]".
         1. Let |codings| be the result of [=header list/getting, decoding, and
             splitting=] `` `content-encoding` `` in |response|'s
             [=response/header list=].
-        1. If |codings| doesn't include `"mi-sha256-03"`, return a failure.
+        1. If |codings| doesn't include `"mi-sha256-03"`, return an error string
+            "[=signed exchange report/invalid_integrity_header=]".
         1. Assert: [=Handle content codings=] used the value of |mi| as the
             [=integrity proof for the first record=] when decoding the
             `mi-sha256-03` content encoding to produce the bytes in |stream|.
 
     : Anything else
-    :: Return a failure.
+    :: Return an error string
+        "[=signed exchange report/invalid_integrity_header=]".
 
     </dl>
 1. Let |body| be a new [=body=].
@@ -1051,9 +1055,36 @@ A [=request=] |browserRequest| <dfn>matches the stored exchange</dfn>
     Behavior=] returning a list of lists.
 1. Return "match".
 
+<h3 algorithm id="create-a-new-report">Create a new signed exchange report</h3>
+To <dfn>create a new signed exchange report</dfn> with |request| and
+|actualResponse|, the UA MUST:
+
+1. Let |report| be a new [=signed exchange report=] struct.
+1. Set |report|'s [=signed exchange report/outer request=] to |request|.
+1. Set |report|'s [=signed exchange report/outer response=] to |actualResponse|.
+1. Set |report|'s [=signed exchange report/server IP=] to the IP address of the
+    server from which the user agent received the |actualResponse|, if
+    available.
+1. Return |report|.
+
+<h3 algorithm id="wait-and-queue-a-report">Wait and queue a report</h3>
+To <dfn>wait and queue a report for</dfn> |parsedExchange| and |report|, the UA
+MUST:
+
+1. Wait until |parsedExchange|'s [=response/body=]'s [=body/stream=] is
+    [=ReadableStream/closed=] or [=ReadableStream/errored=].
+1. If |parsedExchange|'s [=response/body=]'s [=body/stream=] is
+    [=ReadableStream/closed=], run [=queue a signed exchange report=] |report|
+    with "[=signed exchange report/ok=]" as the result and abort these steps.
+1. If |parsedExchange|'s [=response/body=]'s [=body/stream=] is
+    [=ReadableStream/errored=], run [=queue a signed exchange report=] |report|
+    with "[=signed exchange report/mi_error=]" as the result.
+
 <h3 algorithm id="queue-report">Queuing signed exchange report</h3>
 
-<dfn>Queuing signed exchange report</dfn> |report| is the following steps:
+To <dfn>queue a signed exchange report</dfn> |report| and |result|, the UA MUST:
+
+1. Set |report|'s [=signed exchange report/result=] to |result|.
 
 1. Let |report body| and |policy| be the result of
     [=generate a network error report=]</a> with |report|'s
@@ -1062,30 +1093,46 @@ A [=request=] |browserRequest| <dfn>matches the stored exchange</dfn>
 
 1. If |report body|'s `"type"` is `"dns.address_changed"`, abort these steps.
 
+    Note: This means that the NEL report was downgraded because the IP addresses
+    of the server and the |policy| don't match. In this case,
+    [=deliver a network report=] algorithm MUST be called with the error report
+    while handling the response. So we don't need to send the same error report
+    while processing the response as a signed exchange.
+
 1. Add a new property `"sxg"` to |report body| with a new ECMAScript object with
      the following properties:
 
-    * outer_url: |report|'s [=signed exchange report/outer request=]'s
+    * `outer_url`: The [=ASCII encoding=] of the [=URL serializer|serialization=]
+          of |report|'s [=signed exchange report/outer request=]'s
           [=request/url=].
-    * inner_url: |report|'s [=signed exchange report/inner URL=].
-    * cert_url: |report|'s [=signed exchange report/cert URL=].
+    * `inner_url`: |report|'s [=signed exchange report/inner URL=].
+    * `cert_url`: |report|'s [=signed exchange report/cert URL list=].
 
 1. Set |report body|'s `"phase"` to `"sxg"`.
 
 1. Set |report body|'s `"type"` to the result of concatenating a string `"sxg."`
      and the |report|'s [=signed exchange report/result=].
 
-1. If |report body|'s `"type"` is not `"sxg.ok"` and |report body|'s `"sxg"`'s
-    `"cert_url"`'s [=url/scheme=] is not `"data"`:
+1. If |report body|'s `"sxg"`'s `"cert_url"`'s [=url/scheme=] is not `"data"`
+    and |report|'s [=signed exchange report/result=] is
+    "[=signed exchange report/signature_verification_error=]" or
+    "[=signed exchange report/cert_verification_error=]" or
+    "[=signed exchange report/cert_fetch_error=]" or
+    "[=signed exchange report/cert_parse_error=]":
 
-    1. If |report body|'s `"sxg"`'s `"outer_url"`'s [=url/origin=] is different
-        from |report body|'s `"sxg"`'s `"cert_url"`'s [=url/origin=] or
+    1. If |report|'s [=signed exchange report/outer request=]'s
+        [=request/url=]'s [=url/origin=] is different from any [=url/origin=] of
+        the URLs in |report|'s [=signed exchange report/cert URL list=], or
         |report|'s [=signed exchange report/server IP=] is different from
-        |report|'s [=signed exchange report/cert server IP=]:
+        any of the IP address in |report|'s
+        [=signed exchange report/cert server IP list=]:
 
         1. Set |report body|'s `"type"` to `"sxg.failed"`.
         1. Set |report body|'s `"elapsed_time"` to 0.
 
+    Note: This step "downgrades" a Signed Exchange report if the certificate
+    was served from the different server from the server of `"outer_url"`. This
+    is intended to avoid leaking the information about the certificate server.
 1. [=Deliver a network report=]</a> with |report body| and |policy| and
     |report|'s [=signed exchange report/outer request=].
 

--- a/loading.bs
+++ b/loading.bs
@@ -521,8 +521,6 @@ which indicates an error returned by the following steps:
     :: `"b3"`
 
     </dl>
-1. Set |report|'s [=signed exchange report/inner URL=] to |response|'s
-    [=response/URL=].
 1. If |response|'s [=response/URL=]'s [=url/origin=] is not a [=potentially
     trustworthy origin=], return `"non_secure_origin"`.
 
@@ -535,6 +533,7 @@ which indicates an error returned by the following steps:
 1. Let (|magic|, |requestUrlBytes|, |requestUrl|) be the result of [=parsing the
     invariant prefix=] from |stream|. If returns a failure, return
     `"parse_error"`.
+1. Set |report|'s [=signed exchange report/inner URL=] to |requestUrl|.
 1. If |magic| is not the following value, depending on |version|, return
     `"parse_error"`:
     <dl class="switch">

--- a/loading.bs
+++ b/loading.bs
@@ -277,7 +277,7 @@ add the following steps:
             |actualResponse| in the context of |request|'s [=request/client=],
             reporting to |report|.
         1. If |parsedExchange| is not an [=exchange=], run
-            [=queue a signed exchange report=] |report| and
+            [=queue a signed exchange report=] |report| with
             |parsedExchange| as the result, and return a [=network error=].
         1. [=In parallel=], [=wait and queue a report for=] |parsedExchange| and
             |report|.
@@ -397,8 +397,8 @@ A signed exchange report is a [=struct=] with the following items:
 
 <dl dfn-for="signed exchange report">
 : <dfn>result</dfn>
-:: The result string of loading signed exchange. This must be one of an empty
-    string, "<dfn>`ok`</dfn>", "<dfn>`mi_error`</dfn>",
+:: The result string of loading signed exchange. This must be unset or one of
+    "<dfn>`ok`</dfn>", "<dfn>`mi_error`</dfn>",
     "<dfn>`non_secure_origin`</dfn>", "<dfn>`parse_error`</dfn>",
     "<dfn>`invalid_integrity_header`</dfn>",
     "<dfn>`signature_verification_error`</dfn>",
@@ -412,8 +412,8 @@ A signed exchange report is a [=struct=] with the following items:
 :: The logical [=URL=] of the signed exchange, if available. Otherwise, an empty
     string.
 : <dfn>cert URL list</dfn>
-:: The list of [=URL=] of the first "`cert-url`" parameter of signed exchange,
-    if available. Otherwise, an empty list.
+:: The list of [=URL=] which first element is the first "`cert-url`" parameter
+    of signed exchange, if available. Otherwise, an empty list.
 : <dfn>server IP</dfn>
 :: The IP address of the server from which the user agent received the signed
     exchange, if available. Otherwise, an empty string.
@@ -502,7 +502,7 @@ This section defines how to load the formats defined in
 <dfn>Parsing a signed exchange</dfn> of version |version| from a [=response=]
 |response| in the context of an [=environment settings object=] |client|,
 reporting to a [=signed exchange report=] |report| returns an [=exchange=] or a
-string which indicates an error returned by the following steps:
+string which indicates an error  as described by the following steps:
 
 1. Assert: This algorithm is running [=in parallel=].
 1. Assert: The [=signed exchange version=] of |response| is, if |version| is
@@ -1081,7 +1081,8 @@ MUST:
 
 <h3 algorithm id="queue-report">Queuing signed exchange report</h3>
 
-To <dfn>queue a signed exchange report</dfn> |report| and |result|, the UA MUST:
+To <dfn>queue a signed exchange report</dfn> |report| with |result| as the
+result, the UA MUST:
 
 1. Set |report|'s [=signed exchange report/result=] to |result|.
 
@@ -1093,19 +1094,21 @@ To <dfn>queue a signed exchange report</dfn> |report| and |result|, the UA MUST:
 1. If |report body|'s `"type"` is `"dns.address_changed"`, abort these steps.
 
     Note: This means that the NEL report was downgraded because the IP addresses
-    of the server and the |policy| don't match. In this case,
-    [=deliver a network report=] algorithm MUST be called with the error report
-    while handling the response. So we don't need to send the same error report
-    while processing the response as a signed exchange.
+    of the server and the |policy| don't match. In this case, UA have called
+    [=deliver a network report=] algorithm with the error report while handling
+    the response. So we don't need to send the same error report while
+    processing the response as a signed exchange.
 
 1. Add a new property `"sxg"` to |report body| with a new ECMAScript object with
      the following properties:
 
-    * `outer_url`: The [=ASCII encoding=] of the [=URL serializer|serialization=]
-          of |report|'s [=signed exchange report/outer request=]'s
-          [=request/url=].
-    * `inner_url`: |report|'s [=signed exchange report/inner URL=].
-    * `cert_url`: |report|'s [=signed exchange report/cert URL list=].
+    * `outer_url`: The [=URL serializer|serialization=] of |report|'s
+          [=signed exchange report/outer request=]'s [=request/url=].
+    * `inner_url`: The [=URL serializer|serialization=] of |report|'s
+          [=signed exchange report/inner URL=].
+    * `cert_url`: The [=sequence type=] of the result of
+          [=URL serializer|serialization=] of each element of |report|'s
+          [=signed exchange report/cert URL list=].
 
 1. Set |report body|'s `"phase"` to `"sxg"`.
 

--- a/loading.bs
+++ b/loading.bs
@@ -148,7 +148,6 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
         text: SHA-256; url: #
 spec: network-error-logging; urlPrefix: https://w3c.github.io/network-error-logging/#
     type: dfn
-        text: generate a network error report ; url: generate-a-network-error-report
         text: deliver a network report ; url: deliver-a-network-report
 </pre>
 <pre class='link-defaults'>


### PR DESCRIPTION
This change introduces the signed exchange report for distributors discussed at https://github.com/w3c/network-error-logging/issues/99#issuecomment-453421388.

Exemple:
```
{
  "type": "network-error",
  "url": "https://publisher.example/article.html",
  "age": 234,
  "user_agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) ...",
  "body": {
    "referrer": "https://aggregator.example/article.html",
    "sampling_fraction": 1,
    "server_ip": "123.122.121.120",  // The IP address of distributor.example.
    "protocol": "http/1.1",
    "method": "GET",
    "status_code": 200,
    "elapsed_time": 1234,
    "phase": "sxg",
    "type": "sxg.failed",

    "sxg": {
      "outer_url": "https://distributor.example/publisher.example/article.html.sxg",
      "inner_url": "https://publisher.example/article.html",
      "cert_url": "https://distributor.example/publisher.example/cert"
    },
  }
}
```

This spec change requires the new OPTIONAL `additional body` argument of the algorithm of "Generate a network error report" of Network Error Logging spec. https://github.com/w3c/network-error-logging/pull/100


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/horo-t/webpackage/pull/374.html" title="Last updated on Feb 15, 2019, 2:32 AM UTC (7365813)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webpackage/374/aa31685...horo-t:7365813.html" title="Last updated on Feb 15, 2019, 2:32 AM UTC (7365813)">Diff</a>