### PR TITLE
go: Refactor certchain.go

### DIFF
--- a/go/signedexchange/certurl/certchain.go
+++ b/go/signedexchange/certurl/certchain.go
@@ -1,7 +1,10 @@
+// Package certurl implements a parser and a serializer for application/cert-chain+cbor format.
+// See https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#cert-chain-format for the spec.
 package certurl
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/asn1"
 	"errors"
@@ -12,13 +15,13 @@ import (
 	"github.com/WICG/webpackage/go/signedexchange/cbor"
 )
 
-type CertChainItem struct {
+type AugmentedCertificate struct {
 	Cert         *x509.Certificate // A parsed X.509 certificate.
 	OCSPResponse []byte            // DER-encoded OCSP response for Cert.
 	SCTList      []byte            // SignedCertificateTimestampList (Section 3.3 of RFC6962) for Cert.
 }
 
-type CertChain []*CertChainItem
+type CertChain []*AugmentedCertificate
 
 const magicString = "\U0001F4DC\u26D3" // "📜⛓"
 
@@ -31,16 +34,37 @@ func NewCertChain(certs []*x509.Certificate, ocsp, sct []byte) (CertChain, error
 
 	certChain := CertChain{}
 	for _, cert := range certs {
-		certChain = append(certChain, &CertChainItem{Cert: cert})
+		certChain = append(certChain, &AugmentedCertificate{Cert: cert})
 	}
 	certChain[0].OCSPResponse = ocsp
 	certChain[0].SCTList = sct
 	return certChain, nil
 }
 
+// Validate performs basic sanity checks on the cert chain.
+// It returns nil if the chain is valid, or else an error describing a problem.
+func (certChain CertChain) Validate() error {
+	if len(certChain) == 0 {
+		return errors.New("cert-chain: cert chain must not be empty")
+	}
+	for i, item := range certChain {
+		if i == 0 && item.OCSPResponse == nil {
+			return errors.New("cert-chain: the first certificate must have an OCSP response")
+		}
+		if i != 0 && item.OCSPResponse != nil {
+			return fmt.Errorf("cert-chain: certificate at position %d must not have an OCSP response.", i)
+		}
+	}
+	return nil
+}
+
 // Write generates a certificate chain of application/cert-chain+cbor format and writes to w.
-// See https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#cert-chain-format for the spec.
 func (certChain CertChain) Write(w io.Writer) error {
+	if err := certChain.Validate(); err != nil {
+		// Don't serialize invalid cert chain.
+		return err
+	}
+
 	enc := cbor.NewEncoder(w)
 
 	if err := enc.EncodeArrayHeader(len(certChain) + 1); err != nil {
@@ -49,35 +73,8 @@ func (certChain CertChain) Write(w io.Writer) error {
 	if err := enc.EncodeTextString(magicString); err != nil {
 		return err
 	}
-	for i, item := range certChain {
-		mes := []*cbor.MapEntryEncoder{
-			cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
-				keyE.EncodeTextString("cert")
-				valueE.EncodeByteString(item.Cert.Raw)
-			}),
-		}
-		if i == 0 {
-			if item.OCSPResponse == nil {
-				return fmt.Errorf("The first certificate must have an OCSP response.")
-			}
-			mes = append(mes,
-				cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
-					keyE.EncodeTextString("ocsp")
-					valueE.EncodeByteString(item.OCSPResponse)
-				}))
-		} else {
-			if item.OCSPResponse != nil {
-				return fmt.Errorf("Certificate at position %d must not have an OCSP response.", i)
-			}
-		}
-		if item.SCTList != nil {
-			mes = append(mes,
-				cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
-					keyE.EncodeTextString("sct")
-					valueE.EncodeByteString(item.SCTList)
-				}))
-		}
-		if err := enc.EncodeMap(mes); err != nil {
+	for _, item := range certChain {
+		if err := item.EncodeTo(enc); err != nil {
 			return err
 		}
 	}
@@ -85,8 +82,38 @@ func (certChain CertChain) Write(w io.Writer) error {
 	return nil
 }
 
+// EncodeTo encodes ac as an augmented-certificate CBOR item.
+func (ac *AugmentedCertificate) EncodeTo(enc *cbor.Encoder) error {
+	mes := []*cbor.MapEntryEncoder{
+		cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
+			keyE.EncodeTextString("cert")
+			valueE.EncodeByteString(ac.Cert.Raw)
+		}),
+	}
+	if ac.OCSPResponse != nil {
+		mes = append(mes,
+			cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
+				keyE.EncodeTextString("ocsp")
+				valueE.EncodeByteString(ac.OCSPResponse)
+			}))
+	}
+	if ac.SCTList != nil {
+		mes = append(mes,
+			cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
+				keyE.EncodeTextString("sct")
+				valueE.EncodeByteString(ac.SCTList)
+			}))
+	}
+	return enc.EncodeMap(mes)
+}
+
+// CertSha256 returns SHA-256 hash of the DER-encoded X.509v3 certificate.
+func (ac *AugmentedCertificate) CertSha256() []byte {
+	sum := sha256.Sum256(ac.Cert.Raw)
+	return sum[:]
+}
+
 // ReadCertChain parses the application/cert-chain+cbor format.
-// See https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#cert-chain-format for the spec.
 func ReadCertChain(r io.Reader) (CertChain, error) {
 	dec := cbor.NewDecoder(r)
 	n, err := dec.DecodeArrayHeader()
@@ -105,44 +132,51 @@ func ReadCertChain(r io.Reader) (CertChain, error) {
 	}
 	certChain := CertChain{}
 	for i := uint64(1); i < n; i++ {
-		m, err := dec.DecodeMapHeader()
+		ac, err := DecodeAugmentedCertificateFrom(dec)
 		if err != nil {
-			return nil, fmt.Errorf("cert-chain: failed to decode certificate map header: %v", err)
+			return nil, err
 		}
-		item := &CertChainItem{}
-		for j := uint64(0); j < m; j++ {
-			key, err := dec.DecodeTextString()
-			if err != nil {
-				return nil, fmt.Errorf("cert-chain: failed to decode map key: %v", err)
-			}
-			value, err := dec.DecodeByteString()
-			if err != nil {
-				return nil, fmt.Errorf("cert-chain: failed to decode map value: %v", err)
-			}
-			switch key {
-			case "cert":
-				item.Cert, err = x509.ParseCertificate(value)
-				if err != nil {
-					return nil, fmt.Errorf("cert-chain: cannot parse X.509 certificate at position %d: %v", i, err)
-				}
-			case "ocsp":
-				item.OCSPResponse = value
-			case "sct":
-				item.SCTList = value
-			}
-		}
-		if item.Cert == nil {
-			return nil, fmt.Errorf("cert-chain: certificate map at position %d has no \"cert\" key.", i)
-		}
-		if i == 1 && item.OCSPResponse == nil {
-			return nil, fmt.Errorf("cert-chain: the first certificate must have \"ocsp\" key.")
-		}
-		if i != 1 && item.OCSPResponse != nil {
-			return nil, fmt.Errorf("cert-chain: certificate map at position %d must not have \"ocsp\" key.", i)
-		}
-		certChain = append(certChain, item)
+		certChain = append(certChain, ac)
+	}
+	if err := certChain.Validate(); err != nil {
+		return nil, err
 	}
 	return certChain, nil
+}
+
+// DecodeAugmentedCertificateFrom decodes an augmented-certificate CBOR item
+// from dec and returns it as an AugmentedCertificate.
+func DecodeAugmentedCertificateFrom(dec *cbor.Decoder) (*AugmentedCertificate, error) {
+	m, err := dec.DecodeMapHeader()
+	if err != nil {
+		return nil, fmt.Errorf("cert-chain: failed to decode certificate map header: %v", err)
+	}
+	ac := &AugmentedCertificate{}
+	for j := uint64(0); j < m; j++ {
+		key, err := dec.DecodeTextString()
+		if err != nil {
+			return nil, fmt.Errorf("cert-chain: failed to decode map key: %v", err)
+		}
+		value, err := dec.DecodeByteString()
+		if err != nil {
+			return nil, fmt.Errorf("cert-chain: failed to decode map value: %v", err)
+		}
+		switch key {
+		case "cert":
+			ac.Cert, err = x509.ParseCertificate(value)
+			if err != nil {
+				return nil, fmt.Errorf("cert-chain: cannot parse X.509 certificate: %v", err)
+			}
+		case "ocsp":
+			ac.OCSPResponse = value
+		case "sct":
+			ac.SCTList = value
+		}
+	}
+	if ac.Cert == nil {
+		return nil, fmt.Errorf("cert-chain: certificate map must have \"cert\" key.")
+	}
+	return ac, nil
 }
 
 func (chain CertChain) PrettyPrint(w io.Writer) {

--- a/go/signedexchange/certurl/certchain.go
+++ b/go/signedexchange/certurl/certchain.go
@@ -15,6 +15,8 @@ import (
 	"github.com/WICG/webpackage/go/signedexchange/cbor"
 )
 
+// AugmentedCertificate represents an augmented-certificate CBOR structure.
+// https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#cert-chain-format
 type AugmentedCertificate struct {
 	Cert         *x509.Certificate // A parsed X.509 certificate.
 	OCSPResponse []byte            // DER-encoded OCSP response for Cert.


### PR DESCRIPTION
- `CertChainItem` struct is renamed to `AugmentedCertificate` (to match the spec).
- Added methods that {encode,decode} an `AugmentedCertificate` {to,from}
  `cbor.{Encoder,Decoder}`. These will be used from go/bundle to process the
  signatures section.
- Utility methods `Validate()` and `CertSha256()` are added.