### PR TITLE
js/bundle: Allow method chaining in bundle builder

### DIFF
--- a/js/bundle/README.md
+++ b/js/bundle/README.md
@@ -18,16 +18,16 @@ Please be aware that the API is not yet stable and is subject to change any time
 Creating a Bundle:
 ```javascript
 const wbn = require('wbn');
-const fs = require("fs");
+const fs = require('fs');
 
 const primaryURL = 'https://example.com/';
-const builder = new wbn.BundleBuilder(primaryURL);
-builder.setManifestURL('https://example.com/manifest.json');
-builder.addExchange(
-  primaryURL,                          // URL
-  200,                                 // response code
-  {'Content-Type': 'text/html'},       // response headers
-  '<html>Hello, Web Bundle!</html>');  // response body (string or Uint8Array)
+const builder = (new wbn.BundleBuilder(primaryURL))
+  .setManifestURL('https://example.com/manifest.json')
+  .addExchange(
+    primaryURL,                          // URL
+    200,                                 // response code
+    {'Content-Type': 'text/html'},       // response headers
+    '<html>Hello, Web Bundle!</html>');  // response body (string or Uint8Array)
 // Have as many builder.addExchange() for resource URLs as needed for the package.
 
 fs.writeFileSync('out.wbn', builder.createBundle());
@@ -36,7 +36,7 @@ fs.writeFileSync('out.wbn', builder.createBundle());
 Reading a Bundle:
 ```javascript
 const wbn = require('wbn');
-const fs = require("fs");
+const fs = require('fs');
 
 const buf = fs.readFileSync('out.wbn');
 const bundle = new wbn.Bundle(buf);

--- a/js/bundle/src/encoder.ts
+++ b/js/bundle/src/encoder.ts
@@ -58,7 +58,7 @@ export class BundleBuilder {
     status: number,
     headers: Headers,
     payload: Uint8Array | string
-  ) {
+  ): BundleBuilder {
     validateExchangeURL(url);
     if (typeof payload === 'string') {
       payload = byteString(payload);
@@ -67,16 +67,18 @@ export class BundleBuilder {
       url,
       this.addResponse(new HeaderMap(status, headers), payload)
     );
+    return this;
   }
 
-  addFile(url: string, file: string) {
+  addFile(url: string, file: string): BundleBuilder {
     const headers = {
       'Content-Type': mime.getType(file) || 'application/octet-stream',
     };
     this.addExchange(url, 200, headers, fs.readFileSync(file));
+    return this;
   }
 
-  addFilesRecursively(baseURL: string, dir: string) {
+  addFilesRecursively(baseURL: string, dir: string): BundleBuilder {
     if (!baseURL.endsWith('/')) {
       throw new Error("baseURL must end with '/'.");
     }
@@ -96,11 +98,13 @@ export class BundleBuilder {
         this.addFile(baseURL + file, filePath);
       }
     }
+    return this;
   }
 
-  setManifestURL(url: string) {
+  setManifestURL(url: string): BundleBuilder {
     validateExchangeURL(url);
     this.addSection('manifest', url);
+    return this;
   }
 
   private addSection(name: string, content: CBORValue) {

--- a/js/bundle/tests/encoder_test.js
+++ b/js/bundle/tests/encoder_test.js
@@ -30,6 +30,13 @@ describe('Bundle Builder', () => {
   });
 
   describe('addExchange', () => {
+    it('returns the builder itself', () => {
+      const builder = new wbn.BundleBuilder(primaryURL);
+      expect(
+        builder.addExchange(primaryURL, 200, defaultHeaders, defaultContent)
+      ).toBe(builder);
+    });
+
     it('rejects invalid URLs', () => {
       const builder = new wbn.BundleBuilder(primaryURL);
       invalidURLs.forEach(url => {
@@ -49,9 +56,14 @@ describe('Bundle Builder', () => {
   });
 
   describe('addFile', () => {
+    it('returns the builder itself', () => {
+      const file = path.resolve(__dirname, 'testdata/encoder_test/index.html');
+      const builder = new wbn.BundleBuilder(primaryURL);
+      expect(builder.addFile(primaryURL, file)).toBe(builder);
+    });
+
     it('adds an exchange as expected', () => {
       const file = path.resolve(__dirname, 'testdata/encoder_test/index.html');
-
       const builder = new wbn.BundleBuilder(primaryURL);
       builder.addFile(primaryURL, file);
       const generated = builder.createBundle();
@@ -76,6 +88,12 @@ describe('Bundle Builder', () => {
   });
 
   describe('addFilesRecursively', () => {
+    it('returns the builder itself', () => {
+      const dir = path.resolve(__dirname, 'testdata/encoder_test');
+      const builder = new wbn.BundleBuilder(primaryURL);
+      expect(builder.addFilesRecursively(primaryURL, dir)).toBe(builder);
+    });
+
     it('adds exchanges as expected', () => {
       const dir = path.resolve(__dirname, 'testdata/encoder_test');
       const baseURL = 'https://example.com/';
@@ -117,10 +135,15 @@ describe('Bundle Builder', () => {
   });
 
   describe('setManifestURL', () => {
+    it('returns the builder itself', () => {
+      const builder = new wbn.BundleBuilder(primaryURL);
+      expect(builder.setManifestURL(primaryURL)).toBe(builder);
+    });
+
     it('rejects invalid URLs', () => {
       const builder = new wbn.BundleBuilder(primaryURL);
       invalidURLs.forEach(url => {
-        expect(() => builder.addManifestURL(url)).toThrowError();
+        expect(() => builder.setManifestURL(url)).toThrowError();
       });
     });
 


### PR DESCRIPTION
This makes BundleBuilder methods return the builder itself, so that callers can chain method calls, like this:
```javascript
  const bundle = (new BundleBuilder(primaryURL))
    .setManifestURL(...)
    .addExchange(...)
    .addExchange(...)
    .createBundle();
```
This is a common idiom of Builder classes.