### PR TITLE
js/bundle: Support node 8.x

### DIFF
--- a/js/bundle/package.json
+++ b/js/bundle/package.json
@@ -29,5 +29,8 @@
     "@types/node": "^12.7.11",
     "jasmine": "^3.5.0",
     "typescript": "^3.6.3"
+  },
+  "engines": {
+    "node": ">= 8.0.0"
   }
 }

--- a/js/bundle/src/encoder.ts
+++ b/js/bundle/src/encoder.ts
@@ -1,4 +1,5 @@
 import * as CBOR from 'cbor';
+import {URL} from 'url';
 
 declare module 'cbor' {
   // TODO: upstream this to @types/cbor


### PR DESCRIPTION
Just a tiny fix.

I'm not sure this is intended or not, but global `URL` class was added from Node 10.x.

This change will support 8.x which is still at the maintenance LTS stage, actually it will be eol [soon](https://github.com/nodejs/Release) though. Even if doesn't support 8.x, at least supported node version should be specified via "engines" field in package.json.

@irori Could you have a look? Thanks!