### PR TITLE
Promote the privacy-preserving prefetch use case to "Essential"

### DIFF
--- a/draft-yasskin-webpackage-use-cases.md
+++ b/draft-yasskin-webpackage-use-cases.md
@@ -189,6 +189,43 @@ Associated requirements:
 * {{response-headers}}{:format="title"}: The meaning of a resource is heavily
   influenced by its HTTP response headers.
 
+### Privacy-preserving prefetch {#private-prefetch}
+
+Lots of websites link to other websites. Many of these source sites would like
+the targets of these links to load quickly. The source could use `<link
+rel="prefetch">` to prefetch the target of a link, but if the user doesn't
+actually click that link, that leaks the fact that the user saw a page that
+linked to the target. This can be true even if the prefetch is made without
+browser credentials because of mechanisms like TLS session IDs.
+
+Because clients have limited data budgets to prefetch link targets, this use
+case is probably limited to sites that can accurately predict which link their
+users are most likely to click. For example, search engines can predict that
+their users will click one of the first couple results, and news aggreggation
+sites like Reddit or Slashdot can hope that users will read the article if
+they've navigated to its discussion.
+
+Two search engines have built systems to do this with today's technology:
+Google's [AMP](https://www.ampproject.org/) and Baidu's
+[MIP](https://www.mipengine.org/) formats and caches allow them to prefetch
+search results while preserving privacy, at the cost of showing the wrong URLs
+for the results once the user has clicked. A good solution to this problem would
+show the right URLs but still avoid a request to the publishing origin until
+after the user clicks.
+
+Associated requirements:
+
+* {{signing}}{:format="title"}: To prove the content came from the original
+  origin.
+* {{streamed-loading}}{:format="title"}: If the user clicks before the target
+  page is fully transferred, the browser should be able to start loading early
+  parts before the source site finishes sending the whole page.
+* {{transfer-compression}}{:format="title"}
+* {{subsetting}}{:format="title"}: If a prefetched page includes subresources,
+  its publisher might want to provide and sign both WebP and PNG versions of an
+  image, but the source site should be able to transfer only best one for each
+  client.
+
 ## Nice-to-have {#nice-to-have-use-cases}
 
 ### Packaged Web Publications {#uc-web-pub}
@@ -308,43 +345,6 @@ them all inline.
 Associated requirements:
 
 * {{external-dependencies}}{:format="title"}
-
-### Privacy-preserving prefetch {#private-prefetch}
-
-Lots of websites link to other websites. Many of these source sites would like
-the targets of these links to load quickly. The source could use `<link
-rel="prefetch">` to prefetch the target of a link, but if the user doesn't
-actually click that link, that leaks the fact that the user saw a page that
-linked to the target. This can be true even if the prefetch is made without
-browser credentials because of mechanisms like TLS session IDs.
-
-Because clients have limited data budgets to prefetch link targets, this use
-case is probably limited to sites that can accurately predict which link their
-users are most likely to click. For example, search engines can predict that
-their users will click one of the first couple results, and news aggreggation
-sites like Reddit or Slashdot can hope that users will read the article if
-they've navigated to its discussion.
-
-Two search engines have built systems to do this with today's technology:
-Google's [AMP](https://www.ampproject.org/) and Baidu's
-[MIP](https://www.mipengine.org/) formats and caches allow them to prefetch
-search results while preserving privacy, at the cost of showing the wrong URLs
-for the results once the user has clicked. A good solution to this problem would
-show the right URLs but still avoid a request to the publishing origin until
-after the user clicks.
-
-Associated requirements:
-
-* {{signing}}{:format="title"}: To prove the content came from the original
-  origin.
-* {{streamed-loading}}{:format="title"}: If the user clicks before the target
-  page is fully transferred, the browser should be able to start loading early
-  parts before the source site finishes sending the whole page.
-* {{transfer-compression}}{:format="title"}
-* {{subsetting}}{:format="title"}: If a prefetched page includes subresources,
-  its publisher might want to provide and sign both WebP and PNG versions of an
-  image, but the source site should be able to transfer only best one for each
-  client.
 
 ### Cross-CDN Serving {#cross-cdn-serving}
 


### PR DESCRIPTION
It's what our current most enthusiastic customer (AMP) depends on, so we
should be sure not to break it.