### PR TITLE
dump-signedexchange: make validation success/failure more obvious

### DIFF
--- a/go/signedexchange/cmd/dump-signedexchange/main.go
+++ b/go/signedexchange/cmd/dump-signedexchange/main.go
@@ -39,14 +39,14 @@ func run() error {
 		return nil
 	}
 
-	e.PrettyPrintHeaders(os.Stdout)
-
 	if *flagVerify {
 		if err := verify(e); err != nil {
 			return err
 		}
+		fmt.Println()
 	}
 
+	e.PrettyPrintHeaders(os.Stdout)
 	e.PrettyPrintPayload(os.Stdout)
 
 	return nil


### PR DESCRIPTION
- Prints validation result at the top
- Adds a blank line between validation result and dump

Fixes #389.