### PR TITLE
go: Update structuredheader to header-structure-09

### DIFF
--- a/go/signedexchange/verifier.go
+++ b/go/signedexchange/verifier.go
@@ -26,7 +26,7 @@ import (
 const maxMIRecordSize = 16384
 
 type Signature struct {
-	Label       structuredheader.Identifier
+	Label       structuredheader.Token
 	Sig         []byte
 	Integrity   string
 	CertUrl     string


### PR DESCRIPTION
- Change the refs to draft-ietf-httpbis-header-structure-09
- Use the new "key" type for parameter keys
- Identifier was renamed to Token