### PR TITLE
`dump-signedexchange -verify`: decode MICE again.

### DIFF
--- a/go/signedexchange/cmd/dump-signedexchange/main.go
+++ b/go/signedexchange/cmd/dump-signedexchange/main.go
@@ -120,15 +120,15 @@ func run() error {
 			}
 		}
 
-		if *flagPayload {
-			e.PrettyPrintPayload(os.Stdout)
-		}
-
 		if *flagVerify {
 			fmt.Println()
 			if err := verify(e, certFetcher, verificationTime); err != nil {
 				return err
 			}
+		}
+
+		if *flagPayload {
+			e.PrettyPrintPayload(os.Stdout)
 		}
 	}
 


### PR DESCRIPTION
This functionality was reverted in #429 (I think unintentionally);
re-enabling, to allow use of this tool as a hacky way to extract
MICE-decoded payload, via something like:

$ cat sxg | dump-signedexchange -verify | sed '0,/^payload /d' >html