### PR TITLE
js/bundle: Allow non-http(s) URLs

### DIFF
--- a/js/bundle/src/encoder.ts
+++ b/js/bundle/src/encoder.ts
@@ -203,14 +203,10 @@ class HeaderMap extends Map<string, string> {
 }
 
 // Throws an error if `urlString` is not a valid exchange URL, i.e. it must:
-// - be absolute,
-// - have http: or https: protocol, and
+// - be absolute, and
 // - have no credentials (user:password@) or hash (#fragment).
 function validateExchangeURL(urlString: string): void {
-  const url = new URL(urlString);
-  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-    throw new Error("Exchange URL's protocol must be http(s): " + urlString);
-  }
+  const url = new URL(urlString);  // This throws if urlString is not an absolute URL.
   if (url.username !== '' || url.password !== '') {
     throw new Error('Exchange URL must not have credentials: ' + urlString);
   }

--- a/js/bundle/tests/encoder_test.js
+++ b/js/bundle/tests/encoder_test.js
@@ -9,7 +9,6 @@ describe('Bundle Builder', () => {
   const defaultContent = 'Hello, world!';
   const invalidURLs = [
     '',
-    'ftp://example.com/',
     'https://example.com/#fragment',
     'https://user:pass@example.com/',
     'relative/url',


### PR DESCRIPTION
This makes the JS WebBundle encoder be liberal about inner URL schemes.

The format spec currently does not say which URL scheme should be
allowed, which is discussed in #468.