### PR TITLE
CBOR header key must not contain UPPERCASE alphabet

### DIFF
--- a/go/signedexchange/signedexchange.go
+++ b/go/signedexchange/signedexchange.go
@@ -137,6 +137,10 @@ func (e *Exchange) decodeRequestMap(dec *cbor.Decoder) error {
 		if err != nil {
 			return err
 		}
+		key_str := string(key)
+		if key_str != strings.ToLower(key_str) {
+			return fmt.Errorf("signedexchange: request header key MUST NOT contain uppercase alphabet(s): %s", key)
+		}
 		value, err := dec.DecodeByteString()
 		if err != nil {
 			return err
@@ -155,7 +159,7 @@ func (e *Exchange) decodeRequestMap(dec *cbor.Decoder) error {
 			}
 			return fmt.Errorf("signedexchange: found a deprecated request key %q", keyURL)
 		}
-		e.RequestHeaders.Add(string(key), string(value))
+		e.RequestHeaders.Add(key_str, string(value))
 	}
 	return nil
 }
@@ -192,7 +196,8 @@ func (e *Exchange) decodeResponseMap(dec *cbor.Decoder) error {
 		if err != nil {
 			return err
 		}
-		if string(key) != strings.ToLower(string(key)) {
+		key_str := string(key)
+		if key_str != strings.ToLower(key_str) {
 			return fmt.Errorf("signedexchange: response header key MUST NOT contain uppercase alphabet(s): %s", key)
 		}
 		value, err := dec.DecodeByteString()
@@ -206,7 +211,7 @@ func (e *Exchange) decodeResponseMap(dec *cbor.Decoder) error {
 			}
 			continue
 		}
-		e.ResponseHeaders.Add(string(key), string(value))
+		e.ResponseHeaders.Add(key_str, string(value))
 	}
 	return nil
 }

--- a/go/signedexchange/signedexchange.go
+++ b/go/signedexchange/signedexchange.go
@@ -192,6 +192,9 @@ func (e *Exchange) decodeResponseMap(dec *cbor.Decoder) error {
 		if err != nil {
 			return err
 		}
+		if string(key) != strings.ToLower(string(key)) {
+			return fmt.Errorf("signedexchange: response header key MUST NOT contain uppercase alphabet(s): %s", key)
+		}
 		value, err := dec.DecodeByteString()
 		if err != nil {
 			return err


### PR DESCRIPTION
https://tools.ietf.org/html/draft-yasskin-http-origin-signed-responses-05#section-3.2

```
For each response header field, the header field's lowercase name
      as a byte string to the header field's value as a byte string.
```

We should check response header's key does not contains uppercase name along with this spec.