### PR TITLE
gen-bundle: Add option to create a bundle from URL list

### DIFF
--- a/go/bundle/README.md
+++ b/go/bundle/README.md
@@ -50,7 +50,7 @@ gen-bundle -har foo.har -o foo.wbn
 `gen-bundle` also accepts `-URLList FILE` flag. `FILE` is a plain text file with one URL on each line. `gen-bundle` fetches these URLs and put the responses into the bundle. For example, you could create `urls.txt` with:
 
 ```
-# This is a comment.
+# A line starting with '#' is a comment.
 https://example.com/
 https://example.com/manifest.webmanifest
 https://example.com/style.css

--- a/go/bundle/cmd/gen-bundle/fromurllist.go
+++ b/go/bundle/cmd/gen-bundle/fromurllist.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/WICG/webpackage/go/bundle"
+)
+
+func fromURLList(urlListFile string) ([]*bundle.Exchange, error) {
+	input, err := os.Open(urlListFile)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to open %q: %v", urlListFile, err)
+	}
+	defer input.Close()
+	scanner := bufio.NewScanner(input)
+
+	es := []*bundle.Exchange{}
+	for scanner.Scan() {
+		rawURL := strings.TrimSpace(scanner.Text())
+		// Skip blank lines and comments.
+		if len(rawURL) == 0 || rawURL[0] == '#' {
+			continue
+		}
+		log.Printf("Processing %q", rawURL)
+
+		parsedURL, err := url.Parse(rawURL)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse URL %q: %v", rawURL, err)
+		}
+		resp, err := http.Get(rawURL)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to fetch %q: %v", rawURL, err)
+		}
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("Error reading response body of %q: %v", rawURL, err)
+		}
+		e := &bundle.Exchange{
+			Request: bundle.Request{
+				URL: parsedURL,
+			},
+			Response: bundle.Response{
+				Status: resp.StatusCode,
+				Header: resp.Header,
+				Body: body,
+			},
+		}
+		es = append(es, e)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("Error reading %q: %v", urlListFile, err)
+	}
+
+	return es, nil
+}

--- a/go/bundle/cmd/gen-bundle/main.go
+++ b/go/bundle/cmd/gen-bundle/main.go
@@ -19,6 +19,7 @@ var (
 	flagPrimaryURL  = flag.String("primaryURL", "", "Primary URL")
 	flagManifestURL = flag.String("manifestURL", "", "Manifest URL")
 	flagOutput      = flag.String("o", "out.wbn", "Webbundle output file")
+	flagURLList     = flag.String("URLList", "", "URL list file")
 )
 
 func main() {
@@ -71,8 +72,14 @@ func main() {
 			log.Fatal(err)
 		}
 		b.Exchanges = es
+	} else if *flagURLList != "" {
+		es, err := fromURLList(*flagURLList)
+		if err != nil {
+			log.Fatal(err)
+		}
+		b.Exchanges = es
 	} else {
-		fmt.Fprintln(os.Stderr, "Please specify -har or -dir.")
+		fmt.Fprintln(os.Stderr, "Please specify one of -har, -dir, or -URLList.")
 		flag.Usage()
 		return
 	}


### PR DESCRIPTION
After this patch, `gen-bundle -URLList urls.txt` will fetch URLs listed
in `urls.txt` and create a bundle from their responses.
