### PR TITLE
gen-bundle: Better support for b1 and refactoring

### DIFF
--- a/go/bundle/cmd/gen-bundle/fromdir.go
+++ b/go/bundle/cmd/gen-bundle/fromdir.go
@@ -11,52 +11,9 @@ import (
 	"strings"
 
 	"github.com/WICG/webpackage/go/bundle"
-	"github.com/WICG/webpackage/go/bundle/version"
 )
 
-func fromDir(dir string, ver version.Version, baseURL string, startURL string, manifestURL string) error {
-	parsedBaseURL, err := url.Parse(baseURL)
-	if err != nil {
-		return fmt.Errorf("Failed to parse base URL. err: %v", err)
-	}
-	parsedStartURL, err := parsedBaseURL.Parse(startURL)
-	if err != nil {
-		return fmt.Errorf("Failed to parse start URL. err: %v", err)
-	}
-	var parsedManifestURL *url.URL
-	if len(manifestURL) > 0 {
-		parsedManifestURL, err = parsedBaseURL.Parse(manifestURL)
-		if err != nil {
-			return fmt.Errorf("Failed to parse manifest URL. err: %v", err)
-		}
-	}
-
-	fo, err := os.OpenFile(*flagOutput, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-	if err != nil {
-		return fmt.Errorf("Failed to open output file %q for writing. err: %v", *flagOutput, err)
-	}
-	defer fo.Close()
-
-	es, err := createExchangesFromDir(dir, parsedBaseURL)
-	if err != nil {
-		return err
-	}
-	b := &bundle.Bundle{Version: ver, PrimaryURL: parsedStartURL, Exchanges: es, ManifestURL: parsedManifestURL}
-	// Move the startURL entry to first.
-	for i, e := range b.Exchanges {
-		if e.Request.URL.String() == parsedStartURL.String() {
-			b.Exchanges[0], b.Exchanges[i] = b.Exchanges[i], b.Exchanges[0]
-			break
-		}
-	}
-
-	if _, err := b.WriteTo(fo); err != nil {
-		return fmt.Errorf("Failed to write exchange. err: %v", err)
-	}
-	return nil
-}
-
-func createExchangesFromDir(baseDir string, baseURL *url.URL) ([]*bundle.Exchange, error) {
+func fromDir(baseDir string, baseURL *url.URL) ([]*bundle.Exchange, error) {
 	es := []*bundle.Exchange{}
 	err := filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/go/bundle/cmd/gen-bundle/fromhar.go
+++ b/go/bundle/cmd/gen-bundle/fromhar.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/mrichman/hargo"
+
+	"github.com/WICG/webpackage/go/bundle"
+	"github.com/WICG/webpackage/go/signedexchange"
+)
+
+func ReadHar(r io.Reader) (*hargo.Har, error) {
+	dec := json.NewDecoder(r)
+	var har hargo.Har
+	if err := dec.Decode(&har); err != nil {
+		return nil, fmt.Errorf("Failed to parse har. err: %v", err)
+	}
+	return &har, nil
+}
+
+func ReadHarFromFile(path string) (*hargo.Har, error) {
+	fi, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to open input file %q for reading. err: %v", path, err)
+	}
+	defer fi.Close()
+	return ReadHar(fi)
+}
+
+func nvpToHeader(nvps []hargo.NVP, predBanned func(string) bool) (http.Header, error) {
+	h := make(http.Header)
+	for _, nvp := range nvps {
+		// Drop HTTP/2 pseudo headers.
+		if strings.HasPrefix(nvp.Name, ":") {
+			continue
+		}
+		if predBanned(nvp.Name) {
+			log.Printf("Dropping banned header: %q", nvp.Name)
+			continue
+		}
+		h.Add(nvp.Name, nvp.Value)
+	}
+	return h, nil
+}
+
+func contentToBody(c *hargo.Content) ([]byte, error) {
+	if c.Encoding == "base64" {
+		return base64.StdEncoding.DecodeString(c.Text)
+	}
+	return []byte(c.Text), nil
+}
+
+func fromHar(harPath string) ([]*bundle.Exchange, error) {
+	har, err := ReadHarFromFile(harPath)
+	if err != nil {
+		return nil, err
+	}
+
+	es := []*bundle.Exchange{}
+
+	for _, e := range har.Log.Entries {
+		log.Printf("Processing entry: %q", e.Request.URL)
+
+		parsedUrl, err := url.Parse(e.Request.URL) // TODO(kouhei): May be this should e.Respose.RedirectURL?
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse request URL %q. err: %v", e.Request.URL, err)
+		}
+		reqh, err := nvpToHeader(e.Request.Headers, signedexchange.IsStatefulRequestHeader)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse request header for the request %q. err: %v", e.Request.URL, err)
+		}
+		resh, err := nvpToHeader(e.Response.Headers, signedexchange.IsUncachedHeader)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse response header for the request %q. err: %v", e.Request.URL, err)
+		}
+		body, err := contentToBody(&e.Response.Content)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to extract body from response content for the request %q. err: %v", e.Request.URL, err)
+		}
+
+		if e.Request.Method != http.MethodGet {
+			log.Printf("Dropping the entry: non-GET request method (%s)", e.Request.Method)
+			continue
+		}
+		if e.Response.Status < 100 || e.Response.Status > 999 {
+			log.Printf("Dropping the entry: invalid response status (%d)", e.Response.Status)
+			continue
+		}
+
+		e := &bundle.Exchange{
+			Request: bundle.Request{
+				URL:    parsedUrl,
+				Header: reqh,
+			},
+			Response: bundle.Response{
+				Status: e.Response.Status,
+				Header: resh,
+				Body:   body,
+			},
+		}
+		es = append(es, e)
+	}
+
+	return es, nil
+}

--- a/go/bundle/cmd/gen-bundle/main.go
+++ b/go/bundle/cmd/gen-bundle/main.go
@@ -1,139 +1,25 @@
 package main
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"log"
-	"net/http"
 	"net/url"
 	"os"
-	"strings"
-
-	"github.com/mrichman/hargo"
 
 	"github.com/WICG/webpackage/go/bundle"
 	"github.com/WICG/webpackage/go/bundle/version"
-	"github.com/WICG/webpackage/go/signedexchange"
 )
 
 var (
 	flagVersion     = flag.String("version", string(version.Unversioned), "The webbundle format version")
 	flagHar         = flag.String("har", "", "HTTP Archive (HAR) input file")
 	flagDir         = flag.String("dir", "", "Input directory")
-	flagBaseURL     = flag.String("baseURL", "", "Base URL")
-	flagStartURL    = flag.String("startURL", "", "Entry point URL (relative from -baseURL)")
-	flagManifestURL = flag.String("manifestURL", "", "Manifest URL (relative from -baseURL)")
+	flagBaseURL     = flag.String("baseURL", "", "Base URL (used with -dir)")
+	flagPrimaryURL  = flag.String("primaryURL", "", "Primary URL")
+	flagManifestURL = flag.String("manifestURL", "", "Manifest URL")
 	flagOutput      = flag.String("o", "out.wbn", "Webbundle output file")
 )
-
-func ReadHar(r io.Reader) (*hargo.Har, error) {
-	dec := json.NewDecoder(r)
-	var har hargo.Har
-	if err := dec.Decode(&har); err != nil {
-		return nil, fmt.Errorf("Failed to parse har. err: %v", err)
-	}
-	return &har, nil
-}
-
-func ReadHarFromFile(path string) (*hargo.Har, error) {
-	fi, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to open input file %q for reading. err: %v", path, err)
-	}
-	defer fi.Close()
-	return ReadHar(fi)
-}
-
-func nvpToHeader(nvps []hargo.NVP, predBanned func(string) bool) (http.Header, error) {
-	h := make(http.Header)
-	for _, nvp := range nvps {
-		// Drop HTTP/2 pseudo headers.
-		if strings.HasPrefix(nvp.Name, ":") {
-			continue
-		}
-		if predBanned(nvp.Name) {
-			log.Printf("Dropping banned header: %q", nvp.Name)
-			continue
-		}
-		h.Add(nvp.Name, nvp.Value)
-	}
-	return h, nil
-}
-
-func contentToBody(c *hargo.Content) ([]byte, error) {
-	if c.Encoding == "base64" {
-		return base64.StdEncoding.DecodeString(c.Text)
-	}
-	return []byte(c.Text), nil
-}
-
-func fromHar(harPath string, ver version.Version) error {
-	har, err := ReadHarFromFile(harPath)
-	if err != nil {
-		return err
-	}
-
-	fo, err := os.OpenFile(*flagOutput, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-	if err != nil {
-		return fmt.Errorf("Failed to open output file %q for writing. err: %v", *flagOutput, err)
-	}
-	defer fo.Close()
-
-	es := []*bundle.Exchange{}
-
-	for _, e := range har.Log.Entries {
-		log.Printf("Processing entry: %q", e.Request.URL)
-
-		parsedUrl, err := url.Parse(e.Request.URL) // TODO(kouhei): May be this should e.Respose.RedirectURL?
-		if err != nil {
-			return fmt.Errorf("Failed to parse request URL %q. err: %v", e.Request.URL, err)
-		}
-		reqh, err := nvpToHeader(e.Request.Headers, signedexchange.IsStatefulRequestHeader)
-		if err != nil {
-			return fmt.Errorf("Failed to parse request header for the request %q. err: %v", e.Request.URL, err)
-		}
-		resh, err := nvpToHeader(e.Response.Headers, signedexchange.IsUncachedHeader)
-		if err != nil {
-			return fmt.Errorf("Failed to parse response header for the request %q. err: %v", e.Request.URL, err)
-		}
-		body, err := contentToBody(&e.Response.Content)
-		if err != nil {
-			return fmt.Errorf("Failed to extract body from response content for the request %q. err: %v", e.Request.URL, err)
-		}
-
-		if e.Request.Method != http.MethodGet {
-			log.Printf("Dropping the entry: non-GET request method (%s)", e.Request.Method)
-			continue
-		}
-		if e.Response.Status < 100 || e.Response.Status > 999 {
-			log.Printf("Dropping the entry: invalid response status (%d)", e.Response.Status)
-			continue
-		}
-
-		e := &bundle.Exchange{
-			Request: bundle.Request{
-				URL:    parsedUrl,
-				Header: reqh,
-			},
-			Response: bundle.Response{
-				Status: e.Response.Status,
-				Header: resh,
-				Body:   body,
-			},
-		}
-		es = append(es, e)
-	}
-
-	b := &bundle.Bundle{Version: ver, Exchanges: es}
-
-	if _, err := b.WriteTo(fo); err != nil {
-		return fmt.Errorf("Failed to write exchange. err: %v", err)
-	}
-	return nil
-}
 
 func main() {
 	flag.Parse()
@@ -142,28 +28,64 @@ func main() {
 	if !ok {
 		log.Fatalf("Error: failed to parse version %q\n", *flagVersion)
 	}
+	if *flagPrimaryURL == "" {
+		fmt.Fprintln(os.Stderr, "Please specify -primaryURL.")
+		flag.Usage()
+		return
+	}
+	parsedPrimaryURL, err := url.Parse(*flagPrimaryURL)
+	if err != nil {
+		log.Fatalf("Failed to parse primary URL. err: %v", err)
+	}
+	var parsedManifestURL *url.URL
+	if len(*flagManifestURL) > 0 {
+		parsedManifestURL, err = url.Parse(*flagManifestURL)
+		if err != nil {
+			log.Fatalf("Failed to parse manifest URL. err: %v", err)
+		}
+	}
+
+	b := &bundle.Bundle{Version: ver, PrimaryURL: parsedPrimaryURL, ManifestURL: parsedManifestURL}
 
 	if *flagHar != "" {
 		if *flagBaseURL != "" {
 			fmt.Fprintln(os.Stderr, "Warning: -baseURL is ignored when input is HAR.")
 		}
-		if *flagStartURL != "" {
-			fmt.Fprintln(os.Stderr, "Warning: -startURL is ignored when input is HAR.")
+		if *flagPrimaryURL != "" {
+			fmt.Fprintln(os.Stderr, "Warning: -primaryURL is ignored when input is HAR.")
 		}
-		if err := fromHar(*flagHar, ver); err != nil {
+		es, err := fromHar(*flagHar)
+		if err != nil {
 			log.Fatal(err)
 		}
+		b.Exchanges = es
 	} else if *flagDir != "" {
 		if *flagBaseURL == "" {
 			fmt.Fprintln(os.Stderr, "Please specify -baseURL.")
 			flag.Usage()
 			return
 		}
-		if err := fromDir(*flagDir, ver, *flagBaseURL, *flagStartURL, *flagManifestURL); err != nil {
+		parsedBaseURL, err := url.Parse(*flagBaseURL)
+		if err != nil {
+			log.Fatalf("Failed to parse base URL. err: %v", err)
+		}
+		es, err := fromDir(*flagDir, parsedBaseURL)
+		if err != nil {
 			log.Fatal(err)
 		}
+		b.Exchanges = es
 	} else {
 		fmt.Fprintln(os.Stderr, "Please specify -har or -dir.")
 		flag.Usage()
+		return
+	}
+
+	fo, err := os.OpenFile(*flagOutput, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		log.Fatalf("Failed to open output file %q for writing. err: %v", *flagOutput, err)
+	}
+	defer fo.Close()
+	if _, err := b.WriteTo(fo); err != nil {
+		log.Fatalf("Failed to write exchange. err: %v", err)
 	}
 }


### PR DESCRIPTION
Behavioral changes:
- -startURL flag is renamed to -primaryURL, and now it's required
- -startURL and -manifestURL must be absolute

Non-behavioral changes:
- Move fromHar() and its helpers to a separate file (fromhar.go)
- Now fromHar() and fromDir() return a list of exchanges
