### PR TITLE
Add support for JSON output

### DIFF
--- a/go/signedexchange/cmd/dump-signedexchange/main.go
+++ b/go/signedexchange/cmd/dump-signedexchange/main.go
@@ -16,6 +16,7 @@ var (
 	flagSignature = flag.Bool("signature", false, "Print only signature value")
 	flagVerify    = flag.Bool("verify", false, "Perform signature verification")
 	flagCert      = flag.String("cert", "", "Certificate CBOR file. If specified, used instead of fetching from signature's cert-url")
+	flagJSON      = flag.Bool("json", false, "Print output as JSON")
 )
 
 func run() error {
@@ -32,6 +33,11 @@ func run() error {
 	e, err := signedexchange.ReadExchange(in)
 	if err != nil {
 		return err
+	}
+
+	if *flagJSON {
+		e.JSONPrint(os.Stdout)
+		return nil
 	}
 
 	if *flagSignature {
@@ -57,12 +63,12 @@ func verify(e *signedexchange.Exchange) error {
 	if *flagCert != "" {
 		f, err := os.Open(*flagCert)
 		if err != nil {
-			return fmt.Errorf("could not open %s: %v\n", *flagCert, err)
+			return fmt.Errorf("could not open %s: %v", *flagCert, err)
 		}
 		defer f.Close()
 		certBytes, err := ioutil.ReadAll(f)
 		if err != nil {
-			return fmt.Errorf("Could not read %s: %v\n", *flagCert, err)
+			return fmt.Errorf("could not read %s: %v", *flagCert, err)
 		}
 		certFetcher = func(_ string) ([]byte, error) {
 			return certBytes, nil

--- a/go/signedexchange/signedexchange.go
+++ b/go/signedexchange/signedexchange.go
@@ -3,16 +3,13 @@ package signedexchange
 import (
 	"bytes"
 	"encoding/binary"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/WICG/webpackage/go/signedexchange/cbor"
 	"github.com/WICG/webpackage/go/signedexchange/internal/bigendian"
@@ -506,41 +503,4 @@ func (e *Exchange) PrettyPrintHeaders(w io.Writer) {
 func (e *Exchange) PrettyPrintPayload(w io.Writer) {
 	fmt.Fprintf(w, "payload [%d bytes]:\n", len(e.Payload))
 	w.Write(e.Payload)
-}
-
-func (e *Exchange) JSONPrint(w io.Writer) {
-	verificationTime := time.Now()
-	certFetcher := DefaultCertFetcher
-	payload, ok := e.Verify(verificationTime, certFetcher, log.New(ioutil.Discard, "", 0))
-	// f is a copy of e except with Payload as a string, instead of a []byte (to
-	// better serialize to JSON).
-	f := struct {
-		Valid   bool
-		Version version.Version
-
-		// Request
-		RequestURI     string
-		RequestMethod  string
-		RequestHeaders http.Header
-
-		// Response
-		ResponseStatus       int
-		ResponseHeaders      http.Header
-		SignatureHeaderValue string
-
-		// Payload
-		Payload string
-	}{
-		ok,
-		e.Version,
-		e.RequestURI,
-		e.RequestMethod,
-		e.RequestHeaders,
-		e.ResponseStatus,
-		e.ResponseHeaders,
-		e.SignatureHeaderValue,
-		fmt.Sprintf("%s", payload),
-	}
-	s, _ := json.MarshalIndent(f, "", "  ")
-	w.Write(s)
 }

--- a/go/signedexchange/structuredheader/parser.go
+++ b/go/signedexchange/structuredheader/parser.go
@@ -156,7 +156,7 @@ func (p *parser) parseParameterisedList() (ParameterisedList, error) {
 			return items, nil
 		}
 		if !p.consumeChar(',') {
-			return nil, fmt.Errorf("structuredheader: ',' expacted, got '%c'", p.input[0])
+			return nil, fmt.Errorf("structuredheader: ',' expected, got '%c'", p.input[0])
 		}
 		p.discardLeadingOWS()
 	}


### PR DESCRIPTION
Adds a switch, `-json` to `dump-signedexchange` (fixes #418):

```sh
$ curl -sS -H 'accept: application/signed-exchange;v=b3' -H 'amp-cache-transform: google;v="1"' https://amp.dev/ | ./dump-signedexchange -json
{
  "Valid": true,
  "Payload": "",
  "SignatureHeaderValue": {
    "cert-sha256": "lWfYk+0jeC/HkleYD4fj98y6GixIjocIkMpjsB8dToA=",
    "cert-url": "https://amp.dev/amppkg/cert/lWfYk-0jeC_HkleYD4fj98y6GixIjocIkMpjsB8dToA",
    "date": 1559608738,
    "expires": 1560213538,
    "integrity": "digest/mi-sha256-03",
    "sig": "MEYCIQDNXSYTBrsbJVJrm79lPTRXITmvraoQj77axnslJa7HUwIhAOwTFoVFhQwfYICNHa+fSewH6mxaD5K6YPdcGbbgIG6w",
    "validity-url": "https://amp.dev/amppkg/validity"
  },
  "Version": "1b3",
…
```

Can be used with e.g. https://stedolan.github.io/jq/ to extract specific properties such as the cert-url:

```sh
$ curl -sS -H 'accept: application/signed-exchange;v=b3' -H 'amp-cache-transform: google;v="1"' https://amp.dev/ | ./dump-signedexchange -json | jq -r '.SignatureHeaderValue|."cert-url"'
https://amp.dev/amppkg/cert/lWfYk-0jeC_HkleYD4fj98y6GixIjocIkMpjsB8dToA
```

(FYI @patrickkettner re #418, had a quick look and just figured I'd have a go at this!)