### PR TITLE
gen-bundle: Add -headerOverride flag

### DIFF
--- a/go/bundle/README.md
+++ b/go/bundle/README.md
@@ -34,6 +34,7 @@ These command-line flags are common to all the three options:
 - `-primaryURL` specifies the bundle's main resource URL. This URL is also used as the fallback destination when browser cannot process the bundle.
 - `-manifestURL` specifies the bundle's [manifest](https://www.w3.org/TR/appmanifest/) URL.
 - `-o` specifies name of the output bundle file.
+- `-headerOverride` adds additional response header to all bundled responses. Existing values of the header are overwritten.
 
 #### From a HAR file
 


### PR DESCRIPTION
This can be used to inject arbitrary headers to bundled responses. For example, `Access-Control-Allow-Origin: *` may be added to workaround CORS errors in untrusted bundles.