### PR TITLE
Fix #445: Empty responses like redirections don't need a content type.

### DIFF
--- a/draft-yasskin-wpack-bundled-exchanges.md
+++ b/draft-yasskin-wpack-bundled-exchanges.md
@@ -662,16 +662,18 @@ steps, taking the bundle's `stream`, a `request` ({{FETCH}}), and a
 1. If `pseudos[':status']` isn't exactly 3 ASCII decimal digits, return an
    error.
 
-1. If `headers` does not contain a `Content-Type` header, return an error.
+1. Let `payloadLength` be the result of getting the length of a CBOR bytestring
+   header from `stream` ({{parse-bytestring}}). If `payloadLength` is an error,
+   return that error.
+
+1. If `payloadLength` is greater than 0 and `headers` does not contain a
+   `Content-Type` header, return an error.
 
    The client MUST interpret the following payload as this specified media type
    instead of trying to sniff a media type from the bytes of the payload, for
    example by appending an artificial `X-Content-Type-Options: nosniff` header
    field ({{FETCH}}) to `headers`.
 
-1. Let `payloadLength` be the result of getting the length of a CBOR bytestring
-   header from `stream` ({{parse-bytestring}}). If `payloadLength` is an error,
-   return that error.
 1. If `stream.currentOffset + payloadLength != responseMetadata.offset +
    responseMetadata.length`, return an error.
 


### PR DESCRIPTION
Does this make sense?