### PR TITLE
Use the right initial byte for the top-level 6-element array.

### DIFF
--- a/draft-yasskin-wpack-bundled-exchanges.md
+++ b/draft-yasskin-wpack-bundled-exchanges.md
@@ -263,8 +263,8 @@ steps, taking the `stream` as input.
 1. Seek to offset 0 in `stream`. Assert: this operation doesn't fail.
 
 1. If reading 10 bytes from `stream` returns an error or doesn't return the
-   bytes with hex encoding "84 48 F0 9F 8C 90 F0 9F 93 A6" (the CBOR encoding of
-   the 4-item array initial byte and 8-byte bytestring initial byte, followed by
+   bytes with hex encoding "86 48 F0 9F 8C 90 F0 9F 93 A6" (the CBOR encoding of
+   the 6-item array initial byte and 8-byte bytestring initial byte, followed by
    🌐📦 in UTF-8), return a "format error".
 
 1. Let `version` be the result of reading 5 bytes from `stream`. If this is

--- a/draft-yasskin-wpack-bundled-exchanges.md
+++ b/draft-yasskin-wpack-bundled-exchanges.md
@@ -911,7 +911,7 @@ at <https://www.iana.org/assignments/media-types>.
 * Additional information:
 
   * Deprecated alias names for this type: N/A
-  * Magic number(s): 84 48 F0 9F 8C 90 F0 9F 93 A6
+  * Magic number(s): 86 48 F0 9F 8C 90 F0 9F 93 A6
   * File extension(s): .wbn
   * Macintosh file type code(s): N/A
 


### PR DESCRIPTION
Thanks irori for noticing!