### PR TITLE
go/bundle: Add sign-bundle tool

### DIFF
--- a/go/bundle/README.md
+++ b/go/bundle/README.md
@@ -2,9 +2,11 @@
 This directory contains a reference implementation of [Bundled HTTP Exchanges](https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.html) spec.
 
 ## Overview
-We currently provide two command-line tools: `gen-bundle` and `dump-bundle`.
+We currently provide three command-line tools: `gen-bundle`, `sign-bundle` and `dump-bundle`.
 
 `gen-bundle` command is a bundle generator tool. `gen-bundle` consumes a set of http exchanges (currently in the form of [HAR format](https://w3c.github.io/web-performance/specs/HAR/Overview.html) or static files in a local directory), and emits a bundled exchange file.
+
+`sign-bundle` command attaches a signature to a bundle. `sign-bundle` takes an existing bundle file, a certificate and a private key, and emits a new bundle file with cryptographic signature for the bundled exchanges added.
 
 `dump-bundle` command is a bundle inspector tool. `dump-bundle` dumps the enclosed http exchanges of a given bundled exchange file in a human readable form.
 
@@ -22,7 +24,9 @@ We recommend using `go get` to install the command-line tool.
 go get -u github.com/WICG/webpackage/go/bundle/cmd/...
 ```
 
-### Usage
+## Usage
+
+### gen-bundle
 `gen-bundle` generates a bundled exchange file from a HAR file.
 
 One convenient way to generate HAR file is via Chrome Devtools. Navigate to "Network" panel, and right-click on any resource and select "Save as HAR with content".
@@ -39,6 +43,21 @@ gen-bundle -dir static -baseURL https://www.example.com/ -o foo.wbn
 ```
 You can use `-startURL` command-line flag to specify the entry point of the bundle, as a relative URL from `-baseURL`. Currently, this just makes the exchange for `-startURL` the first entry in the bundled exchange file.
 
+### sign-bundle
+`sign-bundle` updates a bundle attaching a cryptographic signature of its exchanges. To use this tool, you need a pair of a private key and a certificate in the `application/cert-chain+cbor` format. See [go/signedexchange](../signedexchange/README.md) for more information on how to create a key and certificate pair.
+
+Assuming you have a key and certificate pair for `example.org`, thils command will sign all exchanges in `unsigned.wbn` whose URL's hostname is `example.org`, and writes a new bundle to `signed.wbn`.
+
+```
+sign-bundle \
+  -i unsigned.wbn \
+  -certificate cert.cbor \
+  -privateKey priv.key \
+  -validityUrl https://example.org/resource.validity.msg \
+  -o signed.wbn
+```
+
+### dump-bundle
 `dump-bundle` dumps the content of a bundled exchange in a human readable form. To display content of a har file, invoke:
 ```
 dump-bundle -i foo.har

--- a/go/bundle/README.md
+++ b/go/bundle/README.md
@@ -46,7 +46,7 @@ You can use `-startURL` command-line flag to specify the entry point of the bund
 ### sign-bundle
 `sign-bundle` updates a bundle attaching a cryptographic signature of its exchanges. To use this tool, you need a pair of a private key and a certificate in the `application/cert-chain+cbor` format. See [go/signedexchange](../signedexchange/README.md) for more information on how to create a key and certificate pair.
 
-Assuming you have a key and certificate pair for `example.org`, thils command will sign all exchanges in `unsigned.wbn` whose URL's hostname is `example.org`, and writes a new bundle to `signed.wbn`.
+Assuming you have a key and certificate pair for `example.org`, this command will sign all exchanges in `unsigned.wbn` whose URL's hostname is `example.org`, and writes a new bundle to `signed.wbn`.
 
 ```
 sign-bundle \

--- a/go/bundle/cmd/sign-bundle/main.go
+++ b/go/bundle/cmd/sign-bundle/main.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"crypto"
+	"flag"
+	"io/ioutil"
+	"log"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/WICG/webpackage/go/bundle"
+	"github.com/WICG/webpackage/go/bundle/signature"
+	"github.com/WICG/webpackage/go/signedexchange"
+	"github.com/WICG/webpackage/go/signedexchange/certurl"
+)
+
+var (
+	flagInput        = flag.String("i", "in.wbn", "Webbundle input file")
+	flagOutput       = flag.String("o", "out.wbn", "Webbundle output file")
+	flagCertificate  = flag.String("certificate", "cert.cbor", "Certificate chain CBOR file")
+	flagPrivateKey   = flag.String("privateKey", "cert-key.pem", "Private key PEM file")
+	flagValidityUrl  = flag.String("validityUrl", "https://example.com/resource.validity.msg", "The URL where resource validity info is hosted at.")
+	flagDate         = flag.String("date", "", "Datetime for the signature in RFC3339 format (2006-01-02T15:04:05Z). (default: current time)")
+	flagExpire       = flag.Duration("expire", 1*time.Hour, "Validity duration of the signature")
+	flagMIRecordSize = flag.Int("miRecordSize", 4096, "Record size of Merkle Integrity Content Encoding")
+)
+
+func readCertChainFromFile(path string) (certurl.CertChain, error) {
+	fi, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer fi.Close()
+	return certurl.ReadCertChain(fi)
+}
+
+func readPrivateKeyFromFile(path string) (crypto.PrivateKey, error) {
+	privkeytext, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return signedexchange.ParsePrivateKey(privkeytext)
+}
+
+func readBundleFromFile(path string) (*bundle.Bundle, error) {
+	fi, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer fi.Close()
+	return bundle.Read(fi)
+}
+
+func writeBundleToFile(b *bundle.Bundle, path string) error {
+	fo, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer fo.Close()
+	_, err = b.WriteTo(fo)
+	return err
+}
+
+func addSignature(b *bundle.Bundle, signer *signature.Signer) error {
+	for _, e := range b.Exchanges {
+		if !signer.CanSignForURL(e.Request.URL) {
+			continue
+		}
+		payloadIntegrityHeader, err := e.AddPayloadIntegrity(b.Version, *flagMIRecordSize)
+		if err != nil {
+			return err
+		}
+		if err := signer.AddExchange(e, payloadIntegrityHeader); err != nil {
+			return err
+		}
+	}
+
+	newSignatures, err := signer.UpdateSignatures(b.Signatures)
+	if err != nil {
+		return err
+	}
+	b.Signatures = newSignatures
+	return nil
+}
+
+func main() {
+	flag.Parse()
+
+	certs, err := readCertChainFromFile(*flagCertificate)
+	if err != nil {
+		log.Fatalf("%s: %v", *flagCertificate, err)
+	}
+
+	privKey, err := readPrivateKeyFromFile(*flagPrivateKey)
+	if err != nil {
+		log.Fatalf("%s: %v", *flagPrivateKey, err)
+	}
+
+	validityUrl, err := url.Parse(*flagValidityUrl)
+	if err != nil {
+		log.Fatalf("failed to parse validity URL %q: %v", *flagValidityUrl, err)
+	}
+
+	var date time.Time
+	if *flagDate == "" {
+		date = time.Now()
+	} else {
+		var err error
+		date, err = time.Parse(time.RFC3339, *flagDate)
+		if err != nil {
+			log.Fatalf("failed to parse date %q: %v", *flagDate, err)
+		}
+	}
+
+	b, err := readBundleFromFile(*flagInput)
+	if err != nil {
+		log.Fatalf("%s: %v", *flagInput, err)
+	}
+
+	signer, err := signature.NewSigner(b.Version, certs, privKey, validityUrl, date, *flagExpire)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := addSignature(b, signer); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := writeBundleToFile(b, *flagOutput); err != nil {
+		log.Fatalf("%s: %v", *flagOutput, err)
+	}
+}

--- a/go/bundle/encoder.go
+++ b/go/bundle/encoder.go
@@ -2,6 +2,7 @@ package bundle
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -52,6 +53,15 @@ func (r Response) EncodeHeader() ([]byte, error) {
 		return nil, fmt.Errorf("bundle: Failed to encode response header: %v", err)
 	}
 	return b.Bytes(), nil
+}
+
+func (r Response) HeaderSha256() ([]byte, error) {
+	headerBytes, err := r.EncodeHeader()
+	if err != nil {
+		return nil, err
+	}
+	sum := sha256.Sum256(headerBytes)
+	return sum[:], nil
 }
 
 var _ = io.WriterTo(&Bundle{})

--- a/go/bundle/signature/signer.go
+++ b/go/bundle/signature/signer.go
@@ -24,7 +24,7 @@ type Signer struct {
 	SignedSubset
 }
 
-// SignedSubset represents the "sisnged-subset" structure.
+// SignedSubset represents a "signed-subset" structure.
 // https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.html#signatures-section
 type SignedSubset struct {
 	ValidityUrl  *url.URL

--- a/go/bundle/signature/signer.go
+++ b/go/bundle/signature/signer.go
@@ -147,6 +147,7 @@ func (s *Signer) UpdateSignatures(signatures *bundle.Signatures) (*bundle.Signat
 	}
 
 	authorityIndex := len(signatures.Authorities)
+	// TODO: Deduplicate intermediate certificates.
 	signatures.Authorities = append(signatures.Authorities, s.Certs...)
 	signedSubsetBytes, err := s.SignedSubset.Encode()
 	if err != nil {

--- a/go/bundle/signature/signer.go
+++ b/go/bundle/signature/signer.go
@@ -1,0 +1,193 @@
+package signature
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rand"
+	"errors"
+	"io"
+	"net/url"
+	"time"
+
+	"github.com/WICG/webpackage/go/bundle"
+	"github.com/WICG/webpackage/go/bundle/version"
+	"github.com/WICG/webpackage/go/internal/signingalgorithm"
+	"github.com/WICG/webpackage/go/signedexchange/cbor"
+	"github.com/WICG/webpackage/go/signedexchange/certurl"
+)
+
+type Signer struct {
+	Version version.Version
+	Certs   certurl.CertChain
+	PrivKey crypto.PrivateKey
+	Rand    io.Reader
+	SignedSubset
+}
+
+// SignedSubset represents the "sisnged-subset" structure.
+// https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.html#signatures-section
+type SignedSubset struct {
+	ValidityUrl  *url.URL
+	AuthSha256   []byte
+	Date         time.Time
+	Expires      time.Time
+	SubsetHashes map[string]*ResponseHashes
+}
+
+type ResponseHashes struct {
+	VariantsValue string
+	Hashes        []*ResourceIntegrity
+}
+
+type ResourceIntegrity struct {
+	HeaderSha256           []byte
+	PayloadIntegrityHeader string
+}
+
+// Encode encodes s as a CBOR item.
+func (s *SignedSubset) Encode() ([]byte, error) {
+	mes := []*cbor.MapEntryEncoder{
+		cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
+			keyE.EncodeTextString("validity-url")
+			valueE.EncodeTextString(s.ValidityUrl.String())
+		}),
+		cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
+			keyE.EncodeTextString("auth-sha256")
+			valueE.EncodeByteString(s.AuthSha256)
+		}),
+		cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
+			keyE.EncodeTextString("date")
+			valueE.EncodeInt(s.Date.Unix())
+		}),
+		cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
+			keyE.EncodeTextString("expires")
+			valueE.EncodeInt(s.Expires.Unix())
+		}),
+		cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
+			keyE.EncodeTextString("subset-hashes")
+			subsetHashes := []*cbor.MapEntryEncoder{}
+			for url, rh := range s.SubsetHashes {
+				subsetHashes = append(subsetHashes,
+					cbor.GenerateMapEntry(func(keyE *cbor.Encoder, valueE *cbor.Encoder) {
+						keyE.EncodeTextString(url)
+						valueE.EncodeArrayHeader(1 + len(rh.Hashes)*2)
+						valueE.EncodeTextString(rh.VariantsValue)
+						for _, ri := range rh.Hashes {
+							valueE.EncodeByteString(ri.HeaderSha256)
+							valueE.EncodeTextString(ri.PayloadIntegrityHeader)
+						}
+					}))
+			}
+			valueE.EncodeMap(subsetHashes)
+		}),
+	}
+	var buf bytes.Buffer
+	enc := cbor.NewEncoder(&buf)
+	if err := enc.EncodeMap(mes); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func NewSigner(ver version.Version, certs certurl.CertChain, privKey crypto.PrivateKey, validityUrl *url.URL, date time.Time, duration time.Duration) (*Signer, error) {
+	if ver == version.Unversioned {
+		return nil, errors.New("signature: unversioned bundles cannot be signed")
+	}
+
+	if err := certs.Validate(); err != nil {
+		return nil, err
+	}
+	authSha256 := certs[0].CertSha256()
+
+	return &Signer{
+		Version: ver,
+		Certs:   certs,
+		PrivKey: privKey,
+		Rand:    rand.Reader,
+		SignedSubset: SignedSubset{
+			ValidityUrl:  validityUrl,
+			AuthSha256:   authSha256,
+			Date:         date,
+			Expires:      date.Add(duration),
+			SubsetHashes: make(map[string]*ResponseHashes),
+		},
+	}, nil
+}
+
+// CanSignForURL returns true iff this signer can sign for a resource with given URL.
+func (s *Signer) CanSignForURL(u *url.URL) bool {
+	return s.Certs[0].Cert.VerifyHostname(u.Hostname()) == nil
+}
+
+// AddExchange adds resource integrity information of e for signing.
+func (s *Signer) AddExchange(e *bundle.Exchange, payloadIntegrityHeader string) error {
+	headerSha256, err := e.Response.HeaderSha256()
+	if err != nil {
+		return err
+	}
+	ri := &ResourceIntegrity{HeaderSha256: headerSha256, PayloadIntegrityHeader: payloadIntegrityHeader}
+
+	if _, ok := s.SubsetHashes[e.Request.URL.String()]; ok {
+		// TODO: Fix this when we implement variants.
+		return errors.New("signature: multiple exchanges for single URL is not supported")
+	}
+
+	s.SubsetHashes[e.Request.URL.String()] = &ResponseHashes{
+		VariantsValue: "",
+		Hashes:        []*ResourceIntegrity{ri},
+	}
+	return nil
+}
+
+// UpdateSignatures updates bundle.Signatures by adding the cert chain and
+// the signature of exchanges added with AddExchange.
+func (s *Signer) UpdateSignatures(signatures *bundle.Signatures) (*bundle.Signatures, error) {
+	if signatures == nil {
+		signatures = &bundle.Signatures{}
+	}
+
+	authorityIndex := len(signatures.Authorities)
+	signatures.Authorities = append(signatures.Authorities, s.Certs...)
+	signedSubsetBytes, err := s.SignedSubset.Encode()
+	if err != nil {
+		return nil, err
+	}
+	sig, err := s.sign(signedSubsetBytes)
+	if err != nil {
+		return nil, err
+	}
+	signatures.VouchedSubsets = append(signatures.VouchedSubsets,
+		&bundle.VouchedSubset{
+			Authority: uint64(authorityIndex),
+			Sig:       sig,
+			Signed:    signedSubsetBytes,
+		})
+	return signatures, err
+}
+
+func (s *Signer) sign(signed []byte) ([]byte, error) {
+	alg, err := signingalgorithm.SigningAlgorithmForPrivateKey(s.PrivKey, s.Rand)
+	if err != nil {
+		return nil, err
+	}
+
+	return alg.Sign(generateSignedMessage(signed, s.Version))
+}
+
+// https://github.com/WICG/webpackage/issues/472#issuecomment-520080192
+// TODO: Update the above reference once we have spec text for this.
+func generateSignedMessage(signed []byte, ver version.Version) []byte {
+	// The message is the concatenation of:
+	var buf bytes.Buffer
+	// 1. A string that consists of octet 32 (0x20) repeated 64 times.
+	for i := 0; i < 64; i++ {
+		buf.WriteByte(0x20)
+	}
+	// 2. A context string: "Web Package <version>".
+	buf.WriteString(ver.SignatureContextString())
+	// 3. A single 0 byte which serves as a separator.
+	buf.WriteByte(0)
+	// 4. The signed bstr.
+	buf.Write(signed)
+	return buf.Bytes()
+}

--- a/go/bundle/signature/signer_test.go
+++ b/go/bundle/signature/signer_test.go
@@ -1,0 +1,180 @@
+package signature_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/WICG/webpackage/go/bundle"
+	. "github.com/WICG/webpackage/go/bundle/signature"
+	"github.com/WICG/webpackage/go/bundle/version"
+	"github.com/WICG/webpackage/go/signedexchange"
+	"github.com/WICG/webpackage/go/signedexchange/certurl"
+)
+
+const (
+	// A certificate for "example.org"
+	pemCerts = `-----BEGIN CERTIFICATE-----
+MIIBhjCCAS2gAwIBAgIJAOhR3xtYd5QsMAoGCCqGSM49BAMCMDIxFDASBgNVBAMM
+C2V4YW1wbGUub3JnMQ0wCwYDVQQKDARUZXN0MQswCQYDVQQGEwJVUzAeFw0xODEx
+MDUwOTA5MjJaFw0xOTEwMzEwOTA5MjJaMDIxFDASBgNVBAMMC2V4YW1wbGUub3Jn
+MQ0wCwYDVQQKDARUZXN0MQswCQYDVQQGEwJVUzBZMBMGByqGSM49AgEGCCqGSM49
+AwEHA0IABH1E6odXRm3+r7dMYmkJRmftx5IYHAsqgA7zjsFfCvPqL/fM4Uvi8EFu
+JVQM/oKEZw3foCZ1KBjo/6Tenkoj/wCjLDAqMBAGCisGAQQB1nkCARYEAgUAMBYG
+A1UdEQQPMA2CC2V4YW1wbGUub3JnMAoGCCqGSM49BAMCA0cAMEQCIEbxRKhlQYlw
+Ja+O9h7misjLil82Q82nhOtl4j96awZgAiB6xrvRZIlMtWYKdi41BTb5fX22gL9M
+L/twWg8eWpYeJA==
+-----END CERTIFICATE-----
+`
+	pemPrivateKey = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIEMac81NMjwO4pQ2IGKZ3UdymYtnFAXEjKdvAdEx4DQwoAoGCCqGSM49
+AwEHoUQDQgAEfUTqh1dGbf6vt0xiaQlGZ+3HkhgcCyqADvOOwV8K8+ov98zhS+Lw
+QW4lVAz+goRnDd+gJnUoGOj/pN6eSiP/AA==
+-----END EC PRIVATE KEY-----`
+
+	miRecordSize = 4096
+	validityURL  = "https://example.org/resource.validity"
+)
+
+var signatureDate = time.Date(2018, 1, 31, 17, 13, 20, 0, time.UTC)
+var signatureDuration = 1 * time.Hour
+
+var expectedSig = []byte{
+	0x30, 0x44, 0x02, 0x20, 0x17, 0x92, 0xb5, 0x06, 0xb6, 0xda, 0xff, 0x8d,
+	0xc9, 0x92, 0xa5, 0x7f, 0x9d, 0x5c, 0xb2, 0xd0, 0x24, 0xb5, 0xda, 0xd2,
+	0x6d, 0xa8, 0x53, 0x7d, 0x80, 0x4d, 0xf5, 0x12, 0xec, 0x5b, 0x94, 0x27,
+	0x02, 0x20, 0x03, 0xfc, 0xb0, 0x1b, 0x65, 0xa7, 0xd1, 0xaa, 0x19, 0xaa,
+	0x02, 0x7f, 0xa3, 0x87, 0x81, 0x41, 0x5c, 0x5a, 0x56, 0xb8, 0xef, 0x03,
+	0x2e, 0xd8, 0xf4, 0x6e, 0xa1, 0x65, 0x30, 0x27, 0x37, 0x3c,
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(b []byte) (int, error) {
+	for i := range b {
+		b[i] = 0
+	}
+	return len(b), nil
+}
+
+func urlMustParse(rawurl string) *url.URL {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func createTestCertChain(t *testing.T) certurl.CertChain {
+	certs, err := signedexchange.ParseCertificates([]byte(pemCerts))
+	if err != nil {
+		t.Fatal(err)
+	}
+	chain, err := certurl.NewCertChain(certs, []byte("dummy ocsp"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return chain
+}
+
+func createTestSigner(t *testing.T) *Signer {
+	certChain := createTestCertChain(t)
+
+	privKey, err := signedexchange.ParsePrivateKey([]byte(pemPrivateKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validityUrl := urlMustParse(validityURL)
+
+	signer, err := NewSigner(version.VersionB1, certChain, privKey, validityUrl, signatureDate, signatureDuration)
+	if err != nil {
+		t.Fatalf("Failed to create Signer: %v", err)
+	}
+	signer.Rand = zeroReader{}
+	return signer
+}
+
+func TestCanSignForURL(t *testing.T) {
+	signer := createTestSigner(t)
+
+	if !signer.CanSignForURL(urlMustParse("https://example.org/index.html")) {
+		t.Error("CanSignFor unexpectedly returned false for https://example.org/index.html")
+	}
+	if signer.CanSignForURL(urlMustParse("https://example.com/index.html")) {
+		t.Error("CanSignFor unexpectedly returned true for https://example.com/index.html")
+	}
+}
+
+func TestSignatureGeneration(t *testing.T) {
+	signer := createTestSigner(t)
+
+	e := &bundle.Exchange{
+		bundle.Request{
+			URL: urlMustParse("https://example.org/index.html"),
+		},
+		bundle.Response{
+			Status: 200,
+			Header: http.Header{"Content-Type": []string{"text/html"}},
+			Body:   []byte("hello, world!"),
+		},
+	}
+	integrity, err := e.AddPayloadIntegrity(signer.Version, miRecordSize)
+	if err != nil {
+		t.Fatalf("AddPayloadIntegrity failed: %v", err)
+	}
+
+	if err := signer.AddExchange(e, integrity); err != nil {
+		t.Fatalf("signer.AddExchange failed: %v", err)
+	}
+
+	signatures, err := signer.UpdateSignatures(nil)
+	if err != nil {
+		t.Fatalf("signer.UpdateSignatures failed: %v", err)
+	}
+
+	if len(signatures.Authorities) != 1 {
+		t.Fatalf("Unexpected size of signatures.Authorities: %d", len(signatures.Authorities))
+	}
+	expectedCerts := createTestCertChain(t)
+	if !reflect.DeepEqual(signatures.Authorities[0], expectedCerts[0]) {
+		t.Errorf("signatures.Authorities[0]:\n got: %v\n want: %v", signatures.Authorities[0], expectedCerts[0])
+	}
+
+	if len(signatures.VouchedSubsets) != 1 {
+		t.Fatalf("Unexpected size of signatures.VouchedSubsets: %d", len(signatures.VouchedSubsets))
+	}
+	vh := signatures.VouchedSubsets[0]
+	if vh.Authority != 0 {
+		t.Errorf("Authority: got %d, want %d", vh.Authority, 0)
+	}
+	if !bytes.Equal(vh.Sig, expectedSig) {
+		t.Errorf("Sig:\n got: %v\n want: %v", vh.Sig, expectedSig)
+	}
+
+	headerSha256, err := e.Response.HeaderSha256()
+	if err != nil {
+		t.Fatalf("HeaderSha256 failed: %v", err)
+	}
+	expectedSigned, err := (&SignedSubset{
+		ValidityUrl: urlMustParse(validityURL),
+		AuthSha256: expectedCerts[0].CertSha256(),
+		Date: signatureDate,
+		Expires: signatureDate.Add(signatureDuration),
+		SubsetHashes: map[string]*ResponseHashes{
+			e.Request.URL.String(): &ResponseHashes{
+				VariantsValue: "",
+				Hashes: []*ResourceIntegrity{
+					&ResourceIntegrity{headerSha256, "digest/mi-sha256-03"},
+				},
+			},
+		},
+	}).Encode()
+
+	if !bytes.Equal(vh.Signed, expectedSigned) {
+		t.Errorf("Signed:\n got: %v\n want: %v", vh.Signed, expectedSigned)
+	}
+}

--- a/go/bundle/version/version.go
+++ b/go/bundle/version/version.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"io"
+
+	"github.com/WICG/webpackage/go/signedexchange/mice"
 )
 
 type Version string
@@ -68,6 +70,24 @@ func ParseMagicBytes(r io.Reader) (Version, error) {
 		return VersionB1, nil
 	}
 	return "", errors.New("bundle: unrecognized version magic")
+}
+
+func (v Version) MiceEncoding() mice.Encoding {
+	switch v {
+	case VersionB1:
+		return mice.Draft03Encoding
+	default:
+		panic("not reached")
+	}
+}
+
+func (v Version) SignatureContextString() string {
+	switch v {
+	case VersionB1:
+		return "Web Package 1 b1"
+	default:
+		panic("not reached")
+	}
 }
 
 func (v Version) HasPrimaryURLField() bool {


### PR DESCRIPTION
This adds `sign-bundle` command line tool. It takes an existing bundle, a certificate chain (generated by `gen-certurl`) and a private key, and creates a new bundle with a "signatures" section added.

The generated signatures section includes a signature that covers all exchanges whose hostname matches the certificate. Also, this tool encodes those exchanges with the mi-sha256-03 content encoding.