### PR TITLE
go: Add strucured header writer

### DIFF
--- a/go/signedexchange/signedexchange_test.go
+++ b/go/signedexchange/signedexchange_test.go
@@ -105,9 +105,9 @@ func TestSignedExchange(t *testing.T) {
 		},
 	}
 	expectedSignatureHeader := map[version.Version]string{
-		version.Version1b1: "label; sig=*MEYCIQCbay5VbkR9mi4pnwDAJamuf7Fj1CWnEnJt6Uxm7YeqiwIhAL8JISyzF5sDhtUaEbNCE6vgv2NIKCkONzLgwL23UL6P*; validity-url=\"https://example.com/resource.validity\"; integrity=\"mi-draft2\"; cert-url=\"https://example.com/cert.msg\"; cert-sha256=*eLWHusI0YcDcHSG5nkYbyZddE2sidVyhx6iSYoJ+SFc=*; date=1517418800; expires=1517422400",
-		version.Version1b2: "label; sig=*MEUCIHNiDRQncQpVxW2x+woinMUTY8nuSQfi0mbJ5J6x7FZyAiEAgh6FH6PdncNCK8GHTwN3wfUUUFdjVswNi1PfIgCOwHk=*; validity-url=\"https://example.com/resource.validity\"; integrity=\"digest/mi-sha256-03\"; cert-url=\"https://example.com/cert.msg\"; cert-sha256=*eLWHusI0YcDcHSG5nkYbyZddE2sidVyhx6iSYoJ+SFc=*; date=1517418800; expires=1517422400",
-		version.Version1b3: "label; sig=*MEUCIEQPK0UKPm9/XP5Jko2V72vTrGlBqB9HHoOzhJmVPflmAiEAwCSBw98NhUhFGJaxL6ITT+QZBBeO7TCLAiHn1apY6Es=*; validity-url=\"https://example.com/resource.validity\"; integrity=\"digest/mi-sha256-03\"; cert-url=\"https://example.com/cert.msg\"; cert-sha256=*eLWHusI0YcDcHSG5nkYbyZddE2sidVyhx6iSYoJ+SFc=*; date=1517418800; expires=1517422400",
+		version.Version1b1: "label;cert-sha256=*eLWHusI0YcDcHSG5nkYbyZddE2sidVyhx6iSYoJ+SFc=*;cert-url=\"https://example.com/cert.msg\";date=1517418800;expires=1517422400;integrity=\"mi-draft2\";sig=*MEYCIQCbay5VbkR9mi4pnwDAJamuf7Fj1CWnEnJt6Uxm7YeqiwIhAL8JISyzF5sDhtUaEbNCE6vgv2NIKCkONzLgwL23UL6P*;validity-url=\"https://example.com/resource.validity\"",
+		version.Version1b2: "label;cert-sha256=*eLWHusI0YcDcHSG5nkYbyZddE2sidVyhx6iSYoJ+SFc=*;cert-url=\"https://example.com/cert.msg\";date=1517418800;expires=1517422400;integrity=\"digest/mi-sha256-03\";sig=*MEUCIHNiDRQncQpVxW2x+woinMUTY8nuSQfi0mbJ5J6x7FZyAiEAgh6FH6PdncNCK8GHTwN3wfUUUFdjVswNi1PfIgCOwHk=*;validity-url=\"https://example.com/resource.validity\"",
+		version.Version1b3: "label;cert-sha256=*eLWHusI0YcDcHSG5nkYbyZddE2sidVyhx6iSYoJ+SFc=*;cert-url=\"https://example.com/cert.msg\";date=1517418800;expires=1517422400;integrity=\"digest/mi-sha256-03\";sig=*MEUCIEQPK0UKPm9/XP5Jko2V72vTrGlBqB9HHoOzhJmVPflmAiEAwCSBw98NhUhFGJaxL6ITT+QZBBeO7TCLAiHn1apY6Es=*;validity-url=\"https://example.com/resource.validity\"",
 	}
 
 	testForEachVersion(t, func(ver version.Version, t *testing.T) {

--- a/go/signedexchange/signer.go
+++ b/go/signedexchange/signer.go
@@ -230,5 +230,5 @@ func (s *Signer) signatureHeaderValue(e *Exchange) (string, error) {
 			"date": s.Date.Unix(),
 			"expires": s.Expires.Unix(),
 		}}
-	return pi.ToString()
+	return pi.String()
 }

--- a/go/signedexchange/signer.go
+++ b/go/signedexchange/signer.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"net/url"
@@ -15,6 +14,7 @@ import (
 	"github.com/WICG/webpackage/go/signedexchange/cbor"
 	"github.com/WICG/webpackage/go/signedexchange/internal/bigendian"
 	"github.com/WICG/webpackage/go/signedexchange/internal/signingalgorithm"
+	"github.com/WICG/webpackage/go/signedexchange/structuredheader"
 	"github.com/WICG/webpackage/go/signedexchange/version"
 )
 
@@ -209,8 +209,6 @@ func (s *Signer) signatureHeaderValue(e *Exchange) (string, error) {
 		return "", err
 	}
 
-	label := "label"
-	sigb64 := base64.StdEncoding.EncodeToString(sig)
 	integrityStr := ""
 	switch e.Version {
 	case version.Version1b1:
@@ -220,13 +218,17 @@ func (s *Signer) signatureHeaderValue(e *Exchange) (string, error) {
 	default:
 		panic("not reached")
 	}
-	certUrl := s.CertUrl.String()
-	validityUrl := s.ValidityUrl.String()
-	certSha256b64 := base64.StdEncoding.EncodeToString(calculateCertSha256(s.Certs))
-	dateUnix := s.Date.Unix()
-	expiresUnix := s.Expires.Unix()
 
-	return fmt.Sprintf(
-		"%s; sig=*%s*; validity-url=%q; integrity=%q; cert-url=%q; cert-sha256=*%s*; date=%d; expires=%d",
-		label, sigb64, validityUrl, integrityStr, certUrl, certSha256b64, dateUnix, expiresUnix), nil
+	pi := structuredheader.ParameterisedIdentifier{
+		Label: "label",
+		Params: structuredheader.Parameters{
+			"sig": sig,
+			"validity-url": s.ValidityUrl.String(),
+			"integrity": integrityStr,
+			"cert-url": s.CertUrl.String(),
+			"cert-sha256": calculateCertSha256(s.Certs),
+			"date": s.Date.Unix(),
+			"expires": s.Expires.Unix(),
+		}}
+	return pi.ToString()
 }

--- a/go/signedexchange/structuredheader/writer.go
+++ b/go/signedexchange/structuredheader/writer.go
@@ -10,7 +10,7 @@ import (
 	"unicode"
 )
 
-func (ll ListOfLists) ToString() (string, error) {
+func (ll ListOfLists) String() (string, error) {
 	var b strings.Builder
 	if err := ll.serialize(&b); err != nil {
 		return "", err
@@ -18,7 +18,7 @@ func (ll ListOfLists) ToString() (string, error) {
 	return b.String(), nil
 }
 
-func (pl ParameterisedList) ToString() (string, error) {
+func (pl ParameterisedList) String() (string, error) {
 	var b strings.Builder
 	if err := pl.serialize(&b); err != nil {
 		return "", err
@@ -26,7 +26,7 @@ func (pl ParameterisedList) ToString() (string, error) {
 	return b.String(), nil
 }
 
-func (pi *ParameterisedIdentifier) ToString() (string, error) {
+func (pi *ParameterisedIdentifier) String() (string, error) {
 	var b strings.Builder
 	if err := pi.serialize(&b); err != nil {
 		return "", err

--- a/go/signedexchange/structuredheader/writer.go
+++ b/go/signedexchange/structuredheader/writer.go
@@ -1,0 +1,174 @@
+package structuredheader
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+func (ll ListOfLists) ToString() (string, error) {
+	var b strings.Builder
+	if err := ll.serialize(&b); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+func (pl ParameterisedList) ToString() (string, error) {
+	var b strings.Builder
+	if err := pl.serialize(&b); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+func (pi *ParameterisedIdentifier) ToString() (string, error) {
+	var b strings.Builder
+	if err := pi.serialize(&b); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-09#section-4.1.3
+func (ll ListOfLists) serialize(out *strings.Builder) error {
+	if len(ll) == 0 {
+		return errors.New("structuredheader: empty List of Lists")
+	}
+
+	outerSep := ""
+	for _, list := range ll {
+		if len(list) == 0 {
+			return errors.New("structuredheader: empty inner list in List of Lists")
+		}
+
+		out.WriteString(outerSep)
+		outerSep = ", "
+
+		innerSep := ""
+		for _, item := range list {
+			out.WriteString(innerSep)
+			innerSep = "; "
+
+			if err := serializeItem(item, out); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-09#section-4.1.4
+func (pl ParameterisedList) serialize(out *strings.Builder) error {
+	if len(pl) == 0 {
+		return errors.New("structuredheader: empty Parameterised List")
+	}
+
+	sep := ""
+	for _, pi := range pl {
+		out.WriteString(sep)
+		sep = ", "
+		if err := pi.serialize(out); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Step 2.1-2.3 of
+// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-09#section-4.1.4
+func (pi *ParameterisedIdentifier) serialize(out *strings.Builder) error {
+	if !isValidToken(string(pi.Label)) {
+		return fmt.Errorf("structuredheader: label %q is not a valid token", pi.Label)
+	}
+	out.WriteString(string(pi.Label))
+
+	// Format in sorted order for reproducibility.
+	var keys []string
+	for k := range pi.Params {
+		keys = append(keys, string(k))
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		out.WriteByte(';')
+		if !isValidKey(k) {
+			return fmt.Errorf("structuredheader: invalid key %q", k)
+		}
+		out.WriteString(k)
+		val := pi.Params[Key(k)]
+		if val != nil {
+			out.WriteByte('=')
+			if err := serializeItem(val, out); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-09#section-4.1.5
+func serializeItem(i Item, out *strings.Builder) error {
+	switch v := i.(type) {
+	case int64:
+		// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-09#section-4.1.6
+		out.WriteString(strconv.FormatInt(v, 10))
+		return nil
+
+	case string:
+		// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-09#section-4.1.8
+		for _, c := range v {
+			if c < ' ' || c > '~' {
+				return fmt.Errorf("structuredheader: couldn't serialize %q as string", v)
+			}
+		}
+		out.WriteString(strconv.Quote(v))
+		return nil
+
+	case Token:
+		// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-09#section-4.1.9
+		if !isValidToken(string(v)) {
+			return fmt.Errorf("structuredheader: couldn't serialize %q as token", v)
+		}
+		out.WriteString(string(v))
+		return nil
+
+	case []byte:
+		// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-09#section-4.1.10
+		out.WriteByte('*')
+		out.WriteString(base64.StdEncoding.EncodeToString(v))
+		out.WriteByte('*')
+		return nil
+
+	default:
+		return fmt.Errorf("structuredheader: couldn't serialize %v as item", i)
+	}
+}
+
+func isValidKey(s string) bool {
+	if len(s) == 0 || !isLCAlpha(s[0]) {
+		return false
+	}
+	for _, c := range s {
+		if c > unicode.MaxASCII || !isKeyChar(byte(c)) {
+			return false
+		}
+	}
+	return true
+}
+
+func isValidToken(s string) bool {
+	if len(s) == 0 || !isAlpha(s[0]) {
+		return false
+	}
+	for _, c := range s {
+		if c > unicode.MaxASCII || !isTokenChar(byte(c)) {
+			return false
+		}
+	}
+	return true
+}

--- a/go/signedexchange/structuredheader/writer_test.go
+++ b/go/signedexchange/structuredheader/writer_test.go
@@ -33,7 +33,7 @@ func TestSerializeItem(t *testing.T) {
 		{[]byte("hoge"), "*aG9nZQ==*"},
 	}
 	for _, c := range cases {
-		s, err := ListOfLists{{c.input}}.ToString()
+		s, err := ListOfLists{{c.input}}.String()
 		if c.expected != "" {
 			if err != nil {
 				t.Errorf("Unexpetedly failed to serialize %v: %v", c.input, err)
@@ -62,7 +62,7 @@ func TestSerializeListOfLists(t *testing.T) {
 		{ListOfLists{{int64(42), int64(-42)}, {Token("foo"), Token("bar")}}, "42; -42, foo; bar"},
 	}
 	for _, c := range cases {
-		s, err := c.input.ToString()
+		s, err := c.input.String()
 		if c.expected != "" {
 			if err != nil {
 				t.Errorf("Unexpetedly failed to serialize %v: %v", c.input, err)
@@ -95,7 +95,7 @@ func TestSerializeParameterisedList(t *testing.T) {
 		{ParameterisedList{{"item1", Parameters{"InvalidKey": int64(123)}}}, ""},
 	}
 	for _, c := range cases {
-		s, err := c.input.ToString()
+		s, err := c.input.String()
 		if c.expected != "" {
 			if err != nil {
 				t.Errorf("Unexpetedly failed to serialize %v: %v", c.input, err)

--- a/go/signedexchange/structuredheader/writer_test.go
+++ b/go/signedexchange/structuredheader/writer_test.go
@@ -1,0 +1,112 @@
+package structuredheader_test
+
+import (
+	. "github.com/WICG/webpackage/go/signedexchange/structuredheader"
+	"testing"
+)
+
+func TestSerializeItem(t *testing.T) {
+	cases := []struct {
+		input    Item
+		expected string // empty if serialization should fail
+	}{
+		{int64(42), "42"},
+		{int64(9223372036854775807), "9223372036854775807"},   // int64 max
+		{int64(-9223372036854775808), "-9223372036854775808"}, // int64 min
+		{"string", `"string"`},
+		{"", `""`},
+		{"\x7f", ""},
+		{"\x1f", ""},
+		{`foo"bar`, `"foo\"bar"`},
+		{`foo\bar`, `"foo\\bar"`},
+		{`foo\"bar`, `"foo\\\"bar"`},
+		{" !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_abcdefghijklmnopqrstuvwxyz{|}~", `" !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_abcdefghijklmnopqrstuvwxyz{|}~"`},
+		{"\u65e5\u672c\u8a9e", ""},
+		{Token("foo"), "foo"},
+		{Token("BAR"), "BAR"},
+		{Token("A123_-.:%*/"), "A123_-.:%*/"},
+		{Token("123"), ""},
+		{Token("_foo"), ""},
+		{Token(""), ""},
+		{[]byte{}, "**"},
+		{[]byte("foo"), "*Zm9v*"},
+		{[]byte("hoge"), "*aG9nZQ==*"},
+	}
+	for _, c := range cases {
+		s, err := ListOfLists{{c.input}}.ToString()
+		if c.expected != "" {
+			if err != nil {
+				t.Errorf("Unexpetedly failed to serialize %v: %v", c.input, err)
+			}
+			if s != c.expected {
+				t.Errorf("%v should serialize to %q, but got %q", c.input, c.expected, s)
+			}
+		} else {
+			if err == nil {
+				t.Errorf("serialization of %v did not fail", c.input)
+			}
+		}
+	}
+}
+
+func TestSerializeListOfLists(t *testing.T) {
+	cases := []struct {
+		input    ListOfLists
+		expected string // empty if serialization should fail
+	}{
+		{ListOfLists{{}}, ""},
+		{ListOfLists{{int64(42)}}, "42"},
+		{ListOfLists{{int64(42)}, {}}, ""},
+		{ListOfLists{{int64(42), Token("foo")}}, "42; foo"},
+		{ListOfLists{{int64(42)}, {Token("foo")}}, "42, foo"},
+		{ListOfLists{{int64(42), int64(-42)}, {Token("foo"), Token("bar")}}, "42; -42, foo; bar"},
+	}
+	for _, c := range cases {
+		s, err := c.input.ToString()
+		if c.expected != "" {
+			if err != nil {
+				t.Errorf("Unexpetedly failed to serialize %v: %v", c.input, err)
+			}
+			if s != c.expected {
+				t.Errorf("%v should serialize to %q, but got %q", c.input, c.expected, s)
+			}
+		} else {
+			if err == nil {
+				t.Errorf("serialization of %v did not fail", c.input)
+			}
+		}
+	}
+}
+
+func TestSerializeParameterisedList(t *testing.T) {
+	cases := []struct {
+		input    ParameterisedList
+		expected string // empty if serialization should fail
+	}{
+		{ParameterisedList{}, ""},
+		{ParameterisedList{{"label", Parameters{}}}, "label"},
+		{ParameterisedList{{"_label", Parameters{}}}, ""},
+		{ParameterisedList{{"item1", Parameters{"n": int64(123)}}}, "item1;n=123"},
+		{ParameterisedList{
+			{"item1", Parameters{"n": int64(123)}},
+			{"item2", Parameters{}},
+			{"item3", Parameters{"n": int64(456)}},
+		}, "item1;n=123, item2, item3;n=456"},
+		{ParameterisedList{{"item1", Parameters{"InvalidKey": int64(123)}}}, ""},
+	}
+	for _, c := range cases {
+		s, err := c.input.ToString()
+		if c.expected != "" {
+			if err != nil {
+				t.Errorf("Unexpetedly failed to serialize %v: %v", c.input, err)
+			}
+			if s != c.expected {
+				t.Errorf("%v should serialize to %q, but got %q", c.input, c.expected, s)
+			}
+		} else {
+			if err == nil {
+				t.Errorf("serialization of %v did not fail", c.input)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This adds ToString() method to the structured header types, and
uses it from signer.go.