### PR TITLE
Update the bundle format

### DIFF
--- a/draft-yasskin-http-origin-signed-responses.md
+++ b/draft-yasskin-http-origin-signed-responses.md
@@ -376,13 +376,14 @@ The resource at a signature's `cert-url` MUST have the
 ~~~cddl
 cert-chain = [
   "📜⛓", ; U+1F4DC U+26D3
-  + {
-    cert: bytes,
-    ? ocsp: bytes,
-    ? sct: bytes,
-    * tstr => any,
-  }
+  + augmented-certificate
 ]
+augmented-certificate = {
+  cert: bytes,
+  ? ocsp: bytes,
+  ? sct: bytes,
+  * tstr => any,
+}
 ~~~
 
 The first map (second item) in the CBOR array is treated as the end-entity

--- a/draft-yasskin-wpack-bundled-exchanges.md
+++ b/draft-yasskin-wpack-bundled-exchanges.md
@@ -376,8 +376,8 @@ URL strings to arrays consisting of a `Variants` header field value
 each of the possible combinations of available-values within the `Variants`
 value in lexicographic (row-major) order.
 
-For example, given a `variants-value` of "Accept-Encoding;gzip;br,
-Accept-Language;en;fr;ja", the list of `location-in-responses` pairs will
+For example, given a `variants-value` of `Accept-Encoding;gzip;br,
+Accept-Language;en;fr;ja`, the list of `location-in-responses` pairs will
 correspond to the `VariantKey`s:
 
 * gzip;en
@@ -388,7 +388,7 @@ correspond to the `VariantKey`s:
 * br;ja
 
 The order of variant-axes is important. If the `variants-value` were
-"Accept-Language;en;fr;ja, Accept-Encoding;gzip;br" instead, the
+`Accept-Language;en;fr;ja, Accept-Encoding;gzip;br` instead, the
 `location-in-responses` pairs would instead correspond to:
 
 * en;gzip
@@ -403,7 +403,7 @@ resource at the specified URL and that no content negotiation is performed.
 
 ~~~ cddl
 index = {* whatwg-url => [ variants-value, +location-in-responses ] }
-variants-value = tstr
+variants-value = bstr
 location-in-responses = (offset: uint, length: uint)
 ~~~
 
@@ -877,6 +877,14 @@ at <https://www.iana.org/assignments/media-types>.
 
 * Required parameters: N/A
 
+  * v: A string denoting the version of the file format. ({{!RFC5234}} ABNF:
+    `version = 1*(DIGIT/%x61-7A)`) The version defined in this specification is `1`.
+
+    Note: RFC EDITOR PLEASE DELETE THIS NOTE; Implementations of drafts of this
+    specification MUST NOT use simple integers to describe their versions, and
+    MUST instead define implementation-specific strings to identify which draft
+    is implemented.
+
 * Optional parameters: N/A
 
 * Encoding considerations: binary
@@ -924,12 +932,12 @@ Review Process: Specification Required
 
 Initial Assignments:
 
-| Section Name | Specification | Metadata |
-| "index" | {{index-section}} | Yes |
-| "manifest" | {{manifest-section}} | Yes |
-| "signatures" | {{signatures-section}} | Yes |
-| "critical" | {{critical-section}} | Yes |
-| "responses" | {{responses-section}} | No |
+| Section Name | Specification | Metadata | Metadata Fields |
+| "index" | {{index-section}} | Yes | "requests" |
+| "manifest" | {{manifest-section}} | Yes | "manifest" |
+| "signatures" | {{signatures-section}} | Yes | "authorities", "vouched-subsets" |
+| "critical" | {{critical-section}} | Yes | |
+| "responses" | {{responses-section}} | No | |
 
 Requirements on new assignments:
 

--- a/draft-yasskin-wpack-bundled-exchanges.md
+++ b/draft-yasskin-wpack-bundled-exchanges.md
@@ -38,6 +38,9 @@ normative:
       org: WHATWG
     date: Living Standard
 
+informative:
+  TLS1.3: RFC8446
+
 --- abstract
 
 Bundled exchanges provide a way to bundle up groups of HTTP request+response
@@ -216,9 +219,9 @@ webbundle = [
   length: bytes .size 8,  ; Big-endian number of bytes in the bundle.
 ]
 
-$section-name /= "index" / "manifest" / "critical" / "responses"
+$section-name /= "index" / "manifest" / "signatures" / "critical" / "responses"
 
-$section /= index / manifest / critical / responses
+$section /= index / manifest / signatures / critical / responses
 
 responses = [*response]
 
@@ -360,7 +363,7 @@ As a special case, an empty `variants-value` indicates that there is only one
 resource at the specified URL and that no content negotiation is performed.
 
 ~~~ cddl
-index = {* tstr => [ variants-value, +location-in-responses ] }
+index = {* whatwg-url => [ variants-value, +location-in-responses ] }
 variants-value = tstr
 location-in-responses = (offset: uint, length: uint)
 ~~~
@@ -448,6 +451,72 @@ map to fill in, the parser MUST do the following:
    return an error.
 
 1. Set `metadata["manifest"]` to `url`.
+
+### Parsing the signatures section {#signatures-section}
+
+The "signatures" section vouches for the resources in the bundle.
+
+The section can contain as many signatures as needed, each by some authority,
+and each covering an arbitrary subset of the resources in the bundle.
+Intermediates, including attackers, can remove signatures from the bundle
+without breaking the other signatures.
+
+The bundle parser's client is responsible to determine the validity and meaning
+of each authority's signatures. In particular, the algorithm below does not
+check that signatures are valid. For example, a client might:
+
+* Use the ecdsa_secp256r1_sha256 algorithm defined in Section 4.2.3 of
+  {{TLS1.3}} to check the validity of any signature with an EC public key on the
+  secp256r1 curve.
+* Reject all signatures by an RSA public key.
+* Treat an X.509 certificate with the CanSignHttpExchanges extension (Section
+  4.2 of {{?I-D.yasskin-http-origin-signed-responses}}) and a valid chain to a
+  trusted root as an authority that vouches for the authenticity of resources
+  claimed to come from that certificate's domains.
+* Treat an X.509 certificate with another extension or EKU as vouching that a
+  particular analysis has run over the signed resources without finding
+  malicious behavior.
+
+A client might also choose different behavior for those kinds of authorities and
+keys.
+
+~~~ cddl
+signatures = [
+  authorities: [*authority],
+  vouched-subsets: [*{
+    authority: index-in-authorities,
+    sig: bstr,
+    signed: bstr  ; Expected to hold a signed-subset item.
+  }],
+]
+authority = augmented-certificate
+index-in-authorities = uint
+whatwg-url = tstr
+
+signed-subset = {
+  validity-url: whatwg-url,
+  auth-sha256: bstr,
+  date: uint,
+  expires: uint,
+  subset-hashes: {+
+    whatwg-url => [variants-value, +resource-integrity]
+  },
+  * tstr => any,
+}
+resource-integrity = (header-sha256: bstr, payload-integrity-header: tstr)
+~~~
+
+The `augmented-certificate` CDDL rule comes from Section 3.3 of {{!I-D.yasskin-http-origin-signed-responses}}.
+
+To parse the signatures section, given its `sectionContents`, the `sectionOffsets`
+map, and the `metadata` map to fill in, the parser MUST do the following:
+
+1. Let `signatures` be the result of parsing `sectionContents` as a CBOR item
+   matching the `signatures` rule in the above CDDL ({{parse-cbor}}).
+1. Set `metadata["authorities"]` to the list of authorities in the first element
+   of the `signatures` array.
+1. Set `metadata["vouched-subsets"]` to the second element of the `signatures`
+   array.
 
 ### Parsing the critical section {#critical-section}
 
@@ -820,6 +889,7 @@ Initial Assignments:
 | Section Name | Specification | Metadata |
 | "index" | {{index-section}} | Yes |
 | "manifest" | {{manifest-section}} | Yes |
+| "signatures" | {{signatures-section}} | Yes |
 | "critical" | {{critical-section}} | Yes |
 | "responses" | {{responses-section}} | No |
 

--- a/draft-yasskin-wpack-bundled-exchanges.md
+++ b/draft-yasskin-wpack-bundled-exchanges.md
@@ -335,7 +335,8 @@ each of the possible combinations of available-values within the `Variants`
 value in lexicographic (row-major) order.
 
 For example, given a `variants-value` of "Accept-Encoding;gzip;br,
-Accept-Language;en;fr;ja", the `variantKeys` list will be:
+Accept-Language;en;fr;ja", the list of `location-in-responses` pairs will
+correspond to the `VariantKey`s:
 
 * gzip;en
 * gzip;fr
@@ -345,8 +346,8 @@ Accept-Language;en;fr;ja", the `variantKeys` list will be:
 * br;ja
 
 The order of variant-axes is important. If the `variants-value` were
-"Accept-Language;en;fr;ja, Accept-Encoding;gzip;br" instead, the `variantKeys`
-list would be:
+"Accept-Language;en;fr;ja, Accept-Encoding;gzip;br" instead, the
+`location-in-responses` pairs would instead correspond to:
 
 * en;gzip
 * en;br
@@ -406,8 +407,9 @@ map, and the `metadata` map to fill in, the parser MUST do the following:
       1. Let `variants` be the result of parsing the first element of
          `responses` as the value of the `Variants` HTTP header field (Section 2
          of {{!I-D.ietf-httpbis-variants}}). If this fails, return an error.
-      1. Let `variantKeys` be the Cartesian product of the lists of available-values
-         for each variant-axis in lexicographic (row-major) order.
+      1. Let `variantKeys` be the Cartesian product of the lists of
+         available-values for each variant-axis in lexicographic (row-major)
+         order. See the examples above.
       1. If the length of `responses` is not `2 * len(variantKeys) + 1`, return
          an error.
       1. Set `requests`\[`parsedUrl`] to a map from `variantKeys`\[`i`] to the


### PR DESCRIPTION
Preview at https://jyasskin.github.io/webpackage/update-bundle-format/draft-yasskin-wpack-bundled-exchanges.html.

Sorry for the late mail: I belatedly realized the [IETF deadline](https://datatracker.ietf.org/meeting/105/important-dates/) is Monday, and it’d be nice to have an update to the bundle format published then. We’ll be able to publish another revision at the beginning of the IETF week.

This update includes:

* An invariant fallback URL, like signed exchanges have.
* A version number, so we can easily know to fall back to a redirect.
* Some infrastructure to identify what kind of error broke the parse, which can feed into both Network Error Logging and #397’s discussion of when to fall back.
* The [index](https://jyasskin.github.io/webpackage/update-bundle-format/draft-yasskin-wpack-bundled-exchanges.html#index-section) maps URLs to a Variants value + a list of the responses for each possible Variant-Key.
* A new [signatures](https://jyasskin.github.io/webpackage/update-bundle-format/draft-yasskin-wpack-bundled-exchanges.html#signatures-section) section allows authorities to vouch for particular subsets of the bundle. For cross-origin trust, which I think will get defined in the loading spec, I think the requirement that the validity-url is same-origin is going to force us to make those single-origin subsets, even when there might be a certificate that is trusted to sign multiple origins. I’ve run the basic structure by @sleevi who liked that the signed fields are all together in a byte string.
