### PR TITLE
js/bundle: interpret the critical section

### DIFF
--- a/js/bundle/src/decoder.ts
+++ b/js/bundle/src/decoder.ts
@@ -4,6 +4,14 @@ interface Headers {
   [key: string]: string;
 }
 
+const knownSections = [
+  'critical',
+  'index',
+  'manifest',
+  'responses',
+  'signatures',
+];
+
 /** This class represents parsed Web Bundle. */
 export class Bundle {
   version: string;
@@ -41,6 +49,15 @@ export class Bundle {
     for (let i = 0; i < sectionsArray.length; i++) {
       this.sections[asString(sectionLengths[i * 2])] = sectionsArray[i];
     }
+
+    if (this.sections['critical']) {
+      for (const name of asArray(this.sections['critical'])) {
+        if (!knownSections.includes(asString(name))) {
+          throw new Error(`unknown section ${name} is marked as critical`);
+        }
+      }
+    }
+
     // The index section records (offset, length) of each response, but our
     // CBOR decoder doesn't preserve location information. So, recalculate
     // offset and length of each response here. This is inefficient, but works.

--- a/js/bundle/tests/decoder_test.js
+++ b/js/bundle/tests/decoder_test.js
@@ -65,4 +65,36 @@ describe('Bundle', () => {
       '<html>Hello, Web Bundle!</html>\n'
     );
   });
+
+  it('throws if an unknown section is marked as critical', () => {
+    const builder = new wbn.BundleBuilder('https://example.com/');
+    builder.addExchange(
+      'https://example.com/',
+      200,
+      { 'Content-Type': 'text/plain' },
+      'Hello, world!'
+    );
+    builder.addSection('critical', ['unknown']);
+    const buf = builder.createBundle();
+    expect(() => new wbn.Bundle(buf)).toThrowError();
+  });
+
+  it('does not throw if all names in the critical section are known', () => {
+    const builder = new wbn.BundleBuilder('https://example.com/');
+    builder.addExchange(
+      'https://example.com/',
+      200,
+      { 'Content-Type': 'text/plain' },
+      'Hello, world!'
+    );
+    builder.addSection('critical', [
+      'critical',
+      'index',
+      'manifest',
+      'responses',
+      'signatures',
+    ]);
+    const buf = builder.createBundle();
+    expect(() => new wbn.Bundle(buf)).not.toThrowError();
+  });
 });


### PR DESCRIPTION
WebBundle parser must fail if the `critical` section includes unknown section names.

https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.html#name-parsing-the-critical-sectio