### PR TITLE
dump-bundle: Treat JavaScript resources as text

### DIFF
--- a/go/bundle/cmd/dump-bundle/main.go
+++ b/go/bundle/cmd/dump-bundle/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"mime"
 	"os"
 	"strings"
 	"time"
@@ -82,7 +83,12 @@ func DumpExchange(e *bundle.Exchange, b *bundle.Bundle, verifier *signature.Veri
 }
 
 func isTextType(mimeType string) bool {
-	return strings.HasPrefix(mimeType, "text/") || strings.HasPrefix(mimeType, "application/javascript")
+	m, _, err := mime.ParseMediaType(mimeType)
+	if err != nil {
+		// Since this is a dump tool, we just ignore parse errors.
+		return false
+	}
+	return strings.HasPrefix(m, "text/") || m == "application/javascript"
 }
 
 func run() error {

--- a/go/bundle/cmd/dump-bundle/main.go
+++ b/go/bundle/cmd/dump-bundle/main.go
@@ -65,7 +65,7 @@ func DumpExchange(e *bundle.Exchange, b *bundle.Bundle, verifier *signature.Veri
 	}
 	if *flagDumpContentText {
 		ctype := e.Response.Header.Get("content-type")
-		if strings.Contains(ctype, "text") {
+		if isTextType(ctype) {
 			if _, err := fmt.Print(string(payload)); err != nil {
 				return err
 			}
@@ -79,6 +79,10 @@ func DumpExchange(e *bundle.Exchange, b *bundle.Bundle, verifier *signature.Veri
 		}
 	}
 	return nil
+}
+
+func isTextType(mimeType string) bool {
+	return strings.HasPrefix(mimeType, "text/") || strings.HasPrefix(mimeType, "application/javascript")
 }
 
 func run() error {


### PR DESCRIPTION
So that dump-bundle will print response body by default.