### PR TITLE
Add JavaScript library for generating bundles

### DIFF
--- a/js/bundle/.gitignore
+++ b/js/bundle/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+lib

--- a/js/bundle/README.md
+++ b/js/bundle/README.md
@@ -1,0 +1,29 @@
+# js/bundle
+This directory contains a JavaScript library for serializing (and parsing, in the future) the `application/webbundle` format defined in the [Bundled HTTP Exchanges](https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.html) draft spec.
+
+## Installation
+Using npm:
+```bash
+npm install webbundle
+```
+
+## Usage
+Please be aware that the API is not yet stable and is subject to change any time.
+
+Example:
+```javascript
+const webbundle = require('webbundle');
+const fs = require("fs");
+
+const primaryURL = 'https://example.com/';
+let builder = new webbundle.BundleBuilder(primaryURL);
+builder.setManifestURL('https://example.com/manifest.json');
+builder.addExchange(
+    primaryURL,                          // URL
+    200,                                 // response code
+    {'Content-Type': 'text/html'},       // response headers
+    '<html>Hello, Web Bundle!</html>');  // response body (string or Uint8Array)
+// Have as many builder.addExchange() for resource URLs as needed for the package.
+
+fs.writeFileSync('out.wbn', builder.createBundle());
+```

--- a/js/bundle/package-lock.json
+++ b/js/bundle/package-lock.json
@@ -1,0 +1,48 @@
+{
+  "name": "webbundle",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/cbor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/cbor/-/cbor-2.0.0.tgz",
+      "integrity": "sha1-xievwu4i8j8jN/7LNGKKT5fGr7s=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.1.tgz",
+      "integrity": "sha512-TJtwsqZ39pqcljJpajeoofYRfeZ7/I/OMUQ5pR4q5wOKf2ocrUvBAZUMhWsOvKx3dVc/aaV5GluBivt0sWqA5A==",
+      "dev": true
+    },
+    "bignumber.js": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+    },
+    "cbor": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.0.1.tgz",
+      "integrity": "sha512-l4ghwqioCyuAaD3LvY4ONwv8NMuERz62xjbMHGdWBqERJPygVmoFER1b4+VS6iW0rXwoVGuKZPPPTofwWOg3YQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0",
+        "nofilter": "^1.0.3"
+      }
+    },
+    "nofilter": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.3.tgz",
+      "integrity": "sha512-FlUlqwRK6reQCaFLAhMcF+6VkVG2caYjKQY3YsRDTl4/SEch595Qb3oLjJRDr8dkHAAOVj2pOx3VknfnSgkE5g=="
+    },
+    "typescript": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
+      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+      "dev": true
+    }
+  }
+}

--- a/js/bundle/package.json
+++ b/js/bundle/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "webbundle",
+  "version": "0.0.1",
+  "description": "Generator for the application/webbundle format, defined in draft-yasskin-wpack-bundled-exchanges-01.",
+  "main": "./lib/webbundle.js",
+  "types": "./lib/webbundle.d.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/WICG/webpackage.git",
+    "directory": "js/bundle"
+  },
+  "keywords": [
+    "webpackage",
+    "bundled exchanges"
+  ],
+  "author": "Kunihiko Sakamoto <ksakamoto@chromium.org>",
+  "license": "W3C-20150513",
+  "dependencies": {
+    "cbor": "^5.0.1"
+  },
+  "devDependencies": {
+    "@types/cbor": "^2.0.0",
+    "@types/node": "^12.7.11",
+    "typescript": "^3.6.3"
+  }
+}

--- a/js/bundle/src/encoder.ts
+++ b/js/bundle/src/encoder.ts
@@ -1,0 +1,141 @@
+import * as CBOR from 'cbor';
+
+declare module 'cbor' {
+    // TODO: upstream this to @types/cbor
+    export function encodeCanonical(input: any): Buffer;
+}
+
+type CBORValue = any;
+
+export class BundleBuilder {
+    private sectionLengths: (string|number)[] = [];
+    private sections: CBORValue[] = [];
+    private responses: Uint8Array[][] = [];
+    private index: {[key:string]: [Uint8Array, number, number]} = {};
+    private currentResponsesOffset = 0;
+
+    constructor(private primaryURL: string) {
+        validateExchangeURL(primaryURL);
+    }
+
+    createBundle(): Buffer {
+        if (!this.index[this.primaryURL]) {
+            throw new Error(`Exchange for primary URL (${this.primaryURL}) does not exist`);
+        }
+
+        this.addSection("index", this.fixupIndex());
+        this.addSection("responses", this.responses);
+        let wbn = CBOR.encodeCanonical(this.createTopLevel());
+        // Fill in the length field.
+        let view = new DataView(wbn.buffer, wbn.byteOffset + wbn.length - 8);
+        view.setUint32(0, Math.floor(wbn.length / 0x100000000));
+        view.setUint32(4, wbn.length & 0xffffffff);
+        return wbn;
+    }
+
+    addExchange(url: string, status: number, headers: {[key:string]: string}, payload: Uint8Array|string) {
+        validateExchangeURL(url);
+        if (typeof payload === 'string')
+            payload = byteString(payload);
+        this.addIndexEntry(url, this.addResponse(new HeaderMap(status, headers), payload));
+    }
+
+    setManifestURL(url: string) {
+        validateExchangeURL(url);
+        this.addSection('manifest', url);
+    }
+
+    private addSection(name: string, content: CBORValue) {
+        if (this.sectionLengths.includes(name)) {
+            throw new Error('Duplicated section: ' + name);
+        }
+        this.sectionLengths.push(name);
+        this.sectionLengths.push(encodedLength(content));
+        this.sections.push(content);
+    }
+
+    private addResponse(headerMap: HeaderMap, payload: Uint8Array): number {
+        if (payload.length > 0 && !headerMap.has('content-type')) {
+            throw new Error('Non-empty exchange must have Content-Type header');
+        }
+
+        let response = [new Uint8Array(CBOR.encodeCanonical(headerMap)), payload];
+        this.responses.push(response);
+        return encodedLength(response);
+    }
+
+    private addIndexEntry(url: string, responseLength: number) {
+        this.index[url] = [
+            new Uint8Array(0), // variants-value
+            this.currentResponsesOffset,
+            responseLength,
+        ];
+        this.currentResponsesOffset += responseLength;
+    }
+
+    private fixupIndex() {
+        // Adjust the offsets by the length of the response section's CBOR header.
+        let responsesHeaderSize = encodedLength(this.responses.length);
+        for (let key in this.index) {
+            this.index[key][1] += responsesHeaderSize;
+        }
+        return this.index;
+    }
+
+    private createTopLevel(): CBORValue {
+        return [
+            byteString('🌐📦'),
+            byteString('b1\0\0'),
+            this.primaryURL,
+            new Uint8Array(CBOR.encodeCanonical(this.sectionLengths)),
+            this.sections,
+            new Uint8Array(8),  // Length (to be filled in later)
+        ];
+    }
+};
+
+class HeaderMap extends Map<string, string> {
+    constructor(status: number, headers: {[key:string]: string}) {
+        super();
+        if (status < 100 || status > 999) {
+            throw new Error('Invalid status code');
+        }
+
+        this.set(':status', status.toString());
+        for (let key in headers) {
+            this.set(key.toLowerCase(), headers[key]);
+        }
+    }
+
+    // This tells the CBOR library how to serialize this object.
+    encodeCBOR(encoder: CBOR.Encoder) {
+        // Convert keys and values to Uint8Array, as the CBOR representation of
+        // header map is {bytestring => bytestring}.
+        let m = new Map<Uint8Array, Uint8Array>();
+        for (let [key, value] of this.entries()) {
+            m.set(byteString(key), byteString(value));
+        }
+        return encoder.pushAny(m);
+    }
+}
+
+// Throws an error if `urlString` is not a valid exchange URL.
+function validateExchangeURL(urlString: string): void {
+    let url = new URL(urlString);
+    if (url.username !== '' || url.password !== '') {
+        throw new Error('Exchange URL must not have credentials: ' + urlString);
+    }
+    if (url.hash !== '') {
+        throw new Error('Exchange URL must not have a hash: ' + urlString);
+    }
+}
+
+// Returns the length of `value` when CBOR-encoded.
+function encodedLength(value: any): number {
+    // We don't need to use canonical encoding here.
+    return CBOR.encode(value).byteLength;
+}
+
+function byteString(s: string): Uint8Array {
+    return Buffer.from(s, 'utf-8');
+}

--- a/js/bundle/src/webbundle.ts
+++ b/js/bundle/src/webbundle.ts
@@ -1,0 +1,2 @@
+export { BundleBuilder } from './encoder';
+// TODO: add decoder

--- a/js/bundle/tsconfig.json
+++ b/js/bundle/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "target": "esnext",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "strict": true,
+        "declaration": true,
+        "newLine": "lf",
+        "outDir": "lib"
+    },
+    "include": [
+        "src/*"
+    ]
+}


### PR DESCRIPTION
The `gen-bundle` Go tool is convenient for simple use cases, but developers who want to support WebBundle generation for their site may need more fine-grained control.

This adds a simple JavaScript library (npm package) for creating application/webbundle resources, which could be used as a building block of popular frontend development toolchain (such as plugins for gulp, webpack, etc.).
