### PR TITLE
Make manifest section of Bundled HTTP Exchanges optional

### DIFF
--- a/draft-yasskin-wpack-bundled-exchanges.md
+++ b/draft-yasskin-wpack-bundled-exchanges.md
@@ -93,8 +93,8 @@ Standard ({{INFRA}}).
 
 # Semantics {#semantics}
 
-A bundle is logically a set of HTTP exchanges, with a primary URL in the bundle
-and an optional URL identifying the manifest(s) of the bundle itself.
+A bundle is logically a set of HTTP exchanges, with a URL identifying the
+primary resource of the bundle.
 
 While the order of the exchanges is not semantically meaningful, it can
 significantly affect performance when the bundle is loaded from a network
@@ -135,7 +135,7 @@ metadata, and if one matches, load that request's response.
 This takes the bundle's stream and returns either an error (where an error is a
 "format error" or a "version error"), an error with a fallback URL (which is
 also the primaryUrl when the bundle parses successfully), or a map ({{INFRA}})
-of metadata containing keys named:
+of metadata containing at least keys named:
 
 primaryUrl
 
@@ -157,14 +157,7 @@ requests
       {{semantics-load-response}}{:format="title"} can use the
       `ResponseMetadata` structures to find the matching response.
 
-manifest
-
-: The URL of the bundle's manifest(s). This is a URL to support bundles with
-  multiple different manifests, where the client uses content negotiation to
-  select the most appropriate one.
-
-The map must include keys named primaryUrl and requests. The map may include
-manifest and other items added by sections defined in the
+The map may include other items added by sections defined in the
 {{section-name-registry}}{:format="title"}.
 
 This operation only waits for a prefix of the stream that, if the bundle is
@@ -371,7 +364,7 @@ steps, taking the `stream` as input.
 
 1. Assert: `metadata` has an entry with the key "primaryUrl".
 
-1. If `metadata` doesn't have entries with keys "requests", return a
+1. If `metadata` doesn't have entries with key "requests", return a
    "format error" with `fallbackUrl`.
 
 1. Return `metadata`.

--- a/draft-yasskin-wpack-bundled-exchanges.md
+++ b/draft-yasskin-wpack-bundled-exchanges.md
@@ -369,8 +369,8 @@ steps, taking the `stream` as input.
 
 1. Assert: `metadata` has an entry with the key "primaryUrl".
 
-1. If `metadata` doesn't have entries with keys "requests" and "manifest",
-   return a "format error" with `fallbackUrl`.
+1. If `metadata` doesn't have entries with keys "requests", return a
+   "format error" with `fallbackUrl`.
 
 1. Return `metadata`.
 

--- a/draft-yasskin-wpack-bundled-exchanges.md
+++ b/draft-yasskin-wpack-bundled-exchanges.md
@@ -46,8 +46,9 @@ informative:
 
 Bundled exchanges provide a way to bundle up groups of HTTP request+response
 pairs to transmit or store them together. They can include multiple top-level
-resources with one identified as the default by a manifest, provide random
-access to their component exchanges, and efficiently store 8-bit resources.
+resources with one identified as the default by a primaryUrl metadata, provide
+random access to their component exchanges, and efficiently store 8-bit
+resources.
 
 --- note_Note_to_Readers
 
@@ -92,8 +93,8 @@ Standard ({{INFRA}}).
 
 # Semantics {#semantics}
 
-A bundle is logically a set of HTTP exchanges, with a URL identifying the
-manifest(s) of the bundle itself.
+A bundle is logically a set of HTTP exchanges, with a primary URL in the bundle
+and an optional URL identifying the manifest(s) of the bundle itself.
 
 While the order of the exchanges is not semantically meaningful, it can
 significantly affect performance when the bundle is loaded from a network
@@ -134,7 +135,7 @@ metadata, and if one matches, load that request's response.
 This takes the bundle's stream and returns either an error (where an error is a
 "format error" or a "version error"), an error with a fallback URL (which is
 also the primaryUrl when the bundle parses successfully), or a map ({{INFRA}})
-of metadata containing at least keys named:
+of metadata containing keys named:
 
 primaryUrl
 
@@ -162,7 +163,8 @@ manifest
   multiple different manifests, where the client uses content negotiation to
   select the most appropriate one.
 
-The map may include other items added by sections defined in the
+The map must include keys named primaryUrl and requests. The map may include
+manifest and other items added by sections defined in the
 {{section-name-registry}}{:format="title"}.
 
 This operation only waits for a prefix of the stream that, if the bundle is

--- a/draft-yasskin-wpack-bundled-exchanges.md
+++ b/draft-yasskin-wpack-bundled-exchanges.md
@@ -364,7 +364,7 @@ steps, taking the `stream` as input.
 
 1. Assert: `metadata` has an entry with the key "primaryUrl".
 
-1. If `metadata` doesn't have entries with key "requests", return a
+1. If `metadata` doesn't have an entry with key "requests", return a
    "format error" with `fallbackUrl`.
 
 1. Return `metadata`.


### PR DESCRIPTION
Currently there is no need to make "manifest" section mandatory.

Chromium side CL: https://crrev.com/c/1861614
