### PR TITLE
go/bundle: Support non-empty variants in decoder

### DIFF
--- a/go/bundle/bundle_test.go
+++ b/go/bundle/bundle_test.go
@@ -66,6 +66,40 @@ func createTestBundle(t *testing.T, ver version.Version) *Bundle {
 	return bundle
 }
 
+func createTestBundleWithVariants(ver version.Version) *Bundle {
+	primaryURL := urlMustParse("https://variants.example.com/")
+	return &Bundle{
+		Version:    ver,
+		PrimaryURL: primaryURL,
+		Exchanges: []*Exchange{
+			&Exchange{
+				Request{URL: primaryURL},
+				Response{
+					Status: 200,
+					Header: http.Header{
+						"Content-Type": []string{"text/plain"},
+						"Variants":     []string{"Accept-Language;en;ja"},
+						"Variant-Key":  []string{"en"},
+					},
+					Body: []byte("Hello, world!"),
+				},
+			},
+			&Exchange{
+				Request{URL: primaryURL},
+				Response{
+					Status: 200,
+					Header: http.Header{
+						"Content-Type": []string{"text/plain"},
+						"Variants":     []string{"Accept-Language;en;ja"},
+						"Variant-Key":  []string{"ja"},
+					},
+					Body: []byte("こんにちは世界"),
+				},
+			},
+		},
+	}
+}
+
 func createTestCerts(t *testing.T) []*certurl.AugmentedCertificate {
 	certs, err := signedexchange.ParseCertificates([]byte(pemCerts))
 	if err != nil {
@@ -91,6 +125,27 @@ func TestWriteAndRead(t *testing.T) {
 			t.Errorf("Bundle.WriteTo returned %d, but wrote %d bytes", n, buf.Len())
 		}
 
+		deserialized, err := Read(&buf)
+		if err != nil {
+			t.Errorf("Bundle.Read unexpectedly failed: %v", err)
+		}
+		if !reflect.DeepEqual(deserialized, bundle) {
+			t.Errorf("got: %v\nwant: %v", deserialized, bundle)
+		}
+	}
+}
+
+func TestWriteAndReadWithVariants(t *testing.T) {
+	for _, ver := range version.AllVersions {
+		if !ver.HasVariantsSupport() {
+			continue
+		}
+		bundle := createTestBundleWithVariants(ver)
+
+		var buf bytes.Buffer
+		if _, err := bundle.WriteTo(&buf); err != nil {
+			t.Errorf("Bundle.WriteTo unexpectedly failed: %v", err)
+		}
 		deserialized, err := Read(&buf)
 		if err != nil {
 			t.Errorf("Bundle.Read unexpectedly failed: %v", err)

--- a/go/bundle/bundle_test.go
+++ b/go/bundle/bundle_test.go
@@ -137,7 +137,7 @@ func TestWriteAndRead(t *testing.T) {
 
 func TestWriteAndReadWithVariants(t *testing.T) {
 	for _, ver := range version.AllVersions {
-		if !ver.HasVariantsSupport() {
+		if !ver.SupportsVariants() {
 			continue
 		}
 		bundle := createTestBundleWithVariants(ver)

--- a/go/bundle/decoder.go
+++ b/go/bundle/decoder.go
@@ -642,7 +642,7 @@ func loadMetadata(bs []byte) (*meta, error) {
 		// Step 22.6. "Follow "name"'s specification from knownSections to process the section, passing sectionContents, stream, sectionOffsets, and metadata. If this returns an error, return a "format error" with fallbackUrl." [spec text]
 		switch so.Name {
 		case "index":
-			if ver.HasVariantsSupport() {
+			if ver.SupportsVariants() {
 				requests, err := parseIndexSection(sectionContents, sectionsStart, sos)
 				if err != nil {
 					return nil, &LoadMetadataError{err, FormatError, fallbackURL}
@@ -662,7 +662,7 @@ func loadMetadata(bs []byte) (*meta, error) {
 			}
 			meta.manifestURL = manifestURL
 		case "signatures":
-			if ver.HasSignaturesSupport() {
+			if ver.SupportsSignatures() {
 				signatures, err := parseSignaturesSection(sectionContents)
 				if err != nil {
 					return nil, &LoadMetadataError{err, FormatError, fallbackURL}

--- a/go/bundle/decoder.go
+++ b/go/bundle/decoder.go
@@ -356,8 +356,38 @@ func parseIndexSection(sectionContents []byte, sectionsStart uint64, sos []secti
 			requests = append(requests, requestEntryWithOffset{Request: Request{URL: parsedUrl}, Offset: offset, Length: length})
 		} else {
 			// Step 4.4. "Otherwise:" [spec text]
-			// TODO: implement.
-			return nil, fmt.Errorf("bundle.index[%d]: non-empty variants-value is not supported.", i)
+			// Step 4.4.1. "Let variants be the result of parsing the first element of responses as the value of the Variants HTTP header field (Section 2 of [I-D.ietf-httpbis-variants]). If this fails, return an error." [spec text]
+			variants, err := parseVariants(string(variants_value))
+			if err != nil {
+				return nil, fmt.Errorf("bundle.index[%d]: Cannot parse variants value %q: %v", i, string(variants_value), err)
+			}
+			// Step 4.4.2. "Let variantKeys be the Cartesian product of the lists of available-values for each variant-axis in lexicographic (row-major) order. See the examples above." [spec text]
+			numVariantKeys, err := variants.numberOfPossibleKeys()
+			if err != nil {
+				return nil, fmt.Errorf("bundle.index[%d]: Invalid variants value %q: %v", i, string(variants_value), err)
+			}
+			// Step 4.4.3. "If the length of responses is not 2 * len(variantKeys) + 1, return an error." [spec text]
+			if numItems != 2*uint64(numVariantKeys)+1 {
+				return nil, fmt.Errorf("bundle.index[%d]: Unexpected size of value array: %d", i, numItems)
+			}
+			// Step 4.4.4. "Set requests[parsedUrl] to a map from variantKeys[i] to the result of calling MakeRelativeToStream on the location-in-responses at responses[2*i+1] and responses[2*i+2], for i in [0, len(variantKeys)). If any MakeRelativeToStream call returns an error, return an error." [spec text]
+			// Currently this implementation just appends all entries to `requests`.
+			// TODO: Preserve the map structure from variant-key to location-in-stream.
+			for j := 0; j < numVariantKeys; j++ {
+				offset, err := dec.DecodeUint()
+				if err != nil {
+					return nil, fmt.Errorf("bundle.index[%d][%d]: Failed to decode offset: %v", i, j, err)
+				}
+				length, err := dec.DecodeUint()
+				if err != nil {
+					return nil, fmt.Errorf("bundle.index[%d][%d]: Failed to decode length: %v", i, j, err)
+				}
+				offset, length, err = makeRelativeToStream(offset, length)
+				if err != nil {
+					return nil, fmt.Errorf("bundle.index[%d][%d]: %v", i, j, err)
+				}
+				requests = append(requests, requestEntryWithOffset{Request: Request{URL: parsedUrl}, Offset: offset, Length: length})
+			}
 		}
 	}
 	return requests, nil

--- a/go/bundle/encoder.go
+++ b/go/bundle/encoder.go
@@ -117,7 +117,7 @@ func (is *indexSection) Finalize(ver version.Version) error {
 	var b bytes.Buffer
 	enc := cbor.NewEncoder(&b)
 
-	if ver.HasVariantsSupport() {
+	if ver.SupportsVariants() {
 		// CDDL:
 		//   index = {* whatwg-url => [ variants-value, +location-in-responses ] }
 		//   variants-value = bstr
@@ -579,7 +579,7 @@ func (b *Bundle) WriteTo(w io.Writer) (int64, error) {
 		}
 		sections = append(sections, ms)
 	}
-	if b.Signatures != nil && b.Version.HasSignaturesSupport() {
+	if b.Signatures != nil && b.Version.SupportsSignatures() {
 		ss, err := newSignaturesSection(b.Signatures)
 		if err != nil {
 			return cw.Written, err

--- a/go/bundle/version/version.go
+++ b/go/bundle/version/version.go
@@ -94,10 +94,10 @@ func (v Version) HasPrimaryURLField() bool {
 	return v != Unversioned
 }
 
-func (v Version) HasVariantsSupport() bool {
+func (v Version) SupportsVariants() bool {
 	return v != Unversioned
 }
 
-func (v Version) HasSignaturesSupport() bool {
+func (v Version) SupportsSignatures() bool {
 	return v != Unversioned
 }


### PR DESCRIPTION
This enables dump-bundle to read bundles that have multiple variants
for single URL.

Also this adds a roundtrip test (serialize and then deserialize) for a
bundle with variants.