### PR TITLE
Define a CAA parameter governing CanSignHttpExchanges cert issuance.

### DIFF
--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -979,6 +979,16 @@ extension. This OID might or might not be used as the final OID for the
 extension, so certificates including it might need to be reissued once the final
 RFC is published.
 
+### Extensions to the CAA Record: cansignhttpexchanges Parameter {#caa-cansignhttpexchanges}
+
+A CAA parameter "cansignhttpexchanges" is defined for the "issue" and
+"issuewild" properties defined by {{!RFC6844}}.  The value of this parameter, if
+specified, SHOULD be "yes".
+
+If the "cansignhttpexchanges" parameter is not present and equal to "yes", the
+CA indicated by the "issue" or "issuewild" property SHOULD NOT issue certificates
+with the CanSignHttpExchanges extension defined in {{cross-origin-cert-req}}.
+
 # Transferring a signed exchange {#transfer}
 
 A signed exchange can be transferred in several ways, of which three are
@@ -1650,6 +1660,13 @@ Restrictions on usage:  N/A
 Author:  See Authors' Addresses section.
 
 Change controller:  IESG
+
+## The cansignhttpexchanges CAA Parameter {#iana-caa-cansignhttpexchanges}
+
+There are no IANA considerations for this parameter. As per the CAA
+specification, the parameter namespace for the CAA "issue" and "issuewild"
+properties has CA-defined semantics. This document merely specifies a
+RECOMMENDED semantic for parameters of the name "cansignhttpexchanges".
 
 --- back
 

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -2136,5 +2136,6 @@ draft-02
 
 # Acknowledgements
 
-Thanks to Devin Mullins, Ilari Liusvaara, Justin Schuh, Mark Nottingham, Mike
-Bishop, Ryan Sleevi, and Yoav Weiss for comments that improved this draft.
+Thanks to Andrew Ayer, Devin Mullins, Ilari Liusvaara, Justin Schuh, Mark
+Nottingham, Mike Bishop, Ryan Sleevi, and Yoav Weiss for comments that improved
+this draft.

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -985,9 +985,10 @@ A CAA parameter "cansignhttpexchanges" is defined for the "issue" and
 "issuewild" properties defined by {{!RFC6844}}.  The value of this parameter, if
 specified, SHOULD be "yes".
 
-If the "cansignhttpexchanges" parameter is not present and equal to "yes", the
-CA indicated by the "issue" or "issuewild" property SHOULD NOT issue certificates
-with the CanSignHttpExchanges extension defined in {{cross-origin-cert-req}}.
+A CA SHOULD NOT issue certificates with the CanSignHttpExchanges extension
+defined in {{cross-origin-cert-req}} unless an applicable issue or issuewild
+property exists for the CA, and the "cansignhttpexchanges" parameter is present
+on the property and is equal to "yes".
 
 The CA/Browser Forum Baseline Requirements ({{BRs}}) are expected to establish
 requirements around the treatment of this parameter.

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -989,6 +989,9 @@ If the "cansignhttpexchanges" parameter is not present and equal to "yes", the
 CA indicated by the "issue" or "issuewild" property SHOULD NOT issue certificates
 with the CanSignHttpExchanges extension defined in {{cross-origin-cert-req}}.
 
+The CA/Browser Forum Baseline Requirements ({{BRs}}) are expected to establish
+requirements around the treatment of this parameter.
+
 # Transferring a signed exchange {#transfer}
 
 A signed exchange can be transferred in several ways, of which three are

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -988,7 +988,7 @@ RFC is published.
 
 A CAA parameter "cansignhttpexchanges" is defined for the "issue" and
 "issuewild" properties defined by {{!RFC6844}}.  The value of this parameter, if
-specified, SHOULD be "yes".
+specified, MUST be "yes".
 
 # Transferring a signed exchange {#transfer}
 

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -2059,6 +2059,7 @@ draft-06
 
 * Add a security consideration for future-dated OCSP responses and for stolen
   private keys.
+* Define a CAA parameter to opt into certificate issuance.
 
 draft-05
 

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -963,6 +963,11 @@ able to make even one unauthorized signature.
 
 Conforming CAs MUST NOT mark this extension as critical.
 
+A conforming CA MUST NOT issue certificates with this extension unless an
+applicable "issue" or "issuewild" CAA property ({{!RFC6844}}) exists for the CA,
+and the "cansignhttpexchanges" parameter ({{caa-cansignhttpexchanges}}) is
+present on the property and is equal to "yes".
+
 Clients MUST NOT accept certificates with this extension in TLS connections
 (Section 4.4.2.2 of {{!RFC8446}}).
 
@@ -984,14 +989,6 @@ RFC is published.
 A CAA parameter "cansignhttpexchanges" is defined for the "issue" and
 "issuewild" properties defined by {{!RFC6844}}.  The value of this parameter, if
 specified, SHOULD be "yes".
-
-A CA SHOULD NOT issue certificates with the CanSignHttpExchanges extension
-defined in {{cross-origin-cert-req}} unless an applicable issue or issuewild
-property exists for the CA, and the "cansignhttpexchanges" parameter is present
-on the property and is equal to "yes".
-
-The CA/Browser Forum Baseline Requirements ({{BRs}}) are expected to establish
-requirements around the treatment of this parameter.
 
 # Transferring a signed exchange {#transfer}
 
@@ -1667,10 +1664,7 @@ Change controller:  IESG
 
 ## The cansignhttpexchanges CAA Parameter {#iana-caa-cansignhttpexchanges}
 
-There are no IANA considerations for this parameter. As per the CAA
-specification, the parameter namespace for the CAA "issue" and "issuewild"
-properties has CA-defined semantics. This document merely specifies a
-RECOMMENDED semantic for parameters of the name "cansignhttpexchanges".
+There are no IANA considerations for this parameter.
 
 --- back
 

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -963,10 +963,13 @@ able to make even one unauthorized signature.
 
 Conforming CAs MUST NOT mark this extension as critical.
 
-A conforming CA MUST NOT issue certificates with this extension unless an
-applicable "issue" or "issuewild" CAA property ({{!RFC6844}}) exists for the CA,
-and the "cansignhttpexchanges" parameter ({{caa-cansignhttpexchanges}}) is
-present on the property and is equal to "yes".
+A conforming CA MUST NOT issue certificates with this extension unless, for each
+dNSName in the subjectAltName extension of the certificate to be issued:
+
+1. An "issue" or "issuewild" CAA property ({{!RFC6844}}) exists that authorizes
+   the CA to issue the certificate; and
+1. The "cansignhttpexchanges" parameter ({{caa-cansignhttpexchanges}}) is
+   present on the property and is equal to "yes"
 
 Clients MUST NOT accept certificates with this extension in TLS connections
 (Section 4.4.2.2 of {{!RFC8446}}).


### PR DESCRIPTION
This gives a stronger indication that the domain owner has opted into the new
security risks than just that a CA issued a certificate with the extension.

@AGWA, how's this look? https://tools.ietf.org/html/draft-ietf-acme-caa-06#section-3 has a MUST, which I've downgraded to a SHOULD here after reading draft-ietf-acme-caa's IANA considerations.

[Preview](https://jyasskin.github.io/webpackage/define-caa/draft-yasskin-http-origin-signed-responses.html#cross-origin-cert-req); [Diff](https://tools.ietf.org/rfcdiff?url1=https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.txt&url2=https://jyasskin.github.io/webpackage/define-caa/draft-yasskin-http-origin-signed-responses.txt)