### PR TITLE
gen-bundle: Add support for Variants

### DIFF
--- a/go/bundle/encoder_test.go
+++ b/go/bundle/encoder_test.go
@@ -1,0 +1,100 @@
+package bundle
+
+import (
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/WICG/webpackage/go/bundle/version"
+	"github.com/WICG/webpackage/go/internal/testhelper"
+)
+
+func urlMustParse(rawurl string) *url.URL {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func TestVariants(t *testing.T) {
+	variants, err := parseVariants("Accept-Encoding;gzip;br, Accept-Language;en;fr;ja")
+	if err != nil {
+		t.Errorf("parseListOfStringLists unexpectedly failed: %v", err)
+	}
+	if nk, err := variants.numberOfPossibleKeys(); nk != 6 || err != nil {
+		t.Errorf("numberOfPossibleKeys: got: (%v, %v) want: (%v, %v)", nk, err, 6, nil)
+	}
+
+	cases := []struct {
+		index      int
+		variantKey []string
+	}{
+		{0, []string{"gzip", "en"}},
+		{1, []string{"gzip", "fr"}},
+		{2, []string{"gzip", "ja"}},
+		{3, []string{"br", "en"}},
+		{4, []string{"br", "fr"}},
+		{5, []string{"br", "ja"}},
+		{-1, []string{"gzip", "es"}},
+		{-1, []string{}},
+		{-1, []string{"gzip"}},
+		{-1, []string{"gzip", "en", "foo"}},
+	}
+	for _, c := range cases {
+		if i := variants.indexInPossibleKeys(c.variantKey); i != c.index {
+			t.Errorf("indexInPossibleKeys: got: %v want: %v", i, c.index)
+		}
+
+		if c.index != -1 {
+			key := variants.possibleKeyAt(c.index)
+			if !reflect.DeepEqual(key, c.variantKey) {
+				t.Errorf("possibleKeyAt(%d): got: %v\nwant: %v", c.index, key, c.variantKey)
+			}
+		}
+	}
+}
+
+func TestIndexSectionWithVariants(t *testing.T) {
+	url := urlMustParse("https://example.com/")
+	variants := []string{"Accept-Encoding;gzip;br, Accept-Language;en;fr"}
+	is := &indexSection{}
+	is.addExchange(
+		&Exchange{
+			Request{URL: url},
+			Response{Header: http.Header{
+				"Variants":    variants,
+				"Variant-Key": []string{"gzip;fr, br;en"},
+			}},
+		}, 20, 2)
+	is.addExchange(
+		&Exchange{
+			Request{URL: url},
+			Response{Header: http.Header{
+				"Variants":    variants,
+				"Variant-Key": []string{"gzip;en"},
+			}},
+		}, 10, 1)
+	is.addExchange(
+		&Exchange{
+			Request{URL: url},
+			Response{Header: http.Header{
+				"Variants":    variants,
+				"Variant-Key": []string{"br;fr"},
+			}},
+		}, 30, 3)
+	if err := is.Finalize(version.VersionB1); err != nil {
+		t.Fatal(err)
+	}
+
+	want := `map["https://example.com/":["Accept-Encoding;gzip;br, Accept-Language;en;fr" 10 1 20 2 20 2 30 3]]`
+
+	got, err := testhelper.CborBinaryToReadableString(is.bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("got: %s\nwant: %s", got, want)
+	}
+}

--- a/go/internal/testhelper/cbor.go
+++ b/go/internal/testhelper/cbor.go
@@ -37,6 +37,8 @@ func readableString(v interface{}) string {
 		return "map[" + strings.Join(vals, " ") + "]"
 	case string, []byte:
 		return fmt.Sprintf("%q", v)
+	case uint64:
+		return fmt.Sprintf("%d", v)
 	default:
 		panic(fmt.Sprintf("not supported type: %T", v))
 	}

--- a/go/signedexchange/certurl/certchain_test.go
+++ b/go/signedexchange/certurl/certchain_test.go
@@ -5,9 +5,9 @@ import (
 	"io/ioutil"
 	"testing"
 
-	. "github.com/WICG/webpackage/go/signedexchange/certurl"
+	"github.com/WICG/webpackage/go/internal/testhelper"
 	"github.com/WICG/webpackage/go/signedexchange"
-	"github.com/WICG/webpackage/go/signedexchange/internal/testhelper"
+	. "github.com/WICG/webpackage/go/signedexchange/certurl"
 )
 
 func createCertChain(t *testing.T) CertChain {


### PR DESCRIPTION
The index section of bundle maps URLs to a Variants value + a list of
the responses for each possible Variant-Key (#450). But before this
patch gen-bundle could not generate a bundle that have multiple variants
for single URL.

This patch teaches indexSection.Finalize() to generate entries with
non-empty variants-value, based on the responses' Variant and
Variant-Key headers [1].

[1] https://tools.ietf.org/html/draft-ietf-httpbis-variants-05