### PR TITLE
Make dump-signedexchange show header integrity value

### DIFF
--- a/go/signedexchange/cmd/dump-signedexchange/main.go
+++ b/go/signedexchange/cmd/dump-signedexchange/main.go
@@ -33,15 +33,16 @@ func (h *headerArgs) Set(value string) error {
 var latestVersion = string(version.AllVersions[len(version.AllVersions)-1])
 
 var (
-	flagCert      = flag.String("cert", "", "Certificate CBOR file. If specified, used instead of fetching from signature's cert-url")
-	flagHeaders   = flag.Bool("headers", true, "Print headers")
-	flagFilename  = flag.String("i", "", "Signed-exchange input file")
-	flagJSON      = flag.Bool("json", false, "Print output as JSON")
-	flagPayload   = flag.Bool("payload", true, "Print payload")
-	flagSignature = flag.Bool("signature", false, "Print only signature value")
-	flagURI       = flag.String("uri", "", "Signed-exchange uri")
-	flagVerify    = flag.Bool("verify", false, "Perform signature verification")
-	flagVersion   = flag.String("version", latestVersion, "Signed exchange version")
+	flagCert            = flag.String("cert", "", "Certificate CBOR file. If specified, used instead of fetching from signature's cert-url")
+	flagHeaders         = flag.Bool("headers", true, "Print headers")
+	flagHeaderIntegrity = flag.Bool("header-integrity", true, "Print header integrity")
+	flagFilename        = flag.String("i", "", "Signed-exchange input file")
+	flagJSON            = flag.Bool("json", false, "Print output as JSON")
+	flagPayload         = flag.Bool("payload", true, "Print payload")
+	flagSignature       = flag.Bool("signature", false, "Print only signature value")
+	flagURI             = flag.String("uri", "", "Signed-exchange uri")
+	flagVerify          = flag.Bool("verify", false, "Perform signature verification")
+	flagVersion         = flag.String("version", latestVersion, "Signed exchange version")
 
 	flagRequestHeader = headerArgs{}
 )
@@ -117,6 +118,12 @@ func run() error {
 			e.PrettyPrintHeaders(os.Stdout)
 		}
 
+		if *flagHeaderIntegrity {
+			if err = e.PrettyPrintHeaderIntegrity(os.Stdout); err != nil {
+				return err
+			}
+		}
+
 		if *flagPayload {
 			e.PrettyPrintPayload(os.Stdout)
 		}
@@ -167,17 +174,23 @@ func jsonPrintHeaders(e *signedexchange.Exchange, certFetcher signedexchange.Cer
 	if err != nil {
 		return err
 	}
+	headerIntegrity, err := e.ComputeHeaderIntegrity();
+	if err != nil {
+		return err
+	}
 
 	f := struct {
 		Payload              []byte `json:",omitempty"` // hides Payload in nested signedexchange.Exchange
 		SignatureHeaderValue []byte `json:",omitempty"` // hides SignatureHeaderValue in nested signedexchange.Exchange
 		Valid                bool
+		HeaderIntegrity      string
 		Signatures           structuredheader.ParameterisedList
 		*signedexchange.Exchange
 	}{
 		nil, // omitted via "omitempty"
 		nil, // omitted via "omitempty"
 		valid,
+		headerIntegrity,
 		sigs,
 		e,
 	}

--- a/go/signedexchange/cmd/dump-signedexchange/main.go
+++ b/go/signedexchange/cmd/dump-signedexchange/main.go
@@ -35,7 +35,6 @@ var latestVersion = string(version.AllVersions[len(version.AllVersions)-1])
 var (
 	flagCert            = flag.String("cert", "", "Certificate CBOR file. If specified, used instead of fetching from signature's cert-url")
 	flagHeaders         = flag.Bool("headers", true, "Print headers")
-	flagHeaderIntegrity = flag.Bool("header-integrity", true, "Print header integrity")
 	flagFilename        = flag.String("i", "", "Signed-exchange input file")
 	flagJSON            = flag.Bool("json", false, "Print output as JSON")
 	flagPayload         = flag.Bool("payload", true, "Print payload")
@@ -116,9 +115,6 @@ func run() error {
 	} else {
 		if *flagHeaders {
 			e.PrettyPrintHeaders(os.Stdout)
-		}
-
-		if *flagHeaderIntegrity {
 			if err = e.PrettyPrintHeaderIntegrity(os.Stdout); err != nil {
 				return err
 			}

--- a/go/signedexchange/cmd/dump-signedexchange/main.go
+++ b/go/signedexchange/cmd/dump-signedexchange/main.go
@@ -33,15 +33,15 @@ func (h *headerArgs) Set(value string) error {
 var latestVersion = string(version.AllVersions[len(version.AllVersions)-1])
 
 var (
-	flagCert            = flag.String("cert", "", "Certificate CBOR file. If specified, used instead of fetching from signature's cert-url")
-	flagHeaders         = flag.Bool("headers", true, "Print headers")
-	flagFilename        = flag.String("i", "", "Signed-exchange input file")
-	flagJSON            = flag.Bool("json", false, "Print output as JSON")
-	flagPayload         = flag.Bool("payload", true, "Print payload")
-	flagSignature       = flag.Bool("signature", false, "Print only signature value")
-	flagURI             = flag.String("uri", "", "Signed-exchange uri")
-	flagVerify          = flag.Bool("verify", false, "Perform signature verification")
-	flagVersion         = flag.String("version", latestVersion, "Signed exchange version")
+	flagCert      = flag.String("cert", "", "Certificate CBOR file. If specified, used instead of fetching from signature's cert-url")
+	flagHeaders   = flag.Bool("headers", true, "Print headers")
+	flagFilename  = flag.String("i", "", "Signed-exchange input file")
+	flagJSON      = flag.Bool("json", false, "Print output as JSON")
+	flagPayload   = flag.Bool("payload", true, "Print payload")
+	flagSignature = flag.Bool("signature", false, "Print only signature value")
+	flagURI       = flag.String("uri", "", "Signed-exchange uri")
+	flagVerify    = flag.Bool("verify", false, "Perform signature verification")
+	flagVersion   = flag.String("version", latestVersion, "Signed exchange version")
 
 	flagRequestHeader = headerArgs{}
 )
@@ -170,7 +170,7 @@ func jsonPrintHeaders(e *signedexchange.Exchange, certFetcher signedexchange.Cer
 	if err != nil {
 		return err
 	}
-	headerIntegrity, err := e.ComputeHeaderIntegrity();
+	headerIntegrity, err := e.ComputeHeaderIntegrity()
 	if err != nil {
 		return err
 	}

--- a/go/signedexchange/signedexchange.go
+++ b/go/signedexchange/signedexchange.go
@@ -517,7 +517,7 @@ func (e *Exchange) ComputeHeaderIntegrity() (string, error) {
 }
 
 func (e *Exchange) PrettyPrintHeaderIntegrity(w io.Writer) error {
-	headerIntegrity, err := e.ComputeHeaderIntegrity();
+	headerIntegrity, err := e.ComputeHeaderIntegrity()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This header integrity value will be used in "allowed-alt-sxg" link header to support subresource signed exchange loading.

https://github.com/WICG/webpackage/issues/347#issuecomment-467743010