### PR TITLE
Make resources attribute DOMTokenList

### DIFF
--- a/explainers/subresource-loading.md
+++ b/explainers/subresource-loading.md
@@ -206,7 +206,7 @@ of resources could look like:
 <link
   rel="webbundle"
   href="https://example.com/dir/subresources.wbn"
-  resources="https://example.com/this,https://example.com/is,https://example.com/not,https://example.com/a,https://example.com/real,https://example.com/list,https://example.com/of,https://example.com/URLs"
+  resources="https://example.com/this https://example.com/is https://example.com/not https://example.com/a https://example.com/real https://example.com/list https://example.com/of https://example.com/URLs"
 />
 ```
 

--- a/explainers/subresource-loading.md
+++ b/explainers/subresource-loading.md
@@ -210,6 +210,8 @@ of resources could look like:
 />
 ```
 
+The `resources` attribute is reflected to JavaScript as a [`DOMTokenList`](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList).
+
 #### Approximate Membership Query datastructure
 
 A page still executes correctly, albeit slower than optimal, if a resource


### PR DESCRIPTION
Make `<link>` elements' `resources` attribute `DOMTokenList` so that the explainer matches chromium's current POC implementation.