### PR TITLE
Provide error message for unexpected mime type

### DIFF
--- a/go/signedexchange/cmd/dump-signedexchange/main.go
+++ b/go/signedexchange/cmd/dump-signedexchange/main.go
@@ -84,6 +84,10 @@ func run() error {
 		if err != nil {
 			return err
 		}
+		respMimeType := resp.Header.Get("Content-Type")
+		if respMimeType != mimeType {
+			return fmt.Errorf("GET %q responded with unexpected content type %q", *flagURI, respMimeType)
+		}
 		in = resp.Body
 		defer resp.Body.Close()
 	} else if (fi.Mode() & os.ModeCharDevice) == 0 { // read sxg from pipe


### PR DESCRIPTION
When fetching with the `-uri` flag, the go http client can give us a more helpful error message than `unknown magic bytes: [60 33 100 111 99 116 121 112]`

This PR checks the mime type of the response against the expected mime type for the version it is requesting and if they do not equal, it will error with `GET "https://example.com" responded with unexpected content type "text/html; charset=utf-8"`