### PR TITLE
Adds support for URI input to dump-signedexchange

### DIFF
--- a/go/signedexchange/README.md
+++ b/go/signedexchange/README.md
@@ -148,11 +148,50 @@ You can dump the content of your sxg file by `dump-signedexchange`. If you want 
 dump-signedexchange -i example.org.hello.sxg
 ```
 
-If `-verify` command-line flag is specified, `dump-signedexchange` checks if the signed exchange is valid.
+If the `-json` flag is passed, the output will be in JSON.
+
+```
+dump-signedexchange -i example.org.hello.sxg -json
+```
+
+You can also dump the content of a signed exchange from a URI. If you want to see the content of the signed exchange you're hosting at https://example.org/hello.html, run this command. By default this will request the latest version.
+
+```
+dump-signedexchange -uri https://example.org/hello.html
+```
+
+If the specified URI requires a special header to serve a signed exchange, you can pass request headers via the `-requestHeader` flag. The header key and value should be separated by a `:`.
+
+```
+dump-signedexchange -uri https://example.org/hello.html -requestHeader AMP-Cache-Transform:any -requestHeader "foo:bar"
+```
+
+When the `-uri` flag is passed to `dump-signedexchange`, you can specify the sxg version to request by passing a `-version` flag. For instance, if you wanted to request a `1b2` signed exchange, you would run the following command. By default, the version is `1b3`.
+
+```
+dump-signedexchange -uri https://example.org/hello.html -version=1b2
+```
+
+`dump-signedexchange` can also operate on piped input. For instance, you could run the following command to retrieve a b3 signed exchange.
+
+```
+curl -H "AMP-Cache-Transform:any" -H "Accept:application/signed-exchange;v=b3" https://example.org/hello.html | dump-signedexchange
+```
+
+`dump-signedexchange` can print the information you want about your signed exchange. By default, both the headers and the payload are printed, but they can be suppressed by passing `-headers=false` and `-payload=false`.
+
+If you would like only the signature to be printed, pass the `-signature` flag.
+
+```
+dump-signedexchange -i example.org.hello.sxg -signature
+```
+
+If the `-verify` command-line flag is specified, `dump-signedexchange` checks if the signed exchange is valid.
 
 By default, `dump-signedexchange` fetches certificate chain from network (from the URL you specified as `-certUrl` parameter of `gen-signedexchange`). But if `-cert filename` flag is given, `dump-signedexchange` reads certificates from `filename`.
 
 For example, If you want to verify `example.org.hello.sxg` using certificates in `cert.cbor`, run this command.
+
 ```
 dump-signedexchange -i example.org.hello.sxg -verify -cert cert.cbor
 ```

--- a/go/signedexchange/signedexchange.go
+++ b/go/signedexchange/signedexchange.go
@@ -236,7 +236,7 @@ func (e *Exchange) decodeExchangeHeaders(dec *cbor.Decoder) error {
 			return fmt.Errorf("signedexchange: failed to decode top-level array header: %v", err)
 		}
 		if n != 2 {
-			return fmt.Errorf("singedexchange: length of header array must be 2 but %d", n)
+			return fmt.Errorf("signedexchange: length of header array must be 2 but %d", n)
 		}
 		if err := e.decodeRequestMap(dec); err != nil {
 			return err

--- a/go/signedexchange/verifier.go
+++ b/go/signedexchange/verifier.go
@@ -64,7 +64,7 @@ func extractSignatureFields(pi structuredheader.ParameterisedIdentifier) (*Signa
 	return sig, nil
 }
 
-// CertFetcher takes certificat URL and returns certificate bytes in
+// CertFetcher takes certificate URL and returns certificate bytes in
 // application/cert-chain+cbor format.
 type CertFetcher = func(url string) ([]byte, error)
 

--- a/go/signedexchange/version/version.go
+++ b/go/signedexchange/version/version.go
@@ -15,7 +15,7 @@ const (
 
 const HeaderMagicBytesLen = 8
 
-var AllVersions = []Version {
+var AllVersions = []Version{
 	Version1b1,
 	Version1b2,
 	Version1b3,
@@ -46,6 +46,10 @@ func (v Version) HeaderMagicBytes() []byte {
 	}
 }
 
+func (v Version) MimeType() string {
+	return fmt.Sprintf("application/signed-exchange;v=%s", v[1:])
+}
+
 func FromMagicBytes(bs []byte) (Version, error) {
 	if bytes.Equal(bs, Version1b1.HeaderMagicBytes()) {
 		return Version1b1, nil
@@ -54,6 +58,6 @@ func FromMagicBytes(bs []byte) (Version, error) {
 	} else if bytes.Equal(bs, Version1b3.HeaderMagicBytes()) {
 		return Version1b3, nil
 	} else {
-		return Version(""), fmt.Errorf("singedexchange: unknown magic bytes: %v", bs)
+		return Version(""), fmt.Errorf("signedexchange: unknown magic bytes: %v", bs)
 	}
 }


### PR DESCRIPTION
This PR makes some quality of life improvements for the dump-signedexchange tool

- Adds support for reading a signed exchange from an HTTPS endpoint rather than from the file system. This feels much more natural to use and allows for faster debugging.
- Allows for more granular control over the output. Generally when I dump a signed exchange, I don't want to see the entire HTML, I'm interested in the signature and the headers.

EDIT:
- The tool will also warn the user if -i or -uri is not passed instead of simply hanging indefinitely

EDIT 2:
- Allows the version to be specified with the `-version` flag which defaults to the latest version
- Allows a header such as `AMP-Cache-Transform: google;v=1` to be sent along with the `-uri` request with the `-requestHeader` flag
- Fixes a few instances of `singedexchange` and makes them `signedexchange`

EDIT 3:
- Added info about json flag to README
- Allows more than one header to be passed with -requestHeader flag
- Mime type factored to version.go
- Input flags take precedence over pipe