### PR TITLE
go/signedexchange: ParsePrivateKey takes pem text, not DER bytes

### DIFF
--- a/go/signedexchange/certs.go
+++ b/go/signedexchange/certs.go
@@ -32,7 +32,23 @@ func ParseCertificates(text []byte) ([]*x509.Certificate, error) {
 	return certs, nil
 }
 
-func ParsePrivateKey(derKey []byte) (crypto.PrivateKey, error) {
+func ParsePrivateKey(text []byte) (crypto.PrivateKey, error) {
+	for len(text) > 0 {
+		var block *pem.Block
+		block, text = pem.Decode(text)
+		if block == nil {
+			return nil, errors.New("signedexchange: invalid PEM block in private key.")
+		}
+
+		privkey, err := parsePrivateKeyBlock(block.Bytes)
+		if err == nil {
+			return privkey, nil
+		}
+	}
+	return nil, errors.New("signedexchange: could not find private key.")
+}
+
+func parsePrivateKeyBlock(derKey []byte) (crypto.PrivateKey, error) {
 	// Try each of 3 key formats and take the first one that successfully parses.
 	if key, err := x509.ParsePKCS1PrivateKey(derKey); err == nil {
 		return key, nil

--- a/go/signedexchange/cmd/gen-signedexchange/main.go
+++ b/go/signedexchange/cmd/gen-signedexchange/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"bytes"
-	"crypto"
-	"encoding/pem"
 	"flag"
 	"fmt"
 	"io"
@@ -93,24 +91,9 @@ func run() error {
 	if !ok {
 		return fmt.Errorf("failed to parse version %q", *flagVersion)
 	}
-
-	var privkey crypto.PrivateKey
-	for {
-		var pemBlock *pem.Block
-		pemBlock, privkeytext = pem.Decode(privkeytext)
-		if pemBlock == nil {
-			return fmt.Errorf("invalid PEM block in private key file %q.", *flagPrivateKey)
-		}
-
-		var err error
-		privkey, err = signedexchange.ParsePrivateKey(pemBlock.Bytes)
-		if err == nil || len(privkeytext) == 0 {
-			break
-		}
-		// Else try next PEM block.
-	}
-	if privkey == nil {
-		return fmt.Errorf("failed to parse private key file %q.", *flagPrivateKey)
+	privkey, err := signedexchange.ParsePrivateKey(privkeytext)
+	if err != nil {
+		return fmt.Errorf("failed to parse private key file %q. err: %v", *flagPrivateKey, err)
 	}
 
 	var fMsg io.WriteCloser

--- a/go/signedexchange/signedexchange_test.go
+++ b/go/signedexchange/signedexchange_test.go
@@ -2,7 +2,6 @@ package signedexchange_test
 
 import (
 	"bytes"
-	"encoding/pem"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -76,8 +75,7 @@ func TestSignedExchange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	derPrivateKey, _ := pem.Decode([]byte(pemPrivateKey))
-	privKey, err := ParsePrivateKey(derPrivateKey.Bytes)
+	privKey, err := ParsePrivateKey([]byte(pemPrivateKey))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,8 +198,7 @@ func TestSignedExchangeBannedCertUrlScheme(t *testing.T) {
 		certs, _ := ParseCertificates([]byte(pemCerts))
 		certUrl, _ := url.Parse("http://example.com/cert.msg")
 		validityUrl, _ := url.Parse("https://example.com/resource.validity")
-		derPrivateKey, _ := pem.Decode([]byte(pemPrivateKey))
-		privKey, _ := ParsePrivateKey(derPrivateKey.Bytes)
+		privKey, _ := ParsePrivateKey([]byte(pemPrivateKey))
 		s := &Signer{
 			Date:        signatureDate,
 			Expires:     signatureDate.Add(1 * time.Hour),
@@ -231,8 +228,7 @@ func createTestExchange(ver version.Version, t *testing.T) (e *Exchange, s *Sign
 		t.Fatal(err)
 	}
 
-	derPrivateKey, _ := pem.Decode([]byte(pemPrivateKey))
-	privKey, err := ParsePrivateKey(derPrivateKey.Bytes)
+	privKey, err := ParsePrivateKey([]byte(pemPrivateKey))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
To make it consistent with ParseCertificates().