### PR TITLE
gen-bundle: Verify that an exchange for primary URL exists

### DIFF
--- a/go/bundle/README.md
+++ b/go/bundle/README.md
@@ -43,7 +43,7 @@ One convenient way to generate HAR file is via Chrome Devtools. Navigate to "Net
 
 Once you have the har file, generate the bundled exchange file via:
 ```
-gen-bundle -har foo.har -o foo.wbn
+gen-bundle -har foo.har -o foo.wbn -primaryURL https://example.com/
 ```
 
 #### From a URL list
@@ -71,7 +71,7 @@ Note that `gen-bundle` does not automatically discover subresources; you have to
 
 You can also create a bundle from a local directory. For example, if you have the necessary files for the site `https://www.example.com/` in `static/` directory, run:
 ```
-gen-bundle -dir static -baseURL https://www.example.com/ -o foo.wbn
+gen-bundle -dir static -baseURL https://example.com/ -o foo.wbn -primaryURL https://example.com/
 ```
 
 ### sign-bundle

--- a/go/bundle/bundle.go
+++ b/go/bundle/bundle.go
@@ -72,3 +72,21 @@ func (e *Exchange) AddPayloadIntegrity(ver version.Version, recordSize int) (str
 	e.Response.Header.Add("Digest", digest)
 	return encoding.IntegrityIdentifier(), nil
 }
+
+// Validate performs basic sanity checks on the bundle.
+func (b *Bundle) Validate() error {
+	if b.Version.HasPrimaryURLField() {
+		hasExchangeForPrimaryURL := false
+		primaryURLString := b.PrimaryURL.String()
+		for _, e := range b.Exchanges {
+			if e.Request.URL.String() == primaryURLString {
+				hasExchangeForPrimaryURL = true
+				break
+			}
+		}
+		if !hasExchangeForPrimaryURL {
+			return fmt.Errorf("bundle: No exchange for primary URL %v", b.PrimaryURL)
+		}
+	}
+	return nil
+}

--- a/go/bundle/encoder.go
+++ b/go/bundle/encoder.go
@@ -379,6 +379,10 @@ func writeFooter(w io.Writer, offset int) error {
 }
 
 func (b *Bundle) WriteTo(w io.Writer) (int64, error) {
+	if err := b.Validate(); err != nil {
+		return 0, err
+	}
+
 	cw := NewCountingWriter(w)
 
 	is := &indexSection{}


### PR DESCRIPTION
After this patch, bundle.Write() fails if the bundle doesn't have
an exchange for its primary URL.

Also add `-primaryURL` flag to the command-line examples in README.