### PR TITLE
js/bundle: Make sure to give CBOR encoder sufficient buffer size

### DIFF
--- a/js/bundle/src/encoder.ts
+++ b/js/bundle/src/encoder.ts
@@ -71,12 +71,16 @@ export class BundleBuilder {
   }
 
   private addSection(name: string, content: CBORValue) {
-    if (this.sectionLengths.find(s => s.name === name)) {
+    if (this.sectionLengths.some(s => s.name === name)) {
       throw new Error('Duplicated section: ' + name);
     }
     let length: number;
     if (name === 'responses') {
-      // The responses section can be large, so avoid using encodedLength().
+      // The responses section can be large, so avoid using encodedLength()
+      // with the entire section's content.
+      // Here, this.currentResponsesOffset holds the sum of all response
+      // lengths. Adding encodedLength(this.responses.length) to this gives
+      // the same result as encodedLength(content).
       length =
         this.currentResponsesOffset + encodedLength(this.responses.length);
     } else {

--- a/js/bundle/src/encoder.ts
+++ b/js/bundle/src/encoder.ts
@@ -1,8 +1,12 @@
 import * as CBOR from 'cbor';
 
 declare module 'cbor' {
-  // TODO: upstream this to @types/cbor
-  export function encodeCanonical(input: CBORValue): Buffer;
+  // TODO: upstream these to @types/cbor
+  interface DecoderOptions {
+    canonical?: boolean;
+    highWaterMark?: number;
+  }
+  export function encodeOne(obj: CBORValue, opts?: DecoderOptions): Buffer;
 }
 
 type CBORValue = unknown;
@@ -11,7 +15,7 @@ interface Headers {
 }
 
 export class BundleBuilder {
-  private sectionLengths: Array<string | number> = [];
+  private sectionLengths: Array<{ name: string; length: number }> = [];
   private sections: CBORValue[] = [];
   private responses: Uint8Array[][] = [];
   private index: Map<string, [Uint8Array, number, number]> = new Map();
@@ -21,6 +25,7 @@ export class BundleBuilder {
     validateExchangeURL(primaryURL);
   }
 
+  // TODO: Provide async version of this.
   createBundle(): Buffer {
     if (!this.index.has(this.primaryURL)) {
       throw new Error(
@@ -30,7 +35,13 @@ export class BundleBuilder {
 
     this.addSection('index', this.fixupIndex());
     this.addSection('responses', this.responses);
-    const wbn = CBOR.encodeCanonical(this.createTopLevel());
+
+    const estimatedBundleSize = this.sectionLengths.reduce(
+      (size, s) => size + s.length,
+      16384 // For headers (including primary URL)
+    );
+    const wbn = encodeCanonical(this.createTopLevel(), estimatedBundleSize);
+
     // Fill in the length field.
     const view = new DataView(wbn.buffer, wbn.byteOffset + wbn.length - 8);
     view.setUint32(0, Math.floor(wbn.length / 0x100000000));
@@ -60,22 +71,35 @@ export class BundleBuilder {
   }
 
   private addSection(name: string, content: CBORValue) {
-    if (this.sectionLengths.includes(name)) {
+    if (this.sectionLengths.find(s => s.name === name)) {
       throw new Error('Duplicated section: ' + name);
     }
-    this.sectionLengths.push(name);
-    this.sectionLengths.push(encodedLength(content));
+    let length: number;
+    if (name === 'responses') {
+      // The responses section can be large, so avoid using encodedLength().
+      length =
+        this.currentResponsesOffset + encodedLength(this.responses.length);
+    } else {
+      length = encodedLength(content);
+    }
+    this.sectionLengths.push({ name, length });
     this.sections.push(content);
   }
 
+  // Adds a response to `this.response`, and returns its length in the
+  // responses section.
   private addResponse(headerMap: HeaderMap, payload: Uint8Array): number {
     if (payload.length > 0 && !headerMap.has('content-type')) {
       throw new Error('Non-empty exchange must have Content-Type header');
     }
 
-    const response = [new Uint8Array(CBOR.encodeCanonical(headerMap)), payload];
+    const response = [new Uint8Array(encodeCanonical(headerMap)), payload];
     this.responses.push(response);
-    return encodedLength(response);
+    // This should be the same as encodedLength(response).
+    return response.reduce(
+      (len, buf) => len + encodedLength(buf.length) + buf.length,
+      1
+    );
   }
 
   private addIndexEntry(url: string, responseLength: number) {
@@ -97,11 +121,15 @@ export class BundleBuilder {
   }
 
   private createTopLevel(): CBORValue {
+    const sectionLengths: Array<string | number> = [];
+    for (const s of this.sectionLengths) {
+      sectionLengths.push(s.name, s.length);
+    }
     return [
       byteString('🌐📦'),
       byteString('b1\0\0'),
       this.primaryURL,
-      new Uint8Array(CBOR.encodeCanonical(this.sectionLengths)),
+      new Uint8Array(encodeCanonical(sectionLengths)),
       this.sections,
       new Uint8Array(8), // Length (to be filled in later)
     ];
@@ -150,10 +178,28 @@ function validateExchangeURL(urlString: string): void {
   }
 }
 
+// Encodes `value` in canonical CBOR. Throws an error if the result is larger
+// than `bufferSize`, because the CBOR encoder silently ignores write errors
+// to its internal stream and returns broken data.
+function encodeCanonical(value: CBORValue, bufferSize = 1024 * 1024): Buffer {
+  const buf = CBOR.encodeOne(value, {
+    canonical: true,
+    highWaterMark: bufferSize,
+  });
+  if (buf.length >= bufferSize) {
+    throw new Error('CBOR encode error: insufficient buffer size');
+  }
+  return buf;
+}
+
 // Returns the length of `value` when CBOR-encoded.
-function encodedLength(value: CBORValue): number {
+function encodedLength(value: CBORValue, bufferSize = 1024 * 1024): number {
   // We don't need to use canonical encoding here.
-  return CBOR.encode(value).byteLength;
+  const len = CBOR.encodeOne(value, { highWaterMark: bufferSize }).byteLength;
+  if (len >= bufferSize) {
+    throw new Error('CBOR encode error: insufficient buffer size');
+  }
+  return len;
 }
 
 function byteString(s: string): Uint8Array {

--- a/js/bundle/tests/encoder_test.js
+++ b/js/bundle/tests/encoder_test.js
@@ -62,4 +62,12 @@ describe('Bundle Builder', () => {
       ).toThrowError();
     });
   });
+
+  it('builds large bundle', () => {
+    const builder = new wbn.BundleBuilder(primaryURL);
+    builder.addExchange(primaryURL, 200, defaultHeaders, new Uint8Array(1024*1024));
+    const buf = builder.createBundle();
+    // Just checks the result is a valid CBOR array.
+    expect(CBOR.decode(buf)).toBeInstanceOf(Array);
+  });
 });


### PR DESCRIPTION
`CBOR.encode()` chokes and generates broken output if given data is
larger than its `highWaterMark` option value [1].

So, this patch:

- Give sufficient buffer size when encoding
- Add checks for encoded results (throws if it doesn't fit the buffer)
- `encodedLength()` internally uses `encode()`, so avoid using it for
  potentially large objects

This fixes #522.

[1] https://github.com/hildjj/node-cbor#highwatermark