### PR TITLE
Bound validity periods to 90 days.

### DIFF
--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -961,6 +961,9 @@ able to make even one unauthorized signature.
 Certificates with this extension MUST be revoked if an unauthorized entity is
 able to make even one unauthorized signature.
 
+Certificates with this extension MUST have a Validity Period no greater than 90
+days.
+
 Conforming CAs MUST NOT mark this extension as critical.
 
 A conforming CA MUST NOT issue certificates with this extension unless, for each
@@ -2061,6 +2064,7 @@ draft-06
 * Add a security consideration for future-dated OCSP responses and for stolen
   private keys.
 * Define a CAA parameter to opt into certificate issuance.
+* Limit certificate lifetimes to 90 days.
 
 draft-05
 

--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -990,6 +990,15 @@ extension. This OID might or might not be used as the final OID for the
 extension, so certificates including it might need to be reissued once the final
 RFC is published.
 
+Some certificates have already been issued with this extension and with validity
+periods longer than 90 days. These certificates will not immediately be treated
+as invalid. Instead:
+
+* Clients MUST reject certificates with this extension that were issued after
+  2019-05-01 and have a Validity Period longer than 90 days.
+* After 2019-08-01, clients MUST reject all certificates with this extension
+  that have a Validity Period longer than 90 days.
+
 ### Extensions to the CAA Record: cansignhttpexchanges Parameter {#caa-cansignhttpexchanges}
 
 A CAA parameter "cansignhttpexchanges" is defined for the "issue" and


### PR DESCRIPTION
This is not necessarily the limit we'll want in the long run, but it
helps ensure that any future changes can go into effect reasonably
quickly.

I won't submit this until I have some indication that the folks who have already started experimenting with signed exchanges can handle 90-day certificates.

@clintwilson, I want to make sure this doesn't cause any problems for you, since I believe Digicert has been issuing certificates with validity periods longer than 90 days. I don't intend to declare that any of your existing certificates are out of bounds.

@AGWA, this isn't intended to stop discussion on #378, just to put _some_ limit in place while we figure out what the right limit is.

Preview: https://jyasskin.github.io/webpackage/90-day-lifetime/draft-yasskin-http-origin-signed-responses.html#cross-origin-cert-req
Diff: https://tools.ietf.org/rfcdiff?url1=https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.txt&url2=https://jyasskin.github.io/webpackage/90-day-lifetime/draft-yasskin-http-origin-signed-responses.txt