### PR TITLE
Add "X-Content-Type-Options: nosniff" to example of firebase hosting config

### DIFF
--- a/examples/firebase.json
+++ b/examples/firebase.json
@@ -22,6 +22,10 @@
           {
             "key": "Content-Type",
             "value": "application/signed-exchange;v=b3"
+          },
+          {
+            "key": "X-Content-Type-Options",
+            "value": "nosniff"
           }
         ]
       }


### PR DESCRIPTION
fixed for
```
Signed exchange response without "X-Content-Type-Options: nosniff" header is not supported.
```