### PR TITLE
Fix #393: Use the right type for the integrity header.

### DIFF
--- a/loading.bs
+++ b/loading.bs
@@ -397,8 +397,8 @@ An exchange signature is a [=struct=] with the following items:
 :: A [=byte sequence=] holding the [=SHA-256=] hash that verified the [=exchange
     signature/certificate chain=]'s [=certificate chain/leaf=].
 : <dfn>integrity header</dfn>
-:: A [=list=] that describes the response header and any of its parameters that
-    guard the integrity of the response payload.
+:: A [=list=] of [=ASCII strings=] that describes the response header and any of
+    its parameters that guard the integrity of the response payload.
 : <dfn>validityUrl</dfn>
 :: A [=URL=] describing where to update this signature.
 : <dfn>validityUrlBytes</dfn>
@@ -890,14 +890,12 @@ To <dfn lt="reading a body|read a body">read a body</dfn> from a [=read buffer=]
 |stream| into a [=response=] |response| using an [=exchange signature=]
 |signature| to check its integrity, the UA MUST:
 
-1. If |signature|'s [=exchange signature/integrity header=]'s first item is:
+1. If |signature|'s [=exchange signature/integrity header=] is:
 
     <dl class="switch">
 
-    : "digest/mi-sha256-03"
+    : «"`digest`", "`mi-sha256-03`"»
     ::
-        1. If the length of |signature|'s [=exchange signature/integrity header=]
-            isn't 1, return a failure.
         1. Let |instance-digests| be the result of [=header list/getting,
             decoding, and splitting=] `` `digest` `` from |response|'s
             [=response/header list=].


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#exchange-signature-integrity-header, #read-a-body
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/webpackage/pull/394.html" title="Last updated on Feb 7, 2019, 10:49 PM UTC (d8b73dd)">Preview</a> (<a href="https://pr-preview.s3.amazonaws.com/jyasskin/webpackage/pull/394.html#exchange-signature-integrity-header" title="#exchange-signature-integrity-header">#exchange-signature-…</a>) (<a href="https://pr-preview.s3.amazonaws.com/jyasskin/webpackage/pull/394.html#read-a-body" title="#read-a-body">#read-a-body</a>) | <a href="https://pr-preview.s3.amazonaws.com/WICG/webpackage/394/3997c75...jyasskin:d8b73dd.html" title="Last updated on Feb 7, 2019, 10:49 PM UTC (d8b73dd)">Diff</a>