### PR TITLE
Fix #556: describe the origin-computation algorithm better.

### DIFF
--- a/explainers/navigation-to-unsigned-bundles.md
+++ b/explainers/navigation-to-unsigned-bundles.md
@@ -149,9 +149,9 @@ Each item of the bundle is addressible using a URL, with the new scheme
 `package:`. (See [below](#alternate-URL-schemes-considered) for some details of
 this choice.) This scheme identifies both the URL of the bundle itself (e.g.
 `https://distributor.example/package.wbn?q=query`) and the claimed URL inside
-the bundle (e.g. `https://publisher.example/page.html?q=query`) These are
-encoded so that the [normal algorithm for computing an origin from a
-URL](https://url.spec.whatwg.org/#concept-url-origin) works, by replacing `:`
+the bundle (e.g. `https://publisher.example/page.html?q=query`). These are
+encoded to minimize the changes needed to the [algorithm for computing an origin
+from a URL](https://url.spec.whatwg.org/#concept-url-origin), by replacing `:`
 with `!`, `/` with `,`, and `?` with `;`, and separating the 2 URLs with `$`.
 Any instance of `!`, `,`, `;`, or `$` in the URLs themselves is %-encoded:
 


### PR DESCRIPTION
I believe that with the encoding suggested here, we can just add "package" to the list at https://url.spec.whatwg.org/#concept-url-origin that includes "https", and that'll make the origin algorithm work for the new scheme. @annevk pointed out that my explanation was too brief; does this do a better job, or is there some other wording that would express it better?