### PR TITLE
Remove credentials from the certificate fetch.

### DIFF
--- a/loading.bs
+++ b/loading.bs
@@ -706,6 +706,8 @@ reporting to a [=signed exchange report=] |report|, returns a
     :: "`none`"
     : [=request/mode=]
     :: "`cors`"
+    : [=request/credentials mode=]
+    :: "`omit`"
 1. Let |certResponse| be the result of [=fetching=] |certRequest|.
 1. Append the IP address of the server from which the user agent received the
     |certResponse| to |report|'s [=signed exchange report/cert server IP list=],


### PR DESCRIPTION
This removes one avenue by which a distributor could send its notion of
a user's ID to another origin, for server-side correlation with that
origin's cookies. That correlation would violate the goals in #422 and seems easy to block.

Thanks @kristoferbaxter and @twifkak for pointing this out.

I don't *think* it's useful to customize the content of a certificate chain to a particular user, especially since the hash of the certificate itself is locked in by the SXG's signature. But if anyone sees a way this'll break things, please speak up.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/webpackage/pull/428.html" title="Last updated on May 1, 2019, 8:05 PM UTC (1321699)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webpackage/428/9634466...jyasskin:1321699.html" title="Last updated on May 1, 2019, 8:05 PM UTC (1321699)">Diff</a>