### PR TITLE
CBOR decoder: block  resource exhaustion attacks

### DIFF
--- a/go/signedexchange/cbor/decoder.go
+++ b/go/signedexchange/cbor/decoder.go
@@ -1,6 +1,7 @@
 package cbor
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"unicode/utf8"
@@ -95,11 +96,11 @@ func (d *Decoder) decodeBytesOfType(expected Type) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	bs := make([]byte, n)
-	if _, err := io.ReadFull(d.r, bs); err != nil {
+	bs := new(bytes.Buffer)
+	if _, err := io.CopyN(bs, d.r, int64(n)); err != nil {
 		return nil, err
 	}
-	return bs, nil
+	return bs.Bytes(), nil
 }
 
 func (d *Decoder) DecodeTextString() (string, error) {

--- a/go/signedexchange/cbor/decoder_test.go
+++ b/go/signedexchange/cbor/decoder_test.go
@@ -48,3 +48,12 @@ func TestDecodeByteString(t *testing.T) {
 		}
 	}
 }
+
+func TestDecodeByteStringNotCrashing(t *testing.T) {
+	var in = []byte{0x5b, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+	e := NewDecoder(bytes.NewReader(in))
+	_, err := e.DecodeByteString()
+	if err == nil {
+		t.Error("got success, want error")
+	}
+}


### PR DESCRIPTION
As stated in https://tools.ietf.org/html/rfc7049#section-8, CBOR decoder should be careful about resource exhaustion attacks. Typical one could be passing `0x5BFFFFFFFFFFFFFFFF`, a header saying "I am a byte string of length 2^64 - 1", without actual data followed.

Current implementation allocates memory for following bytes exactly as the header requested:
https://github.com/WICG/webpackage/blob/ce24b25d587c891a45aa6602fef2ded1854d45fa/go/signedexchange/cbor/decoder.go#L93-L98

For instance, Chromium checks the size of rest bytes beforehand to defend against this:
https://github.com/chromium/chromium/blob/6efa1184771ace08f3e2162b0255c93526d1750d/components/cbor/reader.cc#L352-L355

Disclaimer: I'm not familiar with golang so if there is any better solution, please go that way.

Golang's `io.Reader` seems a sort of "stream" interface therefore the same solution cannot be applicable.
Alternatives could be
- Stop using `io.Reader`
- Read byte by byte into growing buffer
- Try to read by doubling the size (read 1 byte, 2 byte, 4byte, 8 byte...)
(The last two are almost same in terms of amortized complexity trick but the latter can be faster if the read operation costs)

Current choice is to use `bytes.Buffer`, which is, to my understanding, a wrapped growing byte vector which can behave as `io.Writer`. That's because changing to this is super-easy and doesn't cost computation time a lot, very similar to the second solution above.

