### PR TITLE
go/bundle: Add support for multiple versions

### DIFF
--- a/go/bundle/bundle_test.go
+++ b/go/bundle/bundle_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	. "github.com/WICG/webpackage/go/bundle"
+	"github.com/WICG/webpackage/go/bundle/version"
 )
 
 func urlMustParse(rawurl string) *url.URL {
@@ -18,8 +19,9 @@ func urlMustParse(rawurl string) *url.URL {
 	return u
 }
 
-func createTestBundle() *Bundle {
+func createTestBundle(version version.Version) *Bundle {
 	return &Bundle{
+		Version: version,
 		Exchanges: []*Exchange{
 			&Exchange{
 				Request{
@@ -37,22 +39,24 @@ func createTestBundle() *Bundle {
 }
 
 func TestWriteAndRead(t *testing.T) {
-	bundle := createTestBundle()
+	for _, ver := range version.AllVersions {
+		bundle := createTestBundle(ver)
 
-	var buf bytes.Buffer
-	n, err := bundle.WriteTo(&buf)
-	if err != nil {
-		t.Errorf("Bundle.WriteTo unexpectedly failed: %v", err)
-	}
-	if n != int64(buf.Len()) {
-		t.Errorf("Bundle.WriteTo returned %d, but wrote %d bytes", n, buf.Len())
-	}
+		var buf bytes.Buffer
+		n, err := bundle.WriteTo(&buf)
+		if err != nil {
+			t.Errorf("Bundle.WriteTo unexpectedly failed: %v", err)
+		}
+		if n != int64(buf.Len()) {
+			t.Errorf("Bundle.WriteTo returned %d, but wrote %d bytes", n, buf.Len())
+		}
 
-	deserialized, err := Read(&buf)
-	if err != nil {
-		t.Errorf("Bundle.Read unexpectedly failed: %v", err)
-	}
-	if !reflect.DeepEqual(deserialized, bundle) {
-		t.Errorf("got: %v\nwant: %v", deserialized, bundle)
+		deserialized, err := Read(&buf)
+		if err != nil {
+			t.Errorf("Bundle.Read unexpectedly failed: %v", err)
+		}
+		if !reflect.DeepEqual(deserialized, bundle) {
+			t.Errorf("got: %v\nwant: %v", deserialized, bundle)
+		}
 	}
 }

--- a/go/bundle/cmd/dump-bundle/main.go
+++ b/go/bundle/cmd/dump-bundle/main.go
@@ -29,6 +29,8 @@ func run() error {
 		return err
 	}
 
+	fmt.Printf("Version: %v\n", b.Version)
+
 	if b.ManifestURL != nil {
 		fmt.Printf("Manifest URL: %v\n", b.ManifestURL)
 	}

--- a/go/bundle/cmd/gen-bundle/fromdir.go
+++ b/go/bundle/cmd/gen-bundle/fromdir.go
@@ -11,9 +11,10 @@ import (
 	"strings"
 
 	"github.com/WICG/webpackage/go/bundle"
+	"github.com/WICG/webpackage/go/bundle/version"
 )
 
-func fromDir(dir string, baseURL string, startURL string, manifestURL string) error {
+func fromDir(dir string, ver version.Version, baseURL string, startURL string, manifestURL string) error {
 	parsedBaseURL, err := url.Parse(baseURL)
 	if err != nil {
 		return fmt.Errorf("Failed to parse base URL. err: %v", err)
@@ -40,7 +41,7 @@ func fromDir(dir string, baseURL string, startURL string, manifestURL string) er
 	if err != nil {
 		return err
 	}
-	b := &bundle.Bundle{Exchanges: es, ManifestURL: parsedManifestURL}
+	b := &bundle.Bundle{Version: ver, Exchanges: es, ManifestURL: parsedManifestURL}
 	// Move the startURL entry to first.
 	for i, e := range b.Exchanges {
 		if e.Request.URL.String() == parsedStartURL.String() {

--- a/go/bundle/version/version.go
+++ b/go/bundle/version/version.go
@@ -13,6 +13,11 @@ const (
 	VersionB1 Version = "b1"
 )
 
+var AllVersions = []Version{
+	Unversioned,
+	VersionB1,
+}
+
 // The CBOR encoding of the 4-item array initial byte and 8-byte bytestring initial byte, followed by 🌐📦 in UTF-8.
 var HeaderMagicBytesUnversioned = []byte{0x84, 0x48, 0xf0, 0x9f, 0x8c, 0x90, 0xf0, 0x9f, 0x93, 0xa6}
 // The CBOR encoding of the 6-item array initial byte and 8-byte bytestring initial byte, followed by 🌐📦 in UTF-8.

--- a/go/bundle/version/version.go
+++ b/go/bundle/version/version.go
@@ -1,0 +1,65 @@
+package version
+
+import (
+	"bytes"
+	"errors"
+	"io"
+)
+
+type Version string
+
+const (
+	Unversioned Version = "unversioned"
+	VersionB1 Version = "b1"
+)
+
+// The CBOR encoding of the 4-item array initial byte and 8-byte bytestring initial byte, followed by 🌐📦 in UTF-8.
+var HeaderMagicBytesUnversioned = []byte{0x84, 0x48, 0xf0, 0x9f, 0x8c, 0x90, 0xf0, 0x9f, 0x93, 0xa6}
+// The CBOR encoding of the 6-item array initial byte and 8-byte bytestring initial byte, followed by 🌐📦 in UTF-8.
+var HeaderMagicBytes = []byte{0x86, 0x48, 0xf0, 0x9f, 0x8c, 0x90, 0xf0, 0x9f, 0x93, 0xa6}
+
+// The CBOR encoding of a 4-byte byte string holding an ASCII "b1" followed by two 0 bytes
+var VersionMagicBytesB1 = []byte{0x44, 0x62, 0x31, 0x00, 0x00}
+
+func Parse(str string) (Version, bool) {
+	switch Version(str) {
+	case Unversioned:
+		return Unversioned, true
+	case VersionB1:
+		return VersionB1, true
+	}
+	return "", false
+}
+
+func (v Version) HeaderMagicBytes() []byte {
+	switch v {
+	case Unversioned:
+		return HeaderMagicBytesUnversioned
+	case VersionB1:
+		return append(HeaderMagicBytes, VersionMagicBytesB1...)
+	default:
+		panic("not reached")
+	}
+}
+
+func ParseMagicBytes(r io.Reader) (Version, error) {
+	hdrMagic := make([]byte, len(HeaderMagicBytes))
+	if _, err := io.ReadFull(r, hdrMagic); err != nil {
+		return "", err
+	}
+	if bytes.Compare(hdrMagic, HeaderMagicBytesUnversioned) == 0 {
+		return Unversioned, nil
+	}
+	if bytes.Compare(hdrMagic, HeaderMagicBytes) != 0 {
+		return "", errors.New("bundle: header magic mismatch")
+	}
+
+	verMagic := make([]byte, len(VersionMagicBytesB1))
+	if _, err := io.ReadFull(r, verMagic); err != nil {
+		return "", err
+	}
+	if bytes.Compare(verMagic, VersionMagicBytesB1) == 0 {
+		return VersionB1, nil
+	}
+	return "", errors.New("bundle: unrecognized version magic")
+}

--- a/go/bundle/version/version.go
+++ b/go/bundle/version/version.go
@@ -18,12 +18,12 @@ var AllVersions = []Version{
 	VersionB1,
 }
 
-// The CBOR encoding of the 4-item array initial byte and 8-byte bytestring initial byte, followed by 🌐📦 in UTF-8.
+// HeaderMagicBytesUnversioned is the CBOR encoding of the 4-item array initial byte and 8-byte bytestring initial byte, followed by 🌐📦 in UTF-8.
 var HeaderMagicBytesUnversioned = []byte{0x84, 0x48, 0xf0, 0x9f, 0x8c, 0x90, 0xf0, 0x9f, 0x93, 0xa6}
-// The CBOR encoding of the 6-item array initial byte and 8-byte bytestring initial byte, followed by 🌐📦 in UTF-8.
+// HeaderMagicBytes is the CBOR encoding of the 6-item array initial byte and 8-byte bytestring initial byte, followed by 🌐📦 in UTF-8.
 var HeaderMagicBytes = []byte{0x86, 0x48, 0xf0, 0x9f, 0x8c, 0x90, 0xf0, 0x9f, 0x93, 0xa6}
 
-// The CBOR encoding of a 4-byte byte string holding an ASCII "b1" followed by two 0 bytes
+// VersionMagicBytesB1 is the CBOR encoding of a 4-byte byte string holding an ASCII "b1" followed by two 0 bytes
 var VersionMagicBytesB1 = []byte{0x44, 0x62, 0x31, 0x00, 0x00}
 
 func Parse(str string) (Version, bool) {


### PR DESCRIPTION
This is a preparation for supporting the new bundle format (#450).

- Introduces `Version` type to represent spec versions. `version.Unversioned` represents the old format before #450.
- `gen-bundle` now accepts `-version` flag. Note that it doesn't generate valid bundle in the new format yet.