### PR TITLE
go/bundle: Implement encoder / decoder for the signatures section

### DIFF
--- a/go/bundle/bundle.go
+++ b/go/bundle/bundle.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/WICG/webpackage/go/bundle/version"
+	"github.com/WICG/webpackage/go/signedexchange/certurl"
 )
 
 type Request struct {
@@ -28,6 +29,17 @@ func (r Response) String() string {
 type Exchange struct {
 	Request
 	Response
+}
+
+type Signatures struct {
+	Authorities    []*certurl.AugmentedCertificate
+	VouchedSubsets []*VouchedSubset
+}
+
+type VouchedSubset struct {
+	Authority uint64 // index in Authorities
+	Sig       []byte
+	Signed    []byte
 }
 
 func (e *Exchange) Dump(w io.Writer, dumpContentText bool) error {
@@ -73,4 +85,5 @@ type Bundle struct {
 	PrimaryURL  *url.URL
 	Exchanges   []*Exchange
 	ManifestURL *url.URL
+	Signatures  *Signatures
 }

--- a/go/bundle/bundle_test.go
+++ b/go/bundle/bundle_test.go
@@ -58,7 +58,7 @@ func createTestBundle(t *testing.T, ver version.Version) *Bundle {
 	}
 	if ver == version.Unversioned {
 		bundle.Exchanges[0].Request.Header = make(http.Header)
-		bundle.Signatures = nil  // Unversioned bundle cannot have signatures.
+		bundle.Signatures = nil // Unversioned bundle cannot have signatures.
 	}
 	if ver.HasPrimaryURLField() {
 		bundle.PrimaryURL = urlMustParse("https://bundle.example.com/")

--- a/go/bundle/bundle_test.go
+++ b/go/bundle/bundle_test.go
@@ -9,7 +9,22 @@ import (
 
 	. "github.com/WICG/webpackage/go/bundle"
 	"github.com/WICG/webpackage/go/bundle/version"
+	"github.com/WICG/webpackage/go/signedexchange"
+	"github.com/WICG/webpackage/go/signedexchange/certurl"
 )
+
+const pemCerts = `-----BEGIN CERTIFICATE-----
+MIIBhjCCAS2gAwIBAgIJAOhR3xtYd5QsMAoGCCqGSM49BAMCMDIxFDASBgNVBAMM
+C2V4YW1wbGUub3JnMQ0wCwYDVQQKDARUZXN0MQswCQYDVQQGEwJVUzAeFw0xODEx
+MDUwOTA5MjJaFw0xOTEwMzEwOTA5MjJaMDIxFDASBgNVBAMMC2V4YW1wbGUub3Jn
+MQ0wCwYDVQQKDARUZXN0MQswCQYDVQQGEwJVUzBZMBMGByqGSM49AgEGCCqGSM49
+AwEHA0IABH1E6odXRm3+r7dMYmkJRmftx5IYHAsqgA7zjsFfCvPqL/fM4Uvi8EFu
+JVQM/oKEZw3foCZ1KBjo/6Tenkoj/wCjLDAqMBAGCisGAQQB1nkCARYEAgUAMBYG
+A1UdEQQPMA2CC2V4YW1wbGUub3JnMAoGCCqGSM49BAMCA0cAMEQCIEbxRKhlQYlw
+Ja+O9h7misjLil82Q82nhOtl4j96awZgAiB6xrvRZIlMtWYKdi41BTb5fX22gL9M
+L/twWg8eWpYeJA==
+-----END CERTIFICATE-----
+`
 
 func urlMustParse(rawurl string) *url.URL {
 	u, err := url.Parse(rawurl)
@@ -19,7 +34,7 @@ func urlMustParse(rawurl string) *url.URL {
 	return u
 }
 
-func createTestBundle(ver version.Version) *Bundle {
+func createTestBundle(t *testing.T, ver version.Version) *Bundle {
 	bundle := &Bundle{
 		Version: ver,
 		Exchanges: []*Exchange{
@@ -34,9 +49,16 @@ func createTestBundle(ver version.Version) *Bundle {
 				},
 			},
 		},
+		Signatures: &Signatures{
+			Authorities: createTestCerts(t),
+			VouchedSubsets: []*VouchedSubset{
+				&VouchedSubset{Authority: 0, Sig: []byte("sig"), Signed: []byte("sig")},
+			},
+		},
 	}
 	if ver == version.Unversioned {
 		bundle.Exchanges[0].Request.Header = make(http.Header)
+		bundle.Signatures = nil  // Unversioned bundle cannot have signatures.
 	}
 	if ver.HasPrimaryURLField() {
 		bundle.PrimaryURL = urlMustParse("https://bundle.example.com/")
@@ -44,9 +66,21 @@ func createTestBundle(ver version.Version) *Bundle {
 	return bundle
 }
 
+func createTestCerts(t *testing.T) []*certurl.AugmentedCertificate {
+	certs, err := signedexchange.ParseCertificates([]byte(pemCerts))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var acs []*certurl.AugmentedCertificate
+	for _, c := range certs {
+		acs = append(acs, &certurl.AugmentedCertificate{Cert: c})
+	}
+	return acs
+}
+
 func TestWriteAndRead(t *testing.T) {
 	for _, ver := range version.AllVersions {
-		bundle := createTestBundle(ver)
+		bundle := createTestBundle(t, ver)
 
 		var buf bytes.Buffer
 		n, err := bundle.WriteTo(&buf)

--- a/go/bundle/cmd/dump-bundle/main.go
+++ b/go/bundle/cmd/dump-bundle/main.go
@@ -38,7 +38,19 @@ func run() error {
 		fmt.Printf("Manifest URL: %v\n", b.ManifestURL)
 	}
 
+	if b.Signatures != nil {
+		fmt.Println("Signatures:")
+		for i, ac := range b.Signatures.Authorities {
+			fmt.Printf("  Certificate #%d:\n", i)
+			fmt.Println("    Subject:", ac.Cert.Subject.CommonName)
+			fmt.Println("    Valid from:", ac.Cert.NotBefore)
+			fmt.Println("    Valid until:", ac.Cert.NotAfter)
+			fmt.Println("    Issuer:", ac.Cert.Issuer.CommonName)
+		}
+	}
+
 	for _, e := range b.Exchanges {
+		fmt.Println()
 		if err := e.Dump(os.Stdout, *flagDumpContentText); err != nil {
 			return err
 		}

--- a/go/bundle/decoder.go
+++ b/go/bundle/decoder.go
@@ -466,10 +466,10 @@ func parseSignaturesSection(sectionContents []byte) (*Signatures, error) {
 }
 
 var knownSections = map[string]struct{}{
-	"index":      struct{}{},
-	"manifest":   struct{}{},
-	"signatures": struct{}{},
-	"responses":  struct{}{},
+	"index":      {},
+	"manifest":   {},
+	"signatures": {},
+	"responses":  {},
 }
 
 type MetadataErrorType int

--- a/go/bundle/decoder.go
+++ b/go/bundle/decoder.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/WICG/webpackage/go/bundle/version"
 	"github.com/WICG/webpackage/go/signedexchange/cbor"
+	"github.com/WICG/webpackage/go/signedexchange/certurl"
 )
 
 type requestEntryWithOffset struct {
@@ -44,6 +45,7 @@ type meta struct {
 	sectionOffsets []sectionOffset
 	sectionsStart  uint64
 	manifestURL    *url.URL
+	signatures     *Signatures
 	requests       []requestEntryWithOffset
 }
 
@@ -383,10 +385,91 @@ func parseManifestSection(sectionContents []byte) (*url.URL, error) {
 	return manifestURL, nil
 }
 
+// https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.html#signatures-section
+func parseSignaturesSection(sectionContents []byte) (*Signatures, error) {
+	// signatures = [
+	//   authorities: [*authority],
+	//   vouched-subsets: [*{
+	//     authority: index-in-authorities,
+	//     sig: bstr,
+	//     signed: bstr  ; Expected to hold a signed-subset item.
+	//   }],
+	// ]
+	dec := cbor.NewDecoder(bytes.NewBuffer(sectionContents))
+	signaturesLength, err := dec.DecodeArrayHeader()
+	if err != nil {
+		return nil, fmt.Errorf("bundle.signatures: failed to decode array header: %v", err)
+	}
+	if signaturesLength != 2 {
+		return nil, fmt.Errorf("bundle.signatures: unexpected array length: %d", signaturesLength)
+	}
+
+	authoritiesLength, err := dec.DecodeArrayHeader()
+	if err != nil {
+		return nil, fmt.Errorf("bundle.signatures: failed to decode array header: %v", err)
+	}
+	var authorities []*certurl.AugmentedCertificate
+	for i := uint64(0); i < authoritiesLength; i++ {
+		a, err := certurl.DecodeAugmentedCertificateFrom(dec)
+		if err != nil {
+			return nil, fmt.Errorf("bundle.signatures: cannot parse certificate: %v", err)
+		}
+		authorities = append(authorities, a)
+	}
+
+	vouchedSubsetsLength, err := dec.DecodeArrayHeader()
+	if err != nil {
+		return nil, fmt.Errorf("bundle.signatures: failed to decode array header: %v", err)
+	}
+	var vouchedSubsets []*VouchedSubset
+	for i := uint64(0); i < vouchedSubsetsLength; i++ {
+		n, err := dec.DecodeMapHeader()
+		if err != nil {
+			return nil, fmt.Errorf("bundle.signatures: cannot decode map header: %v", err)
+		}
+		if n != 3 {
+			return nil, fmt.Errorf("bundle.signatures: unexpected map size: %d", n)
+		}
+
+		vs := &VouchedSubset{}
+		for i := uint64(0); i < n; i++ {
+			label, err := dec.DecodeTextString()
+			if err != nil {
+				return nil, fmt.Errorf("bundle.signatures: cannot decode map key: %v", err)
+			}
+			switch label {
+			case "authority":
+				vs.Authority, err = dec.DecodeUint()
+				if err != nil {
+					return nil, fmt.Errorf("bundle.signatures: cannot decode authority: %v", err)
+				}
+			case "sig":
+				vs.Sig, err = dec.DecodeByteString()
+				if err != nil {
+					return nil, fmt.Errorf("bundle.signatures: cannot decode sig: %v", err)
+				}
+			case "signed":
+				vs.Signed, err = dec.DecodeByteString()
+				if err != nil {
+					return nil, fmt.Errorf("bundle.signatures: cannot decode signed: %v", err)
+				}
+			default:
+				return nil, fmt.Errorf("bundle.signatures: unexpected map key %q", label)
+			}
+		}
+		vouchedSubsets = append(vouchedSubsets, vs)
+	}
+	return &Signatures{
+		Authorities:    authorities,
+		VouchedSubsets: vouchedSubsets,
+	}, nil
+}
+
 var knownSections = map[string]struct{}{
-	"index":     struct{}{},
-	"manifest":  struct{}{},
-	"responses": struct{}{},
+	"index":      struct{}{},
+	"manifest":   struct{}{},
+	"signatures": struct{}{},
+	"responses":  struct{}{},
 }
 
 type MetadataErrorType int
@@ -548,6 +631,16 @@ func loadMetadata(bs []byte) (*meta, error) {
 				return nil, &LoadMetadataError{err, FormatError, fallbackURL}
 			}
 			meta.manifestURL = manifestURL
+		case "signatures":
+			if ver.HasSignaturesSupport() {
+				signatures, err := parseSignaturesSection(sectionContents)
+				if err != nil {
+					return nil, &LoadMetadataError{err, FormatError, fallbackURL}
+				}
+				meta.signatures = signatures
+			} else {
+				return nil, &LoadMetadataError{errors.New("bundle: signatures section not allowed in this version of bundle"), FormatError, fallbackURL}
+			}
 		case "responses":
 			continue
 		default:
@@ -672,6 +765,6 @@ func Read(r io.Reader) (*Bundle, error) {
 		es = append(es, e)
 	}
 
-	b := &Bundle{Version: m.version, PrimaryURL: m.primaryURL, Exchanges: es, ManifestURL: m.manifestURL}
+	b := &Bundle{Version: m.version, PrimaryURL: m.primaryURL, Exchanges: es, ManifestURL: m.manifestURL, Signatures: m.signatures}
 	return b, nil
 }

--- a/go/bundle/version/version.go
+++ b/go/bundle/version/version.go
@@ -10,7 +10,7 @@ type Version string
 
 const (
 	Unversioned Version = "unversioned"
-	VersionB1 Version = "b1"
+	VersionB1   Version = "b1"
 )
 
 var AllVersions = []Version{
@@ -20,6 +20,7 @@ var AllVersions = []Version{
 
 // HeaderMagicBytesUnversioned is the CBOR encoding of the 4-item array initial byte and 8-byte bytestring initial byte, followed by 🌐📦 in UTF-8.
 var HeaderMagicBytesUnversioned = []byte{0x84, 0x48, 0xf0, 0x9f, 0x8c, 0x90, 0xf0, 0x9f, 0x93, 0xa6}
+
 // HeaderMagicBytes is the CBOR encoding of the 6-item array initial byte and 8-byte bytestring initial byte, followed by 🌐📦 in UTF-8.
 var HeaderMagicBytes = []byte{0x86, 0x48, 0xf0, 0x9f, 0x8c, 0x90, 0xf0, 0x9f, 0x93, 0xa6}
 

--- a/go/bundle/version/version.go
+++ b/go/bundle/version/version.go
@@ -76,3 +76,7 @@ func (v Version) HasPrimaryURLField() bool {
 func (v Version) HasVariantsSupport() bool {
 	return v != Unversioned
 }
+
+func (v Version) HasSignaturesSupport() bool {
+	return v != Unversioned
+}


### PR DESCRIPTION
This adds data structures for the signature section [1], and encoder / decoder for the section. Signing and verification code will be added in follow-up PRs.

[1] https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.html#signatures-section