### PR TITLE
Update loading spec to support subresource substitution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/WICG/webpackage
 
+go 1.15
+
 require (
 	github.com/mrichman/hargo v0.1.2-0.20190117125451-162adce4527e
 	github.com/ugorji/go/codec v0.0.0-20181209151446-772ced7fd4c2

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/WICG/webpackage
 
-go 1.15
-
 require (
 	github.com/mrichman/hargo v0.1.2-0.20190117125451-162adce4527e
 	github.com/ugorji/go/codec v0.0.0-20181209151446-772ced7fd4c2

--- a/loading.bs
+++ b/loading.bs
@@ -122,11 +122,11 @@ spec: 7230; urlPrefix: https://tools.ietf.org/html/rfc7230#
         text: token; url: section-3.2.6
 spec: RFC8288; urlPrefix: https://tools.ietf.org/html/rfc8288#
     type: dfn
-        text: Target Attributes list; url: section-2.2
+        text: Target Attribute; url: section-2.2
         text: Link Target; url: section-3.1
         text: Link Context; url: section-3.2
         text: Relation Type; url: section-3.3
-        text: Target Attributes; url: section-3.4
+        text: Serialisation-Defined Target Attribute; url: section-3.4
         text: Parsing a Link Field Value; url: appendix-B.2
     type: http-header
         text: Link; url: section-3
@@ -281,8 +281,9 @@ Rewrite [=request/clone|clone a request=] to run these steps:
 
 ## New response fields ## {#mp-response}
 
-A [=response=] has an associated <dfn for="response">came from a signed
-exchange</dfn> boolean. Unless stated otherwise, it is false.
+A [=response=] has an associated <dfn for="response" lt="came from a signed
+exchange|did not come from a signed exchange">came from a signed exchange</dfn>
+boolean. Unless stated otherwise, it is false.
 
 A [=response=] has an associated <dfn for="response">signed exchange outer
 header list</dfn> (a [=header list=]). Unless stated otherwise it is empty.
@@ -456,20 +457,20 @@ satisfy the `https://cdn.publisher.example/lib.js` `<script>` element.
     dfn-type=dfn>alternate signed exchange</dfn> at the [=Link Target=] of the
     [=alternate signed exchange link=].
 
-* New serialisation-defined [=Target Attributes=] on the <a http-header>Link</a>
+* New [=serialisation-defined Target Attributes=] on the <a http-header>Link</a>
     header.
 
     * The <dfn element-attr for="link">variants</dfn> target attribute has the
         same values as the <a http-header>Variants</a> Header Field.  There MUST
-        NOT be more than one <{link/variants}> attribute in a link-value; occurrences
-        after the first MUST be ignored by parsers. It is serialized to an HTTP
-        link-param by first encoding as if it were a <a http-header>Variants</a>
-        Header Field value, and then if there are characters that don't match
-        the <a grammar>token</a> production, encoding as a <a
-        grammar>quoted-string</a>.
+        NOT be more than one <{link/variants}> attribute in a link-value;
+        occurrences after the first MUST be ignored by parsers. It is serialized
+        to an HTTP link-param by first encoding as if it were a <a
+        http-header>Variants</a> Header Field value, and then if there are
+        characters that don't match the <a grammar>token</a> production,
+        encoding as a <a grammar>quoted-string</a>.
 
-        This parameter is used in <{link/rel/allowed-alt-sxg}> link and
-        [=alternate signed exchange link=] to indicate what representations are
+        This parameter is used in <{link/rel/allowed-alt-sxg}> links and
+        [=alternate signed exchange links=] to indicate what representations are
         available for the resource at the time that the response is produced.
 
     * The <dfn element-attr for="link">variant-key</dfn> target attribute has
@@ -481,8 +482,8 @@ satisfy the `https://cdn.publisher.example/lib.js` `<script>` element.
         characters that don't match the <a grammar>token</a> production,
         encoding as a <a grammar>quoted-string</a>.
 
-        This parameter is used in <{link/rel/allowed-alt-sxg}> link and
-        [=alternate signed exchange link=] to indicate one or more sets of
+        This parameter is used in <{link/rel/allowed-alt-sxg}> links and
+        [=alternate signed exchange links=] to indicate one or more sets of
         available-values that identify the representation of the resource.
 
 <h3 algorithm id="mp-document">New Document fields</h3>
@@ -494,7 +495,7 @@ section, add the following lines:
 <blockquote dfn-for="Document">
 
 The {{Document}} has a map of <dfn dfn>prefetched signed exchanges for
-navigation</dfn>, which is a [=map=] of [=URL=] to [=exchange=], initially
+navigation</dfn>, which is a [=map=] of [=URLs=] to [=exchanges=], initially
 empty.  <span class="note">This might merge with the set of prefetched resources
 when <{link/rel/prefetch}> is specified more completely.</span>
 
@@ -506,44 +507,45 @@ empty.
 
 <h3 algorithm id="mp-navigation-params">New navigation params struct field</h3>
 
-In the [=navigation params=], add the following items:
+In the [=navigation params=] struct, add the following items:
 
 <dl dfn-for="navigation params">
 
 : <dfn>prefetched subresource signed exchanges</dfn>
-:: A set of [=exchanges=], initially empty.
+:: A set of [=exchanges=], empty unless specified otherwise.
 
 </dl>
 
 <h3 algorithm id="mp-link-type-prefetch">Monkeypatch Link type "prefetch"</h3>
 
 Note: To prefetch the [=alternate signed exchanges=] when the UA receives a
-prefetched main resource signed exchange, this section monkeypatchs Link type
-"<{link/rel/prefetch}>". This is getting all the [=alternate signed exchange
-links=] from the outer response, and see if they are allowed by the inner
-response's <{link/rel/allowed-alt-sxg}> links, and if they are match with the
-inner response's <{link/rel/preload}> links.
+prefetched main resource signed exchange, this section monkeypatches Link type
+"<{link/rel/prefetch}>". This algorithm gets all the [=alternate signed exchange
+links=] from the outer response, checks if they are allowed by the inner
+response's <{link/rel/allowed-alt-sxg}> links, and if they are, associates them
+with the inner response's <{link/rel/preload}> links.
 
 Issue(w3c/resource-hints#77): Currently the behavior of recursive prefetch is
-not defined in the specs. This section monkeypatches Link type
-"<{link/rel/prefetch}>" to support only for the [=alternate signed exchanges=]
-subresources. When we will change the HTML spec to support the general recursive
-prefetching, this section must be made align with the change.
+not specified. This section monkeypatches Link type "<{link/rel/prefetch}>" to
+add support only for the [=alternate signed exchanges=] subresources. When we
+change the HTML spec to support general recursive prefetching, this section
+needs to align with that change.
 
-The [=process the linked resource=] given a link element |el|, boolean
-|success|, and [=response=] |response|:
+To [=process the linked resource|process this type of linked resource=]
+("<{link/rel/prefetch}>"), given a link element |el|, boolean |success|, and
+[=response=] |response|:
 
 1. If |success| is true, [=fire an event=] named {{HTMLElement/load}} at |el|.
 1. Otherwise, [=fire an event=] named {{HTMLElement/error}} at |el|.
-1. If the |success| is false, then return.
-1. If the |response|'s [=response/came from a signed exchange=] is false, then
+1. If |success| is false, then return.
+1. If the |response| [=response/did not come from a signed exchange=], then
     return.
-1. Let |clonedExchange| be the result of creating a new [=exchange=] with the
-    first item of |response|'s [=response/URL list=] and the result of
-    [=response/cloning=] |response|.
-1. [=map/Set=] |clonedExchange| to |el|'s [=Node/node document=]'s
-    [=Document/prefetched signed exchanges for navigation=][|clonedExchange|'s
-    [=exchange/request URL=]].
+1. Let |requestUrl| be the first item of |response|'s [=response/URL list=].
+1. Let |clonedExchange| be the result of creating a new [=exchange=] with
+    |requestUrl| and the result of [=response/cloning=] |response|.
+1. Let |prefetchedSignedExchanges| be |el|'s [=Node/node document=]'s
+    [=Document/prefetched signed exchanges for navigation=].
+1. [=map/Set=] |prefetchedSignedExchanges|[|requestUrl|] to |clonedExchange|.
 1. Let |outerLinkHeader| be the result of [=header list/getting=] `` `Link` ``
     from |response|'s [=response/signed exchange outer header list=].
 1. If |outerLinkHeader| is null, then return.
@@ -760,34 +762,34 @@ add the following steps:
                 links. This is intended to prevent the referrer page from
                 encoding a tracking ID into the set of subresources it
                 prefetches.
-            1. [=list/Append=] the [=alternate signed exchange peload info=]
+            1. [=list/Append=] the [=alternate signed exchange preload info=]
                 (|link|, |linkTarget|, |prefetched alternate exchange|) to
                 |preloadLinkItems|.
         1. For each |preloadLinkItem| of |preloadLinkItems|:
             1. Let |corsAttribute| be the [=CORS settings attribute=] of
-                |preloadLinkItem|'s [=alternate signed exchange peload
+                |preloadLinkItem|'s [=alternate signed exchange preload
                 info/link=]'s [=Target Attribute named=] `"crossorigin"`.
             1. Let |request| be the result of [=creating a potential-CORS
                 request=] given |preloadLinkItem|'s [=alternate signed exchange
-                peload info/target=], the empty string, and |corsAttribute|.
+                preload info/target=], the empty string, and |corsAttribute|.
             1. Set |request|'s [=request/synchronous flag=].
             1. Set |request|'s [=request/client=] to |document|.
             1. Set |request|'s [=request/cryptographic nonce metadata=] to
-                |preloadLinkItem|'s [=alternate signed exchange peload
+                |preloadLinkItem|'s [=alternate signed exchange preload
                 info/link=]'s [=Target Attribute named=] `"nonce"`.
             1. Set |request|'s [=request/integrity metadata=] to
-                |preloadLinkItem|'s [=alternate signed exchange peload
+                |preloadLinkItem|'s [=alternate signed exchange preload
                 info/link=]'s [=Target Attribute named=] `"integrity"`.
             1. Set |request|'s [=request/referrer policy=] to be the [=referrer
                 policy attribute=] of |preloadLinkItem|'s [=alternate signed
-                exchange peload info/link=]'s [=Target Attribute named=]
+                exchange preload info/link=]'s [=Target Attribute named=]
                 `"referrerpolicy"`.
             1. Set |request|'s [=request/destination=] to |preloadLinkItem|'s
-                [=alternate signed exchange peload info/link=]'s [=Target
+                [=alternate signed exchange preload info/link=]'s [=Target
                 Attribute named=] `"as"`.
             1. If |canLoadAlternateSxg| is true, then set |request|'s
                 [=request/stashed exchange=] to |preloadLinkItem|'s [=alternate
-                signed exchange peload info/prefetched alternate exchange=].
+                signed exchange preload info/prefetched alternate exchange=].
 
                 Note: When |canLoadAlternateSxg| if false or there is no
                 matching prefetched alternate exchange, the original resource
@@ -917,55 +919,57 @@ An exchange signature is a [=struct=] with the following items:
 
 <h3 dfn-type=dfn export>Allowed signed exchange link info</h3>
 
-An allowed signed exchange link info is a [=struct=] with the following items:
+An allowed signed exchange link info is a [=struct=] with the following items,
+holding a parsed <{link/rel/allowed-alt-sxg}> link:
 
 <dl dfn-for="allowed signed exchange link info">
 : <dfn>target</dfn>
 :: A [=Link Target=] of the link.
 : <dfn>header integrity</dfn>
-:: A [=string=] holding the value of the link's of [=Target Attributes
-    list|Target Attribute=] named `"header-integrity"`.
+:: A [=string=] holding the value of the link's [=Target Attribute=] named
+    `"header-integrity"`.
 : <dfn>variants</dfn>
-:: A [=string=] holding the value of the link's of [=Target Attributes
-    list|Target Attribute=] named `"variants"`, or null.
+:: A [=string=] holding the value of the link's [=Target Attribute=] named
+    `"variants"`, or null.
 : <dfn>variant key</dfn>
-:: A [=string=] holding the value of the link's of [=Target Attributes
-    list|Target Attribute=] named `"varivariant keyants"`, or null.
+:: A [=string=] holding the value of the link's [=Target Attribute=] named
+    `"variant key"`, or null.
 
 </dl>
 
 <h3 dfn-type=dfn export>Alternate signed exchange link info</h3>
 
-An alternate signed exchange link info is a [=struct=] with the following items:
+An alternate signed exchange link info is a [=struct=] with the following items,
+holding a parsed <{link/rel/alternate}> link:
 
 <dl dfn-for="alternate signed exchange link info">
 : <dfn>target</dfn>
-:: A [=Link Target=] of the link.
+:: The [=Link Target=] of the link.
 : <dfn>context</dfn>
-:: A [=string=] holding the value of the link's of [=Link Context=].
+:: A [=string=] holding the value of the link's [=Link Context=].
 : <dfn>variants</dfn>
-:: A [=string=] holding the value of the link's of [=Target Attributes
-    list|Target Attribute=] named `"variants"`, or null.
+:: A [=string=] holding the value of the link's [=Target Attribute=] named
+    `"variants"`, or null.
 : <dfn>variant key</dfn>
-:: A [=string=] holding the value of the link's of [=Target Attributes
-    list|Target Attribute=] named `"varivariant keyants"`, or null.
+:: A [=string=] holding the value of the link's [=Target Attribute=] named
+    `"variant key"`, or null.
 
 </dl>
 
-<h3 dfn-type=dfn export>Alternate signed exchange peload info</h3>
+<h3 dfn-type=dfn export>Alternate signed exchange preload info</h3>
 
-An alternate signed exchange peload info is a [=struct=] with the following items:
+An alternate signed exchange preload info is a [=struct=] with the following items:
 
-<dl dfn-for="alternate signed exchange peload info">
+<dl dfn-for="alternate signed exchange preload info">
 : <dfn>link</dfn>
 :: A link object [=Parsing a Link Field Value|parsed=] from a HTTP <a
     http-header>Link</a> header.
 : <dfn>target</dfn>
-:: A URL to be preloaded. <span class="note">This MAY be different from
-    [=alternate signed exchange peload info/link=]'s [=Link Target=], when
+:: A URL to be preloaded. <span class="note">This can be different from
+    [=alternate signed exchange preload info/link=]'s [=Link Target=], when
     `"imagesrcset"` is used for image preload.</span>
 : <dfn>prefetched alternate exchange</dfn>
-:: A [=exchange=] of the prefetched [=alternate signed exchange=], or null.
+:: The [=exchange=] of the prefetched [=alternate signed exchange=], or null.
 
 </dl>
 
@@ -1805,17 +1809,14 @@ To <dfn for="read buffer">Dump</dfn> a [=read buffer=] |input| to a
 
         </dl>
 
-<h4 algorithm id="dump-value-of-target-attributes">Get value of [=Target
-Attributes list|Target Attributes=]</h4>
+<h3 algorithm id="dump-value-of-target-attributes">Get value of [=Target Attributes=]</h3>
 
 A link header value |link|'s <dfn noexport>Target Attribute named</dfn> |name|
-is the second item of the first tuple of |link|'s [=Target Attributes
-list|Target Attributes=] whose first item matches the string |name|, or null if
-no such tuple is present.
+is the second item of the first tuple of |link|'s [=Target Attributes=] whose
+first item matches the string |name|, or null if no such tuple is present.
 
 
-<h4 algorithm id="get-allowed-signed-exchange-links">Get allowed signed exchange
-link info</h4>
+<h3 algorithm id="get-allowed-signed-exchange-links">Get allowed signed exchange link info</h3>
 
 The result of <dfn>getting allowed signed exchange link info</dfn> from a
 [=list=] |links| is returned by the following steps:
@@ -1835,8 +1836,8 @@ The result of <dfn>getting allowed signed exchange link info</dfn> from a
         |allowedSxgLinks|.
 1. Return |allowedSxgLinks|.
 
-<h4 algorithm id="get-alternate-signed-exchange-links">Get alternate signed
-exchange link info</h4>
+<h3 algorithm id="get-alternate-signed-exchange-links">Get alternate signed
+exchange link info</h3>
 
 The result of <dfn>getting alternate signed exchange link info</dfn> from a
 [=list=] |links| is returned by the following steps:
@@ -1844,9 +1845,8 @@ The result of <dfn>getting alternate signed exchange link info</dfn> from a
 1. Let |alternateSxgLinks| be an empty [=list=].
 1. For each |link| of |links|:
     1. If |link|'s [=Relation Type=] is not 'alternate', then continue.
-    1. If |link|'s [=Target Attributes list|Target Attributes=] doesn't
-        [=list/contain=] (`"type"`,`"application/signed-exchange"`), then
-        continue.
+    1. If |link|'s [=Target Attributes=] doesn't [=list/contain=]
+        (`"type"`,`"application/signed-exchange"`), then continue.
     1. Let |linkTarget| be |link|'s [=Link Target=].
     1. Let |linkContext| be |link|'s [=Link Context=].
     1. Let |linkVariants| be |link|'s [=Target Attribute named=] `"variants"`.

--- a/loading.bs
+++ b/loading.bs
@@ -557,8 +557,8 @@ add the following steps:
     9. Let |allowed alternate subresource signed exchange links| be null.
 
     10. If |sourceBrowsingContext|'s [=active document=]'s
-        [=Document/prefetched signed exchanges for navigation=] has a matching exchange
-        for the |request|'s [=request/url=], then:
+        [=Document/prefetched signed exchanges for navigation=] has a matching
+        exchange for the |request|'s [=request/url=], then:
 
         1. Let |clonedExchange| be the result of creating a new [=exchange=]
             with the matching exchange's [=exchange/request URL=] and the result
@@ -569,7 +569,7 @@ add the following steps:
             [=request/stashed exchange=].
 
         1. Copy <{link/rel/allowed-alt-sxg}> link of the exchange's
-            [=exchange/response=]'s inner response to
+            [=exchange/response=] to
             |allowed alternate subresource signed exchange links|.
 
 
@@ -583,10 +583,10 @@ add the following steps:
 
     19. Copy |sourceBrowsingContext|'s [=active document=]'s
         [=Document/prefetched subresource signed exchanges=]
-        to navigationParams's
+        to |navigationParams|'s
         [=navigation params/prefetched subresource signed exchanges=].
 
-    20. Set navigationParams's
+    20. Set |navigationParams|'s
         [=navigation params/allowed alternate subresource signed exchange links=]
         to |allowed alternate subresource signed exchange links|.
 
@@ -605,13 +605,13 @@ before
 
 add the following steps:
 
-    15. Move the navigationParams's
+    15. Move the |navigationParams|'s
         [=navigation params/prefetched subresource signed exchanges=] to the
-        document's [=Document/transferred subresource signed exchanges=].
+        |document|'s [=Document/transferred subresource signed exchanges=].
 
-    16. Set document's
+    16. Set |document|'s
         [=Document/allowed alternate subresource signed exchange links=] to
-        navigationParams's
+        |navigationParams|'s
         [=navigation params/allowed alternate subresource signed exchange links=].
 
 
@@ -629,10 +629,11 @@ before
 
 add the following steps:
 
-    1. If |el| is for the main resource's HTTP <a http-header>Link</a> header,
+    5. If |el| is for the main resource's HTTP <a http-header>Link</a> header,
         then:
 
-        1.  For each |allowedAltSxgLink| in [=Document/allowed alternate subresource signed exchange links=]:
+        1.  For each |allowedAltSxgLink| in |el|'s [=Node/node document=]'s
+            [=Document/allowed alternate subresource signed exchange links=]:
 
             1. Let |storedExchange| be the result of creating an [=exchange=]
                 with the URL of the |allowedAltSxgLink| link's [=Link Target=]
@@ -655,7 +656,8 @@ add the following steps:
                 1. Wait until there is no remaining preload Link header of the main
                     resource to be processed.
 
-                1. If for every |el|'s in this step, document's
+                1. If for every |el|'s in this step, |el|'s
+                    [=Node/node document=]'s
                     [=Document/transferred subresource signed exchanges=]
                     contains a |matchingExchange| which [=exchange/response=]'s
                     [=response/header integrity value=] is the same as

--- a/loading.bs
+++ b/loading.bs
@@ -596,17 +596,22 @@ To [=process the linked resource|process this type of linked resource=]
             [=response/header list=].
         1. Let |requestForMatch| be the result of [=creating a potential-CORS
             request=] given |linkTarget|, the empty string, and [=No CORS=].
-        1. If |requestForMatch| doesn't [=matches the stored exchange=]
+        1. If |requestForMatch| [=doesn't match the stored exchange=]
             |storedExchange|, then continue.
-        1. Let |alternateSxgUrl| be [=alternate signed exchange link
+        1. Let |alternateSxgUrl| be the [=alternate signed exchange link
             info/target=] of the first [=alternate signed exchange link info=]
-            of |alternateLinks| whose [=alternate signed exchange link
-            info/variants=] matches |allowedSxgLink|'s [=allowed signed exchange
-            link info/variants=] and whose [=alternate signed exchange link
-            info/variant key=] matches |allowedSxgLink|'s [=allowed signed
-            exchange link info/variant key=] and whose [=alternate signed
-            exchange link info/context=] matches |linkTarget| or continue if it
-            is not present.
+            of |alternateLinks| whose
+
+            * [=alternate signed exchange link info/variants=] is
+                [=string/identical to=] |allowedSxgLink|'s [=allowed signed
+                exchange link info/variants=],
+            * [=alternate signed exchange link info/variant key=] is
+                [=string/identical to=] |allowedSxgLink|'s [=allowed signed
+                exchange link info/variant key=], and
+            * [=alternate signed exchange link info/context=] [=url/equals=]
+                |linkTarget|
+
+            or continue if no such link is present.
         1. Let |sxgRequest| be the result of [=creating a potential-CORS
             request=] given |alternateSxgUrl|, the empty string, and [=No
             CORS=].
@@ -665,7 +670,7 @@ Note: As browsers move toward partitioned HTTP caches, the source document's
 Monkeypatch Page load processing model for HTML files</h3>
 
 Note: To use the [=navigation params/prefetched subresource signed exchanges=]
-after the navigation, this section monkeypatchs [=Page load processing model for
+after the navigation, this section monkeypatches [=Page load processing model for
 HTML files=]. This is getting all the <{link/rel/allowed-alt-sxg}> links from
 the inner response. And use the [=navigation params/prefetched subresource
 signed exchanges=] if the all allowed signe exchanges for subresources which are
@@ -688,7 +693,7 @@ add the following steps:
 
             Note: When the |document|'s [=viewport=] is known is not normatively
             defined in the HTML spec. Need to define the behavior of
-            preloadScanner to define this.
+            the preload scanner to define this.
         1. Let |linkHeader| be the result of [=header list/getting=] `` `Link`
             `` from |navigationParams|'s [=navigation params/response=]'s
             [=response/header list=].
@@ -740,7 +745,7 @@ add the following steps:
                     potential-CORS request=] given |allowedSxgLink|'s [=allowed
                     signed exchange link info/target=], the empty string, and
                     [=No CORS=].
-                1. If |requestForMatch| doesn't [=matches the stored exchange=]
+                1. If |requestForMatch| [=doesn't match the stored exchange=]
                     |storedExchange|, then continue.
                 1. Set |headerIntegrity| to |allowedSxgLink|'s [=allowed signed
                     exchange link info/header integrity=].
@@ -946,7 +951,7 @@ holding a parsed <{link/rel/alternate}> link:
 : <dfn>target</dfn>
 :: The [=Link Target=] of the link.
 : <dfn>context</dfn>
-:: A [=string=] holding the value of the link's [=Link Context=].
+:: A [=URL=] holding the value of the link's [=Link Context=].
 : <dfn>variants</dfn>
 :: A [=string=] holding the value of the link's [=Target Attribute=] named
     `"variants"`, or null.
@@ -1526,7 +1531,7 @@ To <dfn lt="reading a body|read a body">read a body</dfn> from a [=read buffer=]
 
 <h3 algorithm id="request-matching">Request matching</h3>
 
-A [=request=] |browserRequest| <dfn>matches the stored exchange</dfn>
+A [=request=] |browserRequest| <dfn lt="matches the stored exchange|doesn't match the stored exchange">matches the stored exchange</dfn>
 |storedExchange| if the following steps return "match":
 
 1. If |browserRequest|'s [=request/method=] is not `` `GET` `` or `` `HEAD` ``,

--- a/loading.bs
+++ b/loading.bs
@@ -507,6 +507,8 @@ Monkeypatch Link type "prefetch"</h3>
 The [=process the linked resource=] given a link element |el|, boolean
 |success|, and [=response=] |response|:
 
+1. If |success| is true, [=fire an event=] named {{HTMLElement/load}} at |el|.
+1. Otherwise, [=fire an event=] named {{HTMLElement/error}} at |el|.
 1. If the |success| is false, then return.
 1. If the |response|'s [=response/came from a signed exchange=] is false, then
     return.

--- a/loading.bs
+++ b/loading.bs
@@ -174,6 +174,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
         text: response; for: navigation params; url: browsing-the-web.html#navigation-params-response
         text: selecting an image source; url: images.html#select-an-image-source
         text: Use Credentials; url: urls-and-fetching.html#attr-crossorigin-use-credentials
+        text: Page load processing model for HTML files; url: browsing-the-web.html#read-html
 spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf
     type: dfn
         text: SHA-256; url: #
@@ -498,6 +499,16 @@ In the [=navigation params=], add the following items:
 
 <h3 algorithm id="mp-link-type-prefetch">Monkeypatch Link type "prefetch"</h3>
 
+Note: To prefetch the [=alternate signed exchanges=] when the UA receives a
+prefetched main resource signed exchange, this section monkeypatchs
+Link type "<{link/rel/prefetch}>".
+
+Issue(w3c/resource-hints#77): Currently the behavior of recursive prefetch is
+not defined in the specs. This section monkeypatches Link type
+"<{link/rel/prefetch}>" to support only for the [=alternate signed exchanges=]
+subresources. When we will change the HTML spec to support the general recursive
+prefetching, this section must be made align with the change.
+
 The [=process the linked resource=] given a link element |el|, boolean
 |success|, and [=response=] |response|:
 
@@ -587,12 +598,6 @@ The [=process the linked resource=] given a link element |el|, boolean
                 exchanges=].
 
 
-Issue(w3c/resource-hints#77): Currently the behavior of recursive prefetch is
-not defined in the specs. This section monkeypatches Link type
-"<{link/rel/prefetch}>" to support the recursive prefetching of alternate signed
-exchange subresources. When we will change the HTML spec to support the general
-recursive prefetching, this section must be made align with the change.
-
 <h3 algorithm id="mp-process-a-navigate-fetch">
 Monkeypatch process a navigate fetch</h3>
 In [process a navigate fetch](https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch)
@@ -635,15 +640,28 @@ Note: As browsers move toward partitioned HTTP caches, the source document's
 
 <h3 algorithm id="mp-page-load-processing-model-for-html-fiiles">
 Monkeypatch Page load processing model for HTML files</h3>
-In
-[Page load processing model for HTML files](https://html.spec.whatwg.org/multipage/browsing-the-web.html#read-html)
-before
+
+Note: To use the prefetched subresource signed exchanges after the navigation,
+this section monkeypatchs [=Page load processing model for HTML files=].
+
+Issue(whatwg/html#4224): Currently the processing model of the HTTP <a
+http-header>Link</a> header is not defined in the HTML spec. This section
+monkeypatches only for <a http-header>Link</a> rel=preload HTTP headers. When we
+will change the HTML spec to generally support <a http-header>Link</a> HTTP
+headers, this section must be made align with the change.
+
+
+In [=Page load processing model for HTML files=] before
 
 > 2. Create an HTML parser and ...
 
 add the following steps:
     2. Run the following steps [=in parallel=]:
-        1. Wait until |document|'s [=viewport=] is initialized.
+        1. Wait until |document|'s [=viewport=] is known.
+
+            Note: When the |document|'s [=viewport=] is known is not normatively
+            defined in the HTML spec. Need to define the behavior of
+            preloadScanner to define this.
         1. Let |linkHeader| be the result of [=header list/getting=] `` `Link`
             `` from |navigationParams|'s [=navigation params/response=]'s
             [=response/header list=].
@@ -745,15 +763,13 @@ add the following steps:
             1. If |canLoadAlternateSxg| is true, then set |request|'s
                 [=request/stashed exchange=] to |preloadLinkItem|'s [=alternate
                 signed exchange peload info/prefetched alternate exchange=].
+
+                Note: When |canLoadAlternateSxg| if false or there is no
+                matching prefetched alternate exchange, the original resource
+                declared in the  <{link/rel/preload}> <a http-header>Link</a>
+                header |link| will be fetched.
             1. [=Fetch=] |request| in parallel.
 
-Issue(whatwg/html#4224): Currently the processing model of the HTTP <a
-http-header>Link</a> header is not defined in the HTML spec. This section
-monkeypatches the [Page load processing model for HTML
-files](https://html.spec.whatwg.org/multipage/browsing-the-web.html#read-html)
-to support proccessing <a http-header>Link</a> rel=preload HTTP headers. When we
-will change the HTML spec to generally support <a http-header>Link</a> HTTP
-headers, this section must be made align with the change.
 
 # Structures # {#structs}
 

--- a/loading.bs
+++ b/loading.bs
@@ -566,6 +566,7 @@ To [=process the linked resource|process this type of linked resource=]
     1. If |innerLink|'s [=Relation Type=] is not 'preload', then continue.
     1. Let |linkTarget| be |innerLink|'s [=Link Target=].
     1. Let |asAttribute| be |innerLink|'s [=Target Attribute named=] `"as"`.
+    1. If |asAttribute| is not a [=potential destination=], continue.
     1. If |asAttribute| is `"image"`, then:
         1. Let |imagesrcset| be |innerLink|'s [=Target Attribute named=]
             `"imagesrcset"`.
@@ -595,7 +596,9 @@ To [=process the linked resource|process this type of linked resource=]
             key=] in |storedExchange|'s [=exchange/response=]'s
             [=response/header list=].
         1. Let |requestForMatch| be the result of [=creating a potential-CORS
-            request=] given |linkTarget|, the empty string, and [=No CORS=].
+            request=] given a url of |linkTarget|, a destination of the result
+            of [=destination/translating=] |asAttribute|, and a
+            corsAttributeState of [=No CORS=].
         1. If |requestForMatch| [=doesn't match the stored exchange=]
             |storedExchange|, then continue.
         1. Let |alternateSxgUrl| be the [=alternate signed exchange link
@@ -613,53 +616,55 @@ To [=process the linked resource|process this type of linked resource=]
 
             or continue if no such link is present.
         1. Let |sxgRequest| be the result of [=creating a potential-CORS
-            request=] given |alternateSxgUrl|, the empty string, and [=No
-            CORS=].
+            request=] given a url of |alternateSxgUrl|, a destination of the
+            result of [=destination/translating=] |asAttribute|, and a
+            corsAttributeState of [=No CORS=].
         1. Run the following steps [=in parallel=]:
             1. Let |sxgResponse| be the result of [=fetching=] |sxgRequest|.
             1. If |sxgResponse|'s [=response/came from a signed exchange=] is
                 true, and |sxgResponse|'s [=response/URL=] is the same as
-                |linkTarget|, then create an [=exchange=] with the URL of
-                |linkTarget| and the result of [=response/cloning=]
-                |sxgResponse|, and store the exchange to |el|'s [=Node/node
-                document=]'s [=Document/prefetched subresource signed
-                exchanges=].
+                |linkTarget|, then [=queue a task=] on the [=networking task source=] to:
+                1. Let |sxgExchange| be a new [=exchange=] with a
+                    [=exchange/request URL=] of |linkTarget| and a
+                    [=exchange/response=] of |sxgResponse|.
+                1. [=set/Append=] |sxgExchange| to |el|'s [=Node/node
+                    document=]'s [=Document/prefetched subresource signed
+                    exchanges=].
 
 
-<h3 algorithm id="mp-process-a-navigate-fetch">
-Monkeypatch process a navigate fetch</h3>
+<h3 algorithm id="mp-process-a-navigate-fetch">Monkeypatch process a navigate fetch</h3>
+
 In [process a navigate fetch](https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch)
 before
 
-> 9. While true:
+> 4. Let <var ignore>reservedEnvironment</var> be null.
 
 add the following steps:
 
-    9. If |sourceBrowsingContext|'s [=active document=]'s
-        [=Document/prefetched signed exchanges for navigation=][|request|'s
-        [=request/url=]] [=map/exists=], then:
+4. If |sourceBrowsingContext|'s [=active document=]'s [=Document/prefetched
+    signed exchanges for navigation=] [=map/contains=] an entry for a key of
+    |request|'s [=request/url=], then:
 
-        1. Let |prefetchedExchange| be |sourceBrowsingContext|'s
-            [=active document=]'s [=Document/prefetched signed exchanges for
-            navigation=][|request|'s [=request/url=]].
+    1. Let |prefetchedExchange| be |sourceBrowsingContext|'s [=active
+        document=]'s [=Document/prefetched signed exchanges for
+        navigation=][|request|'s [=request/url=]].
 
-        1. Set |request|'s [=request/stashed exchange=] to the result of
-            creating a new [=exchange=] with |prefetchedExchange|'s
-            [=exchange/request URL=] and the result of [=response/cloning=]
-            |prefetchedExchange|'s [=exchange/response=].
+    1. Set |request|'s [=request/stashed exchange=] to the result of creating a
+        new [=exchange=] with |prefetchedExchange|'s [=exchange/request URL=]
+        and the result of [=response/cloning=] |prefetchedExchange|'s
+        [=exchange/response=].
 
 
-And before
+And in
 
-> 17. Run process a navigate response with navigationType, the source browsing
->     context, and navigationParams.
+> 16. Let <var ignore>navigationParams</var> be a new [=navigation params=]
+>     whose ...
 
-add the following steps:
+add:
 
-    18. Copy |sourceBrowsingContext|'s [=active document=]'s
-        [=Document/prefetched subresource signed exchanges=]
-        to <var ignore=''>navigationParams</var>'s
-        [=navigation params/prefetched subresource signed exchanges=].
+16. ... [=navigation params/prefetched subresource signed exchanges=] is
+    |sourceBrowsingContext|'s [=active document=]'s [=Document/prefetched
+    subresource signed exchanges=], ...
 
 Note: As browsers move toward partitioned HTTP caches, the source document's
     cache will likely be separate from the target's cache, so we can't just pass
@@ -670,17 +675,17 @@ Note: As browsers move toward partitioned HTTP caches, the source document's
 Monkeypatch Page load processing model for HTML files</h3>
 
 Note: To use the [=navigation params/prefetched subresource signed exchanges=]
-after the navigation, this section monkeypatches [=Page load processing model for
-HTML files=]. This is getting all the <{link/rel/allowed-alt-sxg}> links from
-the inner response. And use the [=navigation params/prefetched subresource
-signed exchanges=] if the all allowed signe exchanges for subresources which are
-indicated by the inner response's <{link/rel/preload}> links are prefetched.
+after the navigation, this section monkeypatches [=Page load processing model
+for HTML files=]. This gets all the <{link/rel/allowed-alt-sxg}> links from the
+inner response that are also preloaded and uses the [=navigation
+params/prefetched subresource signed exchanges=] if all of those links were
+prefetched.
 
 Issue(whatwg/html#4224): Currently the processing model of the HTTP <a
 http-header>Link</a> header is not defined in the HTML spec. This section
 monkeypatches only for <a http-header>Link</a> rel=preload HTTP headers. When we
 will change the HTML spec to generally support <a http-header>Link</a> HTTP
-headers, this section must be made align with the change.
+headers, this section must be made to align with the change.
 
 
 In [=Page load processing model for HTML files=] before
@@ -688,119 +693,123 @@ In [=Page load processing model for HTML files=] before
 > 2. Create an HTML parser and ...
 
 add the following steps:
-    2. Run the following steps [=in parallel=]:
-        1. Wait until |document|'s [=viewport=] is known.
+2. Run the following steps [=in parallel=]:
+    1. Wait until |document|'s [=viewport=] is known.
 
-            Note: When the |document|'s [=viewport=] is known is not normatively
-            defined in the HTML spec. Need to define the behavior of
-            the preload scanner to define this.
-        1. Let |linkHeader| be the result of [=header list/getting=] `` `Link`
-            `` from |navigationParams|'s [=navigation params/response=]'s
-            [=response/header list=].
-        1. If |linkHeader| is null, then return.
-        1. Let |links| be the result of [=Parsing a Link Field Value=] from
-            |linkHeader|.
-        1. Let |allowedSxgLinks| be the result of [=getting allowed signed
-            exchange link info=] from |links|.
-        1. Let |preloadLinkItems| be an empty [=list=].
-        1. Let |canLoadAlternateSxg| be true.
-        1. For each |link| of |links|:
-            1. If |link|'s [=Relation Type=] is not 'preload', then continue.
-            1. Let |linkTarget| be |link|'s [=Link Target=].
-            1. Let |asAttribute| be |link|'s [=Target Attribute named=] `"as"`.
-            1. If |asAttribute| is null, then continue.
-            1. If |asAttribute| is `"image"`, then:
-                1. Let |imagesrcset| be |link|'s [=Target Attribute named=]
-                    `"imagesrcset"`.
-                1. Let |imagesizes| be |link|'s [=Target Attribute named=]
-                    `"imagesizes"`.
-                1. Create a <{link}> element |linkElement| whose <{link/href}>
-                    attribute is |linkTarget|, and <{link/imagesrcset}>
-                    attribute is |imagesrcset|, and <{link/imagesizes}>
-                    attribute is |imagesizes|.
-                1. Let |selected source| and <var ignore=''>selected pixel
-                    density</var> be the URL and pixel density that results from
-                    [=selecting an image source=] given |linkElement|,
-                    respectively.
-                1. If |selected source| is not null, then set |linkTarget| to
-                    the result of [=URL parser|parsing=] |selected source|, with
-                    a base URL of |navigationParams|'s [=navigation
-                    params/response=]'s [=response/URL=].
-            1. Let |headerIntegrity| be null.
-            1. For each |allowedSxgLink| of |allowedSxgLinks|:
-                1. Let |storedExchange| be the result of creating an
-                    [=exchange=] with the URL of |allowedSxgLink|'s [=allowed
-                    signed exchange link info/target=] and a new [=response=].
-                1. If |allowedSxgLink|'s [=allowed signed exchange link
-                    info/variants=] is null, [=header list/set=] `` `Variants`
-                    ``/|allowedSxgLink|'s [=allowed signed exchange link
-                    info/variants=] in |storedExchange|'s
-                    [=exchange/response=]'s [=response/header list=].
-                1. If |allowedSxgLink|'s [=allowed signed exchange link
-                    info/variant key=] is not null, [=header list/set=] ``
-                    `Variant-Key` ``/|allowedSxgLink|'s [=allowed signed
-                    exchange link info/variant key=] in |storedExchange|'s
-                    [=exchange/response=]'s [=response/header list=].
-                1. Let |requestForMatch| be the result of [=creating a
-                    potential-CORS request=] given |allowedSxgLink|'s [=allowed
-                    signed exchange link info/target=], the empty string, and
-                    [=No CORS=].
-                1. If |requestForMatch| [=doesn't match the stored exchange=]
-                    |storedExchange|, then continue.
-                1. Set |headerIntegrity| to |allowedSxgLink|'s [=allowed signed
-                    exchange link info/header integrity=].
-            1. Let |prefetched alternate exchange| be null.
-            1. For each |sxg| of |navigationParams|'s [=navigation
-                params/prefetched subresource signed exchanges=]:
-                1. If |headerIntegrity| is the same as the value of |sxg|'s
-                    [=exchange/response=]'s [=response/header integrity value=]
-                    encoded as a [[CSP]] <a grammar>hash-source</a>, then set
-                    |prefetched alternate exchange| to |sxg|.
-            1. If |headerIntegrity| is not null and |prefetched alternate
-                exchange| is null, then set |canLoadAlternateSxg| to false.
+        Note: When the |document|'s [=viewport=] is known is not normatively
+        defined in the HTML spec. Need to define the behavior of
+        the preload scanner to define this.
+    1. Let |linkHeader| be the result of [=header list/getting=] `` `Link`
+        `` from |navigationParams|'s [=navigation params/response=]'s
+        [=response/header list=].
+    1. If |linkHeader| is null, then return.
+    1. Let |links| be the result of [=Parsing a Link Field Value=] from
+        |linkHeader|.
+    1. Let |allowedSxgLinks| be the result of [=getting allowed signed
+        exchange link info=] from |links|.
+    1. Let |preloadLinkItems| be an empty [=list=].
+    1. Let |canLoadAlternateSxg| be true.
+    1. For each |link| of |links|:
+        1. If |link|'s [=Relation Type=] is not 'preload', then continue.
+        1. Let |linkTarget| be |link|'s [=Link Target=].
+        1. Let |asAttribute| be |link|'s [=Target Attribute named=] `"as"`.
+        1. If |asAttribute| is not a [=potential destination=], continue.
+        1. If |asAttribute| is `"image"`, then:
+            1. Let |imagesrcset| be |link|'s [=Target Attribute named=]
+                `"imagesrcset"`.
+            1. Let |imagesizes| be |link|'s [=Target Attribute named=]
+                `"imagesizes"`.
+            1. Create a <{link}> element |linkElement| whose <{link/href}>
+                attribute is |linkTarget|, and <{link/imagesrcset}>
+                attribute is |imagesrcset|, and <{link/imagesizes}>
+                attribute is |imagesizes|.
+            1. Let |selected source| and <var ignore=''>selected pixel
+                density</var> be the URL and pixel density that results from
+                [=selecting an image source=] given |linkElement|,
+                respectively.
+            1. If |selected source| is not null, then set |linkTarget| to
+                the result of [=URL parser|parsing=] |selected source|, with
+                a base URL of |navigationParams|'s [=navigation
+                params/response=]'s [=response/URL=].
+        1. Let |headerIntegrity| be null.
+        1. For each |allowedSxgLink| of |allowedSxgLinks|:
+            1. Let |storedExchange| be the result of creating an
+                [=exchange=] with the URL of |allowedSxgLink|'s [=allowed
+                signed exchange link info/target=] and a new [=response=].
+            1. If |allowedSxgLink|'s [=allowed signed exchange link
+                info/variants=] is null, [=header list/set=] `` `Variants`
+                ``/|allowedSxgLink|'s [=allowed signed exchange link
+                info/variants=] in |storedExchange|'s
+                [=exchange/response=]'s [=response/header list=].
+            1. If |allowedSxgLink|'s [=allowed signed exchange link
+                info/variant key=] is not null, [=header list/set=] ``
+                `Variant-Key` ``/|allowedSxgLink|'s [=allowed signed
+                exchange link info/variant key=] in |storedExchange|'s
+                [=exchange/response=]'s [=response/header list=].
+            1. Let |requestForMatch| be the result of [=creating a
+                potential-CORS request=] given a url of |allowedSxgLink|'s
+                [=allowed signed exchange link info/target=], a destination of
+                the result of [=destination/translating=] |asAttribute|, and a
+                corsAttributeState of [=No CORS=].
+            1. If |requestForMatch| [=doesn't match the stored exchange=]
+                |storedExchange|, then continue.
+            1. Set |headerIntegrity| to |allowedSxgLink|'s [=allowed signed
+                exchange link info/header integrity=].
+        1. Let |prefetched alternate exchange| be null.
+        1. For each |sxg| of |navigationParams|'s [=navigation
+            params/prefetched subresource signed exchanges=]:
+            1. If |headerIntegrity| is the same as the value of |sxg|'s
+                [=exchange/response=]'s [=response/header integrity value=]
+                encoded as a [[CSP]] <a grammar>hash-source</a>, then set
+                |prefetched alternate exchange| to |sxg|.
+        1. If |headerIntegrity| is not null and |prefetched alternate
+            exchange| is null, then set |canLoadAlternateSxg| to false.
 
-                Note: This means that there is a matching
-                <{link/rel/allowed-alt-sxg}> link for the <{link/rel/preload}>
-                |link|, but the matching signed exchange has not been
-                prefetched. In this case the UA MUST NOT use the prefetched
-                subresource signed exchanges for other  <{link/rel/preload}>
-                links. This is intended to prevent the referrer page from
-                encoding a tracking ID into the set of subresources it
-                prefetches.
-            1. [=list/Append=] the [=alternate signed exchange preload info=]
-                (|link|, |linkTarget|, |prefetched alternate exchange|) to
-                |preloadLinkItems|.
-        1. For each |preloadLinkItem| of |preloadLinkItems|:
-            1. Let |corsAttribute| be the [=CORS settings attribute=] of
-                |preloadLinkItem|'s [=alternate signed exchange preload
-                info/link=]'s [=Target Attribute named=] `"crossorigin"`.
-            1. Let |request| be the result of [=creating a potential-CORS
-                request=] given |preloadLinkItem|'s [=alternate signed exchange
-                preload info/target=], the empty string, and |corsAttribute|.
-            1. Set |request|'s [=request/synchronous flag=].
-            1. Set |request|'s [=request/client=] to |document|.
-            1. Set |request|'s [=request/cryptographic nonce metadata=] to
-                |preloadLinkItem|'s [=alternate signed exchange preload
-                info/link=]'s [=Target Attribute named=] `"nonce"`.
-            1. Set |request|'s [=request/integrity metadata=] to
-                |preloadLinkItem|'s [=alternate signed exchange preload
-                info/link=]'s [=Target Attribute named=] `"integrity"`.
-            1. Set |request|'s [=request/referrer policy=] to be the [=referrer
-                policy attribute=] of |preloadLinkItem|'s [=alternate signed
-                exchange preload info/link=]'s [=Target Attribute named=]
-                `"referrerpolicy"`.
-            1. Set |request|'s [=request/destination=] to |preloadLinkItem|'s
-                [=alternate signed exchange preload info/link=]'s [=Target
-                Attribute named=] `"as"`.
-            1. If |canLoadAlternateSxg| is true, then set |request|'s
-                [=request/stashed exchange=] to |preloadLinkItem|'s [=alternate
-                signed exchange preload info/prefetched alternate exchange=].
+            Note: This means that there is a matching
+            <{link/rel/allowed-alt-sxg}> link for the <{link/rel/preload}>
+            |link|, but the matching signed exchange has not been
+            prefetched. In this case the UA can't use the prefetched
+            subresource signed exchanges for other  <{link/rel/preload}>
+            links. This is intended to prevent the referrer page from
+            encoding a tracking ID into the set of subresources it
+            prefetches.
+        1. [=list/Append=] the [=alternate signed exchange preload info=]
+            (|link|, |linkTarget|, |prefetched alternate exchange|) to
+            |preloadLinkItems|.
+    1. For each |preloadLinkItem| of |preloadLinkItems|:
+        1. Let |asAttribute| be |preloadLinkItem|'s [=alternate signed exchange
+            preload info/link=]'s [=Target Attribute named=] `"as"`.
+        1. Assert: |asAttribute| is a [=potential destination=].
+        1. Let |corsAttributeState| be the state of a synthetic [=CORS settings
+            attribute=] with a value of |preloadLinkItem|'s [=alternate signed
+            exchange preload info/link=]'s [=Target Attribute named=]
+            `"crossorigin"`.
+        1. Let |request| be the result of [=creating a potential-CORS request=]
+            given a url of |preloadLinkItem|'s [=alternate signed exchange
+            preload info/target=], a destination of the result of
+            [=destination/translating=] |asAttribute|, and a corsAttributeState
+            of |corsAttributeState|.
+        1. Set |request|'s [=request/synchronous flag=].
+        1. Set |request|'s [=request/client=] to |document|.
+        1. Set |request|'s [=request/cryptographic nonce metadata=] to
+            |preloadLinkItem|'s [=alternate signed exchange preload
+            info/link=]'s [=Target Attribute named=] `"nonce"`.
+        1. Set |request|'s [=request/integrity metadata=] to
+            |preloadLinkItem|'s [=alternate signed exchange preload
+            info/link=]'s [=Target Attribute named=] `"integrity"`.
+        1. Set |request|'s [=request/referrer policy=] to be the [=referrer
+            policy attribute=] of |preloadLinkItem|'s [=alternate signed
+            exchange preload info/link=]'s [=Target Attribute named=]
+            `"referrerpolicy"`.
+        1. If |canLoadAlternateSxg| is true, then set |request|'s
+            [=request/stashed exchange=] to |preloadLinkItem|'s [=alternate
+            signed exchange preload info/prefetched alternate exchange=].
 
-                Note: When |canLoadAlternateSxg| if false or there is no
-                matching prefetched alternate exchange, the original resource
-                declared in the  <{link/rel/preload}> <a http-header>Link</a>
-                header |link| will be fetched.
-            1. [=Fetch=] |request| in parallel.
+            Note: When |canLoadAlternateSxg| if false or there is no
+            matching prefetched alternate exchange, the original resource
+            declared in the  <{link/rel/preload}> <a http-header>Link</a>
+            header |link| will be fetched.
+        1. [=Fetch=] |request| [=in parallel=].
 
 
 # Structures # {#structs}
@@ -929,7 +938,7 @@ holding a parsed <{link/rel/allowed-alt-sxg}> link:
 
 <dl dfn-for="allowed signed exchange link info">
 : <dfn>target</dfn>
-:: A [=Link Target=] of the link.
+:: A [=URL=] holding the value of the link's [=Link Target=].
 : <dfn>header integrity</dfn>
 :: A [=string=] holding the value of the link's [=Target Attribute=] named
     `"header-integrity"`.
@@ -949,7 +958,7 @@ holding a parsed <{link/rel/alternate}> link:
 
 <dl dfn-for="alternate signed exchange link info">
 : <dfn>target</dfn>
-:: The [=Link Target=] of the link.
+:: A [=URL=] holding the value of the link's [=Link Target=].
 : <dfn>context</dfn>
 :: A [=URL=] holding the value of the link's [=Link Context=].
 : <dfn>variants</dfn>

--- a/loading.bs
+++ b/loading.bs
@@ -116,6 +116,10 @@ spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231#
         text: HTTP media type; url: section-3.1.1.1
     type: http-header
         text: Date; url: section-7.1.1.2
+spec: 7230; urlPrefix: https://tools.ietf.org/html/rfc7230#
+    type: grammar
+        text: quoted-string; url: section-3.2.6
+        text: token; url: section-3.2.6
 spec: RFC8288; urlPrefix: https://tools.ietf.org/html/rfc8288#
     type: dfn
         text: Target Attributes list; url: section-2.2
@@ -278,7 +282,7 @@ Rewrite [=request/clone|clone a request=] to run these steps:
 ## New response fields ## {#mp-response}
 
 A [=response=] has an associated <dfn for="response">came from a signed
-exchange</dfn> boolean, which is false by default.
+exchange</dfn> boolean. Unless stated otherwise, it is false.
 
 A [=response=] has an associated <dfn for="response">signed exchange outer
 header list</dfn> (a [=header list=]). Unless stated otherwise it is empty.
@@ -286,7 +290,8 @@ header list</dfn> (a [=header list=]). Unless stated otherwise it is empty.
 A [=response=] has an associated <dfn for="response">header integrity
 value</dfn>, either null or, for responses that [=response/came from a signed
 exchange=], a [=byte sequence=] holding the [=SHA-256=] hash that verified the
-[=exchange/response=]'s [=response/header list=].
+[=exchange/response=]'s [=response/header list=]. Unless stated otherwise, it is
+null.
 
 Note: The [=response/header integrity value=] doesn’t change even if the
 publisher signs the content again or changes the signing key, but it does change
@@ -440,7 +445,7 @@ satisfy the `https://cdn.publisher.example/lib.js` `<script>` element.
     <{link/header-integrity}> parameter. The <dfn element-attr
     for="link">header-integrity</dfn> parameter holds the value of the
     [=response/header integrity value=] of the [=alternate signed exchange=],
-    encoded as a [[CSP]] <a grammar>hash-source</a>. 
+    encoded as a [[CSP]] <a grammar>hash-source</a>.
 * An <dfn>alternate signed exchange link</dfn> is a <a http-header>Link</a>
     header sent with a signed exchange |S|, with the <{link/rel/alternate}> link
     type, the `type` parameter set to `application/signed-exchange`, and a
@@ -451,21 +456,34 @@ satisfy the `https://cdn.publisher.example/lib.js` `<script>` element.
     dfn-type=dfn>alternate signed exchange</dfn> at the [=Link Target=] of the
     [=alternate signed exchange link=].
 
-* New [=Target Attributes=] on the <a http-header>Link</a> header.
+* New serialisation-defined [=Target Attributes=] on the <a http-header>Link</a>
+    header.
 
-    * The <dfn element-attr for="link">variants</dfn> parameter may be present.
+    * The <dfn element-attr for="link">variants</dfn> target attribute has the
+        same values as the <a http-header>Variants</a> Header Field.  There MUST
+        NOT be more than one <{link/variants}> attribute in a link-value; occurrences
+        after the first MUST be ignored by parsers. It is serialized to an HTTP
+        link-param by first encoding as if it were a <a http-header>Variants</a>
+        Header Field value, and then if there are characters that don't match
+        the <a grammar>token</a> production, encoding as a <a
+        grammar>quoted-string</a>.
+
         This parameter is used in <{link/rel/allowed-alt-sxg}> link and
         [=alternate signed exchange link=] to indicate what representations are
         available for the resource at the time that the response is produced.
-        This attribute is using the same format as <a
-        http-header>Variants</a> Header Field.
 
-    * The <dfn element-attr for="link">variant-key</dfn> parameter may be
-        present. This parameter is used in <{link/rel/allowed-alt-sxg}> link and
+    * The <dfn element-attr for="link">variant-key</dfn> target attribute has
+        the same values as the <a http-header>Variant-Key</a> Header Field.
+        There MUST NOT be more than one <{link/variant-key}> attribute in a
+        link-value; occurrences after the first MUST be ignored by parsers. It
+        is serialized to an HTTP link-param by first encoding as if it were a <a
+        http-header>Variant-Key</a> Header Field value, and then if there are
+        characters that don't match the <a grammar>token</a> production,
+        encoding as a <a grammar>quoted-string</a>.
+
+        This parameter is used in <{link/rel/allowed-alt-sxg}> link and
         [=alternate signed exchange link=] to indicate one or more sets of
         available-values that identify the representation of the resource.
-        This parameter is using the same format as <a
-        http-header>Variant-Key</a> Header Field.
 
 <h3 algorithm id="mp-document">New Document fields</h3>
 
@@ -614,7 +632,7 @@ add the following steps:
         [=Document/prefetched signed exchanges for navigation=][|request|'s
         [=request/url=]] [=map/exists=], then:
 
-        1. Let |prefetchedExchange| be |sourceBrowsingContext|'s 
+        1. Let |prefetchedExchange| be |sourceBrowsingContext|'s
             [=active document=]'s [=Document/prefetched signed exchanges for
             navigation=][|request|'s [=request/url=]].
 
@@ -678,7 +696,7 @@ add the following steps:
         1. Let |allowedSxgLinks| be the result of [=getting allowed signed
             exchange link info=] from |links|.
         1. Let |preloadLinkItems| be an empty [=list=].
-        1. Let |canLoadAlternateSxg| be true. 
+        1. Let |canLoadAlternateSxg| be true.
         1. For each |link| of |links|:
             1. If |link|'s [=Relation Type=] is not 'preload', then continue.
             1. Let |linkTarget| be |link|'s [=Link Target=].
@@ -733,7 +751,7 @@ add the following steps:
                     |prefetched alternate exchange| to |sxg|.
             1. If |headerIntegrity| is not null and |prefetched alternate
                 exchange| is null, then set |canLoadAlternateSxg| to false.
-                
+
                 Note: This means that there is a matching
                 <{link/rel/allowed-alt-sxg}> link for the <{link/rel/preload}>
                 |link|, but the matching signed exchange has not been
@@ -1817,7 +1835,7 @@ The result of <dfn>getting allowed signed exchange link info</dfn> from a
         |allowedSxgLinks|.
 1. Return |allowedSxgLinks|.
 
-<h4 algorithm id="get-alternate-signed-exchange-links">Get alternate signed 
+<h4 algorithm id="get-alternate-signed-exchange-links">Get alternate signed
 exchange link info</h4>
 
 The result of <dfn>getting alternate signed exchange link info</dfn> from a

--- a/loading.bs
+++ b/loading.bs
@@ -331,6 +331,67 @@ Note: Applying the signed exchange's response here has the effect of letting a
 newer HTTP cache entry override a signed exchange's content, and of not storing
 the signed exchange's response in the HTTP cache.
 
+# Subresource substitution # {#subresource-substitution}
+
+To support [Signed Exchange subresource substitution](https://github.com/WICG/webpackage/blob/master/explainers/signed-exchange-subresource-subtitution-explainer.md),
+this secion describes how web browsers prefetch subresource signed exchanges.
+
+<h3 algorithm id="mp-fetching-the-resource-hint-link">
+Monkeypatch Fetching the resource hint link</h3>
+In [Fetching the resource hint
+link](https://w3c.github.io/resource-hints/#fetching-the-resource-hint-link),
+add the following lines:
+
+The user agent SHOULD prefetch the alternate subresources signed exchanges if
+declared in link headers in the outer and the inner response header of the
+signed exchanges by running the following steps:
+    1. When the UA detects a "preload" link HTTP header in a signed exchange
+        inner response, check whether a matching “allowed-alt-sxg” link HTTP
+        header in the inner response exists or not. (Note that multiple
+        `allowed-alt-sxg` links can be present for the same preload if they
+        include `variants` and `variant-key` attributes. In that case, the UA
+        uses the algorithm written in [HTTP Representation
+        Variants](https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html)
+        spec to find the matching header.)
+    1. If an `allowed-alt-sxg` link exists, check whether the signed exchange
+        was served with a matching “alternate” link HTTP header.
+    1. If the outer signed exchange did identify an alternate version of the
+        subresource, prefetch the subresource signed exchange.
+    1. If the resulting signed exchange is valid and matches the allowed-alt-sxg
+        link, attach it to the top-level prefetch.
+
+<h3 algorithm id="mp-navigating-across-documents">
+Monkeypatch Navigating across documents</h3>
+In [navigating across documents](https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigating-across-documents),
+add the following step:
+    1. Copy the signed exchanges that were prefetched above to the target
+        document except for the one that serves the navigation itself.
+- Note that as browsers move toward partitioned HTTP caches, the source
+    document's cache will likely be separate from the target's cache, so
+    we can't just pass prefetched content through the cache.
+
+
+<h3 algorithm id="mp-link-type-preload">
+Monkeypatch Link type "preload"</h3>
+
+The navigated-to document has a set of preloads for which it uses the
+allowed-alt-sxg link relation to declare that they can be served by signed
+exchanges. The UA either serves all of them from SXGs prefetched by the previous
+page, or none of them.
+So in [processing](https://www.w3.org/TR/preload/#processing) of [Link type
+"preload"](https://www.w3.org/TR/preload/#link-type-preload) add the following
+step:
+    1. For each preload, use the imagesrcset and imagesizes attributes to pick a
+        single URL to preload.
+    1. Identify the subset |SxgPreloads| of those preloads with an
+        `allowed-alt-sxg` link for that selected URL.
+    1. If every member of |SxgPreloads| has a valid signed exchange that was
+        transferred from the referring document, use the signed contents of
+        those resources to satisfy the preloads. Ignore any other prefetched
+        signed exchanges.
+    1. Otherwise, ignore all prefetched signed exchanges and re-fetch the
+        preloads from their original URLs.
+
 # Structures # {#structs}
 
 <h3 dfn-type=dfn export>Exchange</h3>

--- a/loading.bs
+++ b/loading.bs
@@ -117,6 +117,8 @@ spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231#
     type: http-header
         text: Date; url: section-7.1.1.2
 spec: RFC8288; urlPrefix: https://tools.ietf.org/html/rfc8288#
+    type: dfn
+        text: Target Attributes list; url: section-2.2
     type: http-header
         text: Link; url: section-3
     type: dfn
@@ -124,7 +126,12 @@ spec: RFC8288; urlPrefix: https://tools.ietf.org/html/rfc8288#
     type: dfn
         text: Link Context; url: section-3.2
     type: dfn
+        text: Relation Type; url: section-3.3
+    type: dfn
         text: Target Attributes; url: section-3.4
+    type: dfn
+        text: Parsing a Link Field Value; url: appendix-B.2
+        
 spec: RFC5988; urlPrefix: https://tools.ietf.org/html/rfc5988#
     type: dfn
         text: semantically equivalent; url: #page-5:~:text=semantically%20equivalent
@@ -165,15 +172,23 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
         for: link; text: crossorigin; url: semantics.html#attr-link-crossorigin
         for: link; text: href; url: semantics.html#attr-link-href
     type: dfn;
-        text: appropriate time; url: semantics.html#processing-the-type-attribute
+        text: Anonymous; url: urls-and-fetching.html#attr-crossorigin-anonymous
+        text: CORS settings attribute; url: urls-and-fetching.html#cors-settings-attribute
         text: creating a potential-cors request; url: urls-and-fetching.html#create-a-potential-cors-request
         text: fetch and process the linked resource; url: semantics.html#fetch-and-process-the-linked-resource
         text: linked resource fetch setup steps; url: semantics.html#linked-resource-fetch-setup-steps
         text: navigation params; url: browsing-the-web.html#navigation-params
+        text: No CORS; url: urls-and-fetching.html#attr-crossorigin-none
         text: process the linked resource; url: semantics.html#process-the-linked-resource
+        text: response; for: navigation params; url: browsing-the-web.html#navigation-params-response
+        text: selecting an image source; url: images.html#select-an-image-source
+        text: Use Credentials; url: urls-and-fetching.html#attr-crossorigin-use-credentials
 spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf
     type: dfn
         text: SHA-256; url: #
+spec: CSS2; urlPrefix: https://drafts.csswg.org/css2/
+    type: dfn
+        text: viewport; url: #viewport
 </pre>
 <pre class='link-defaults'>
 spec:fetch; type:dfn; for:/; text:response
@@ -272,6 +287,9 @@ Rewrite [=request/clone|clone a request=] to run these steps:
 
 A [=response=] has an associated <dfn for="response">came from a signed
 exchange</dfn> boolean, which is false by default.
+
+A [=response=] has an associated <dfn for="response">signed exchange outer
+header list</dfn> (a [=header list=]). Unless stated otherwise it is empty.
 
 A [=response=] has an associated <dfn for="response">header integrity
 value</dfn>, either null or, for responses that [=response/came from a signed
@@ -457,58 +475,7 @@ satisfy the `https://cdn.publisher.example/lib.js` `<script>` element.
         This parameter is using the same format as <a
         http-header>Variant-Key</a> Header Field.
 
-The [=appropriate time=] to [=fetch and process the linked resource=] for an
-[=alternate signed exchange link=] is when the following steps return true:
-
-<ol algorithm="appropriate time for an alternate signed exchange link">
-
-1. Let |signedResponse| be the [=response=] created from the signed exchange in
-    the response that held the [=alternate signed exchange link=].
-1. Let |allowedSxgLinks| be the set of <{link/rel/allowed-alt-sxg}> <a
-    http-header>Link</a> HTTP headers on |signedResponse| whose [=Link Target=]
-    is the same as the [=alternate signed exchange link=]'s [=Link Context=] and
-    whose <{link/variants}> parameter and <{link/variant-key}> parameter are the
-    same as the [=alternate signed exchange link=]'s parameters if they are
-    present.
-1. If |allowedSxgLinks| is empty, return false.
-1. Let |preload links| be the set of <{link/rel/preload}> <a
-    http-header>Link</a> HTTP headers on |signedResponse|.
-1. For each |preload link| in |preload links|, use the following steps to
-     resolve the link's actual target, incorporating attributes like
-     <{link/imagesrcset}> and <{link/imagesizes}>:
-    1. Let |el| be a [=semantically equivalent=] link element to |preload link|.
-    1. If |el|'s <{link/href}> attribute's value is the empty string, then
-        continue.
-    1. Let |url| be the result of [=URL parser|parsing=] |el|'s <{link/href}>
-        attribute's value, with a base URL of |signedResponse|'s
-        [=response/URL=].
-    1. Let |corsAttributeState| be the current state of the |el|'s
-        <{link/crossorigin}> content attribute.
-    1. Let |request| be the result of [=creating a potential-CORS request=]
-        given |url|, the empty string, and |corsAttributeState|.
-    1. Run the [=linked resource fetch setup steps=], given |el| and |request|.
-        If the result is false, then continue.
-    1. If |request|'s [=request/URL=] is same as the same as the [=alternate
-        signed exchange link=]'s [=Link Context=], return true.
-1. Return false.
-
-</ol>
-
-<div algorithm="process the alternate signed exchange linked resource">
-
-The [=process the linked resource=] steps for an [=alternate signed exchange
-link=] , given boolean |success|, and [=response=] |response|:
-
-1. If |success| is false, return.
-1. If the |response| [=response/came from a signed exchange=], create an
-    [=exchange=] with the URL of the <{link/rel/allowed-alt-sxg}> link's [=Link
-    Target=] URL and the result of [=response/cloning=] the inner response of
-    the [=alternate signed exchange=], and store the exchange to the
-    [=Document/prefetched subresource signed exchanges=] of the document.
-
-</div>
-
-<h3 algorithm id="mp-document">Monkeypatch Document</h3>
+<h3 algorithm id="mp-document">New Document fields</h3>
 
 At the end of
 [the Document object](https://html.spec.whatwg.org/multipage/dom.html#the-document-object)
@@ -516,26 +483,18 @@ section, add the following lines:
 
 <blockquote dfn-for="Document">
 
-The {{Document}} has a set of <dfn dfn>prefetched signed exchanges for
-navigation</dfn>, which is a set of [=exchanges=], initially empty.  <span
-class="note">This might merge with the set of prefetched resources when
-<{link/rel/prefetch}> is specified more completely.</span>
+The {{Document}} has a map of <dfn dfn>prefetched signed exchanges for
+navigation</dfn>, which is a [=map=] of [=URL=] to [=exchange=], initially
+empty.  <span class="note">This might merge with the set of prefetched resources
+when <{link/rel/prefetch}> is specified more completely.</span>
 
 The {{Document}} has a set of <dfn dfn>prefetched
 subresource signed exchanges</dfn>, which is a set of [=exchanges=], initially
 empty.
 
-The {{Document}} has a set of <dfn dfn>transferred
-subresource signed exchanges</dfn>, which is a set of [=exchanges=], initially
-empty.
-
-The {{Document}} has a set of <dfn dfn>allowed
-alternate subresource signed exchange links</dfn>, which is a set of
-<{link/rel/allowed-alt-sxg}> links, initially empty.
-
 </blockquote>
 
-<h3 algorithm id="mp-navigation-params">Monkeypatch navigation params struct</h3>
+<h3 algorithm id="mp-navigation-params">New navigation params struct field</h3>
 
 In the [=navigation params=], add the following items:
 
@@ -543,24 +502,136 @@ In the [=navigation params=], add the following items:
 
 : <dfn>prefetched subresource signed exchanges</dfn>
 :: A set of [=exchanges=], initially empty.
-: <dfn>allowed alternate subresource signed exchange links</dfn>
-:: A set of <{link/rel/allowed-alt-sxg}> links, initially empty.
 
 </dl>
 
-<h3 algorithm id="mp-fetching-the-resource-hint-link">Monkeypatch Fetching the resource hint link</h3>
+<h3 algorithm id="mp-link-type-prefetch">
+Monkeypatch Link type "prefetch"</h3>
 
-At the end of the [Fetching the resource hint
-link](https://w3c.github.io/resource-hints/#fetching-the-resource-hint-link)
-section in [[resource-hints]], add the following lines:
+The [=process the linked resource=] given a link element |el|, boolean
+|success|, and [=response=] |response|:
 
-The user agent SHOULD run the following steps if the response of a
-<{link/rel/prefetch}>ed resource [=response/came from a signed exchange=]:
+1. If the |success| is false, then return.
+1. If the |response|'s [=response/came from a signed exchange=] is false, then
+    return.
+1. Let |clonedExchange| be the result of creating a new [=exchange=] with the
+    first item of |response|'s [=response/URL list=] and the result of
+    [=response/cloning=] |response|.
+1. [=map/Set=] |el|'s [=Node/node document=]'s [=Document/prefetched signed
+    exchanges for navigation=][|clonedExchange|'s [=exchange/request URL=]] to
+    |clonedExchange|.
+1. Let |outerLinkHeader| be the result of [=header list/getting=] `` `Link` ``
+    from |response|'s [=response/signed exchange outer header list=].
+1. If |outerLinkHeader| is null, then return.
+1. Let |outerLinks| be the result of [=Parsing a Link Field Value=] from
+    |outerLinkHeader|.
+1. If |outerLinks| is null, then return.
+1. Let |innerLinkHeader| be the result of [=header list/getting=] `` `Link` ``
+    from |response|'s [=response/header list=].
+1. If |innerLinkHeader| is null, then return.
+1. Let |innerLinks| be the result of [=Parsing a Link Field Value=] from
+    |innerLinkHeader|.
+1. If |innerLinks| is null, then return.
+1. Let |alternateLinks| be an empty [=list=].
+1. For each |outerLink| of |outerLinks|:
+    1. If |outerLink|'s [=Relation Type=] is not 'alternate', then continue.
+    1. If |outerLink|'s [=Target Attributes list|Target Attributes=] doesn't
+        [=list/contain=] (`"type"`,`"application/signed-exchange"`), then
+        continue.
+    1. Let |linkTarget| be |outerLink|'s [=Link Target=].
+    1. Let |linkContext| be |outerLink|'s [=Link Context=].
+    1. Let |outerLinkVariants| be the second item of the first tuple of
+        |outerLink|'s [=Target Attributes list|Target Attributes=] whose first
+        item matches the string `"variants"` or the empty string ("") if it is
+        not present.
+    1. Let |outerLinkVariantKey| be the second item of the first tuple of
+        |outerLink|'s [=Target Attributes list|Target Attributes=] whose first
+        item matches the string `"variant-key"` or the empty string ("") if it
+        is not present.
+    1. [=list/Append=] (|linkContext|, |outerLinkVariants|,
+        |outerLinkVariantKey|, |linkTarget|) to |alternateLinks|.
+1. Let |allowedSxgLinks| be an empty [=list=].
+1. For each |innerLink| of |innerLinks|:
+    1. If |innerLink|'s [=Relation Type=] is not 'allowed-alt-sxg', then
+        continue.
+    1. Let |linkTarget| be |innerLink|'s [=Link Target=].
+    1. Let |innerLinkVariants| be the second item of the first tuple of
+        |innerLink|'s [=Target Attributes list|Target Attributes=] whose first
+        item matches the string `"variants"` or the empty string ("") if it is
+        not present.
+    1. Let |innerLinkVariantKey| be the second item of the first tuple of
+        |innerLink|'s [=Target Attributes list|Target Attributes=] whose first
+        item matches the string `"variant-key"` or the empty string ("") if it
+        is not present.
+    1. Let |headerIntegrity| be the second item of the first tuple of
+        |innerLink|'s [=Target Attributes list|Target Attributes=] whose first
+        item matches the string `"header-integrity"` or continue if it is not
+        present.
+    1. [=list/Append=] (|linkTarget|, |innerLinkVariants|,
+        |innerLinkVariantKey|, |headerIntegrity|) to |allowedSxgLinks|.
+1. For each |innerLink| of |innerLinks|:
+    1. If |innerLink|'s [=Relation Type=] is not 'preload', then continue.
+    1. Let |linkTarget| be |innerLink|'s [=Link Target=].
+    1. Let |asAttribute| be the second item of the first tuple of |innerLink|'s
+        [=Target Attributes list|Target Attributes=] whose first item matches
+        the string `"as"` or the empty string ("") if it is not present.
+    1. If |asAttribute| is `"image"`, then:
+        1. Let |imagesrcset| be the second item of the first tuple of
+            |innerLink|'s [=Target Attributes list|Target Attributes=] whose
+            first item matches the string `"imagesrcset"` or the empty string
+            ("") if it is not present.
+        1. Let |imagesizes| be the second item of the first tuple of
+            |innerLink|'s [=Target Attributes list|Target Attributes=] whose
+            first item matches the string `"imagesizes"` or the empty string
+            ("") if it is not present.
+        1. Create a <{link}> element |linkElement| which <{link/href}> attribute
+            is |linkTarget|, and <{link/imagesrcset}> attribute is
+            |imagesrcset|, and <{link/imagesizes}> is |imagesizes|.
+        1. Let |selected source| and <var ignore=''>selected pixel density</var>
+            be the URL and pixel density that results from [=selecting an image
+            source=] given |linkElement|, respectively.
+        1. If |selected source| is not null, then set |linkTarget| to the result
+            of [=URL parser|parsing=] |selected source|, with a base URL of
+            |response|'s [=response/URL=].
+    1. For each |allowedSxgLink| of |allowedSxgLinks|:
+        1. If the first element isn't the same as |linkTarget|, then continue.
+        1. Let |innerLinkVariants| be the second item of |allowedSxgLink|.
+        1. Let |innerLinkVariantKey| be the third item of |allowedSxgLink|.
+        1. Let |storedExchange| be the result of creating an [=exchange=] with
+            the URL of |linkTarget| and a new [=response=].
+        1. If |innerLinkVariants| is not the empty string (""), [=header
+            list/set=] `` `Variants` ``/|innerLinkVariants| in
+            |storedExchange|'s [=exchange/response=]'s [=response/header list=].
+        1. If |innerLinkVariantKey| is not the empty string (""), [=header
+            list/set=] `` `Variant-Key` ``/|innerLinkVariantKey| in
+            |storedExchange|'s [=exchange/response=]'s [=response/header list=].
+        1. Let |requestForMatch| be the result of [=creating a potential-CORS
+            request=] given |linkTarget|, the empty string, and [=No CORS=].
+        1. If |requestForMatch| doesn't [=matches the stored exchange=]
+            |storedExchange|, then continue.
+        1. Let |alternateSxgUrl| be the first item of the first tuple of
+            |alternateLinks| whose second item matches |innerLinkVariants| and
+            whose third item matches |innerLinkVariantKey| and whose fourth item
+            matches |linkTarget| or continue if it is not present.
+        1. Let |sxgRequest| be the result of [=creating a potential-CORS
+            request=] given |alternateSxgUrl|, the empty string, and [=No
+            CORS=].
+        1. Run the following steps [=in parallel=]:
+            1. Let |sxgResponse| be the result of [=fetching=] |sxgRequest|.
+            1. If |sxgResponse|'s [=response/came from a signed exchange=] is
+                true, and |sxgResponse|'s [=response/URL=] is the same as
+                |linkTarget|, then create an [=exchange=] with the URL of
+                |linkTarget| and the result of [=response/cloning=]
+                |sxgResponse|, and store the exchange to |el|'s [=Node/node
+                document=]'s [=Document/prefetched subresource signed
+                exchanges=].
 
-    1. Let |clonedResponse| be the result of [=response/cloning=] the response.
-    1. Create an [=exchange=] with the request URL and |clonedResponse|,
-        and store the exchange to the
-        [=Document/prefetched signed exchanges for navigation=] of the Document.
+
+Issue(w3c/resource-hints#77): Currently the behavior of recursive prefetch is
+not defined in the specs. This section monkeypatches Link type
+"<{link/rel/prefetch}>" to support the recursive prefetching of alternate signed
+exchange subresources. When we will change the HTML spec to support the general
+recursive prefetching, this section must be made align with the change.
 
 <h3 algorithm id="mp-process-a-navigate-fetch">
 Monkeypatch process a navigate fetch</h3>
@@ -571,24 +642,18 @@ before
 
 add the following steps:
 
-    9. Let |allowed alternate subresource signed exchange links| be null.
+    9. If |sourceBrowsingContext|'s [=active document=]'s
+        [=Document/prefetched signed exchanges for navigation=][|request|'s
+        [=request/url=]] [=map/exists=], then:
 
-    10. If |sourceBrowsingContext|'s [=active document=]'s
-        [=Document/prefetched signed exchanges for navigation=] has a matching
-        exchange for the |request|'s [=request/url=], then:
+        1. Let |prefetchedExchange| be |sourceBrowsingContext|'s 
+            [=active document=]'s [=Document/prefetched signed exchanges for
+            navigation=][|request|'s [=request/url=]].
 
-        1. Let |clonedExchange| be the result of creating a new [=exchange=]
-            with the matching exchange's [=exchange/request URL=] and the result
-            of [=response/cloning=] the matching exchange's
-            [=exchange/response=].
-
-        1. Move |clonedExchange| to the |request|'s
-            [=request/stashed exchange=].
-
-        1. Copy <{link/rel/allowed-alt-sxg}> link of the exchange's
-            [=exchange/response=] to
-            |allowed alternate subresource signed exchange links|.
-
+        1. Set |request|'s [=request/stashed exchange=] to the result of
+            creating a new [=exchange=] with |prefetchedExchange|'s
+            [=exchange/request URL=] and the result of [=response/cloning=]
+            |prefetchedExchange|'s [=exchange/response=].
 
 
 And before
@@ -598,99 +663,161 @@ And before
 
 add the following steps:
 
-    19. Copy |sourceBrowsingContext|'s [=active document=]'s
+    18. Copy |sourceBrowsingContext|'s [=active document=]'s
         [=Document/prefetched subresource signed exchanges=]
-        to |navigationParams|'s
+        to <var ignore=''>navigationParams</var>'s
         [=navigation params/prefetched subresource signed exchanges=].
-
-    20. Set |navigationParams|'s
-        [=navigation params/allowed alternate subresource signed exchange links=]
-        to |allowed alternate subresource signed exchange links|.
 
 Note: As browsers move toward partitioned HTTP caches, the source document's
     cache will likely be separate from the target's cache, so we can't just pass
     prefetched content through the cache.
 
 
-<h3 algorithm id="mp-initialise-the-document-object">
-Monkeypatch Initialize a Document object</h3>
+<h3 algorithm id="mp-page-load-processing-model-for-html-fiiles">
+Monkeypatch Page load processing model for HTML files</h3>
 In
-[initialize a Document object](https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object)
+[Page load processing model for HTML files](https://html.spec.whatwg.org/multipage/browsing-the-web.html#read-html)
 before
 
-> 15. Return document.
+> 2. Create an HTML parser and ...
 
 add the following steps:
-
-    15. Move the |navigationParams|'s
-        [=navigation params/prefetched subresource signed exchanges=] to the
-        |document|'s [=Document/transferred subresource signed exchanges=].
-
-    16. Set |document|'s
-        [=Document/allowed alternate subresource signed exchange links=] to
-        |navigationParams|'s
-        [=navigation params/allowed alternate subresource signed exchange links=].
-
-
-<h3 algorithm id="mp-link-type-preload">
-Monkeypatch Link type "preload"</h3>
-
-The navigated-to document has a set of preloads for which it uses the
-<{link/rel/allowed-alt-sxg}> link relation to declare that they can be served by
-signed exchanges. The UA either serves all of them from SXGs prefetched by the
-previous page, or none of them. So in the
-[linked resource fetch setup steps for preload type of linked resource](https://html.spec.whatwg.org/multipage/links.html#link-type-preload:linked-resource-fetch-setup-steps)
-before
-
-> 5. Return true.
-
-add the following steps:
-
-    5. If |el| is for the main resource's HTTP <a http-header>Link</a> header,
-        then:
-
-        1.  For each |allowedAltSxgLink| in |el|'s [=Node/node document=]'s
-            [=Document/allowed alternate subresource signed exchange links=]:
-
-            1. Let |storedExchange| be the result of creating an [=exchange=]
-                with the URL of the |allowedAltSxgLink| link's [=Link Target=]
-                URL and a new [=response=].
-                
-            1. If |allowedAltSxgLink| has <{link/variants}> parameter,
-                [=header list/set=] `` `Variants` ``/|allowedAltSxgLink|'s
-                <{link/variants}> in |storedExchange|'s [=exchange/response=]'s
-                [=response/header list=].
-                
-            1. If |allowedAltSxgLink| has <{link/variant-key}> parameter,
-                [=header list/set=] `` `Variant-Key` ``/|allowedAltSxgLink|'s
-                <{link/variant-key}> in |storedExchange|'s [=exchange/response=]'s
-                [=response/header list=].
-
-
-            1. If |request| [=matches the stored exchange=] |storedExchange|,
-                then run the following steps in parallel:
-
-                1. Wait until there is no remaining preload Link header of the main
-                    resource to be processed.
-
-                1. If for every |el|'s in this step, |el|'s
-                    [=Node/node document=]'s
-                    [=Document/transferred subresource signed exchanges=]
-                    contains a |matchingExchange| which [=exchange/response=]'s
-                    [=response/header integrity value=] is the same as
-                    |allowedAltSxgLink|'s <{link/header-integrity}> parameter,
-                    then set the |request|'s [=request/stashed exchange=] to
-                    |matchingExchange|.
-
-                1. Return true.
-
-            1. Otherwise, return true.
+    2. Run the following steps [=in parallel=]:
+        1. Wait until |document|'s [=viewport=] is initialized.
+        1. Let |linkHeader| be the result of [=header list/getting=] `` `Link`
+            `` from |navigationParams|'s [=navigation params/response=]'s
+            [=response/header list=].
+        1. If |linkHeader| is null, then return.
+        1. Let |links| be the result of [=Parsing a Link Field Value=] from
+            |linkHeader|.
+        1. Let |allowedSxgLinks| be an empty [=list=].
+        1. For each |link| of |links|:
+            1. If |link|'s [=Relation Type=] is not 'allowed-alt-sxg', then
+                continue.
+            1. Let |linkTarget| be |link|'s [=Link Target=].
+            1. Let |linkVariants| be the second item of the first tuple of
+                |link|'s [=Target Attributes list|Target Attributes=] whose
+                first item matches the string `"variants"` or the empty string
+                ("") if it is not present.
+            1. Let |linkVariantKey| be the second item of the first tuple of
+                |link|'s [=Target Attributes list|Target Attributes=] whose
+                first item matches the string `"variant-key"` or the empty
+                string ("") if it is not present.
+            1. Let |headerIntegrity| be the second item of the first tuple of
+                |link|'s [=Target Attributes list|Target Attributes=] whose
+                first item matches the string `"header-integrity"` or continue
+                if it is not present.
+            1. [=list/Append=] (|linkTarget|, |linkVariants|, |linkVariantKey|,
+                |headerIntegrity|) to |allowedSxgLinks|.
+        1. Let |preloadLinkItems| be an empty [=list=].
+        1. Let |canLoadAlternateSxg| be true. 
+        1. For each |link| of |links|:
+            1. If |link|'s [=Relation Type=] is not 'preload', then continue.
+            1. Let |linkTarget| be |link|'s [=Link Target=].
+            1. Let |asAttribute| be the second item of the first tuple of
+                |link|'s [=Target Attributes list|Target Attributes=] whose
+                first item matches the string `"as"` or the empty string ("") if
+                it is not present.
+            1. If |asAttribute| is an empty string, then continue.
+            1. If |asAttribute| is `"image"`, then:
+                1. Let |imagesrcset| be the second item of the first tuple of
+                    |link|'s [=Target Attributes list|Target Attributes=] whose
+                    first item matches the string `"imagesrcset"` or the empty
+                    string ("") if it is not present.
+                1. Let |imagesizes| be the second item of the first tuple of
+                    |link|'s [=Target Attributes list|Target Attributes=] whose
+                    first item matches the string `"imagesizes"` or the empty
+                    string ("") if it is not present.
+                1. Create a <{link}> element |linkElement| which <{link/href}>
+                    attribute is |linkTarget|, and <{link/imagesrcset}>
+                    attribute is |imagesrcset|, and <{link/imagesizes}> is
+                    |imagesizes|.
+                1. Let |selected source| and <var ignore=''>selected pixel
+                    density</var> be the URL and pixel density that results from
+                    [=selecting an image source=] given |linkElement|,
+                    respectively.
+                1. If |selected source| is not null, then set |linkTarget| to
+                    the result of [=URL parser|parsing=] |selected source|, with
+                    a base URL of |navigationParams|'s [=navigation
+                    params/response=]'s [=response/URL=].
+            1. Let |headerIntegrity| be an empty string.
+            1. For each |allowedSxgLink| of |allowedSxgLinks|:
+                1. If the first element isn't the same as |linkTarget|, then
+                    continue.
+                1. Let |innerLinkVariants| be the second item of
+                    |allowedSxgLink|.
+                1. Let |innerLinkVariantKey| be the third item of
+                    |allowedSxgLink|.
+                1. Let |storedExchange| be the result of creating an
+                    [=exchange=] with the URL of |linkTarget| and a new
+                    [=response=].
+                1. If |innerLinkVariants| is not the empty string (""), [=header
+                    list/set=] `` `Variants` ``/|innerLinkVariants| in
+                    |storedExchange|'s [=exchange/response=]'s [=response/header
+                    list=].
+                1. If |innerLinkVariantKey| is not the empty string (""),
+                    [=header list/set=] `` `Variant-Key`
+                    ``/|innerLinkVariantKey| in |storedExchange|'s
+                    [=exchange/response=]'s [=response/header list=].
+                1. Let |requestForMatch| be the result of [=creating a
+                    potential-CORS request=] given |linkTarget|, the empty
+                    string, and [=No CORS=].
+                1. If |requestForMatch| doesn't [=matches the stored exchange=]
+                    |storedExchange|, then continue.
+                1. Set |headerIntegrity| to the fourth item of |allowedSxgLink|.
+            1. Let |alternateSXG| be null.
+            1. For each |sxg| of |navigationParams|'s [=navigation
+                params/prefetched subresource signed exchanges=]:
+                1. If |headerIntegrity| is the same as the value of |sxg|'s
+                    [=exchange/response=]'s [=response/header integrity value=]
+                    encoded as a [[CSP]] <a grammar>hash-source</a>, then set
+                    |alternateSXG| to |sxg|.
+            1. If |headerIntegrity| is not an empty string and |alternateSXG| is
+                null, then set |canLoadAlternateSxg| to false.
+            1. [=list/Append=] (|link|, |linkTarget|, |headerIntegrity|,
+                |alternateSXG|) to |preloadLinkItems|.
+        1. For each |preloadLinkItem| of |preloadLinkItems|:
+            1. Let |link| be the first item of |preloadLinkItem|.
+            1. Let |linkTarget| be the second item of |preloadLinkItem|.
+            1. Let |headerIntegrity| be the third item of |preloadLinkItem|.
+            1. Let |alternateSXG| be the fourth item of |preloadLinkItem|.
+            1. Let |corsAttribute| be the [=CORS settings attribute=] of the
+                second item of the first tuple of |link|'s [=Target Attributes
+                list|Target Attributes=] whose first item matches the string
+                `"crossorigin"` or [=No CORS=] if it is not present.
+            1. Let |request| be the result of [=creating a potential-CORS
+                request=] given |linkTarget|, the empty string, and
+                |corsAttribute|.
+            1. Set |request|'s [=request/synchronous flag=].
+            1. Set |request|'s [=request/client=] to |document|.
+            1. Set |request|'s [=request/cryptographic nonce metadata=] to be
+                the second item of the first tuple of |link|'s [=Target
+                Attributes list|Target Attributes=] whose first item matches the
+                string `"nonce"` if it is present.
+            1. Set |request|'s [=request/integrity metadata=] to be the second
+                item of the first tuple of |link|'s [=Target Attributes
+                list|Target Attributes=] whose first item matches the string
+                `"integrity"` if it is present.
+            1. Set |request|'s [=request/referrer policy=] to be the [=referrer
+                policy attribute=] of second item of the first tuple of |link|'s
+                [=Target Attributes list|Target Attributes=] whose first item
+                matches the string `"referrerpolicy"` if it is present.
+            1. Set |request|'s [=request/destination=] to the second item of the
+                first tuple of |link|'s [=Target Attributes list|Target
+                Attributes=] whose first item matches the string `"as"` or the
+                empty string ("") if it is not present.
+            1. If |canLoadAlternateSxg| is true and |alternateSXG| is not null,
+                then set |request|'s [=request/stashed exchange=] to
+                |alternateSXG|.
+            1. [=Fetch=] |request| in parallel.
 
 Issue(whatwg/html#4224): Currently the processing model of the HTTP <a
-http-header>Link</a> header is not defined. In this section, we treat the ``
-`preload` `` <a http-header>Link</a> headers as if their [=semantically
-equivalent=] <{link/rel/preload}> type link elements are generated and
-processed at some point.
+http-header>Link</a> header is not defined in the HTML spec. This section
+monkeypatches the [Page load processing model for HTML
+files](https://html.spec.whatwg.org/multipage/browsing-the-web.html#read-html)
+to support proccessing <a http-header>Link</a> rel=preload HTTP headers. When we
+will change the HTML spec to generally support <a http-header>Link</a> HTTP
+headers, this section must be made align with the change.
 
 # Structures # {#structs}
 
@@ -933,6 +1060,8 @@ following steps
         |requestUrl|.
 1. Set |parsedExchange|'s [=exchange/response=]'s [=response/came from a signed
     exchange=] to true.
+1. Set |parsedExchange|'s [=exchange/response=]'s [=response/signed exchange
+    outer header list=] to |response|'s [=response/header list=].
 1. Set |parsedExchange|'s [=exchange/response=]'s [=response/header integrity
     value=] to the [=SHA-256=] hash of |headerBytes|.
 1. If |parsedSignature| [=exchange signature/does not establish cross-origin

--- a/loading.bs
+++ b/loading.bs
@@ -131,10 +131,6 @@ spec: RFC8288; urlPrefix: https://tools.ietf.org/html/rfc8288#
         text: Target Attributes; url: section-3.4
     type: dfn
         text: Parsing a Link Field Value; url: appendix-B.2
-        
-spec: RFC5988; urlPrefix: https://tools.ietf.org/html/rfc5988#
-    type: dfn
-        text: semantically equivalent; url: #page-5:~:text=semantically%20equivalent
 spec: RFC8446; urlPrefix: https://tools.ietf.org/html/draft-ietf-tls-tls13-28#
     text: ecdsa_secp256r1_sha256; type: dfn; url: section-4.2.3
 spec: draft-ietf-httpbis-variants; urlPrefix: https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html#
@@ -525,13 +521,13 @@ The [=process the linked resource=] given a link element |el|, boolean
 1. If |outerLinkHeader| is null, then return.
 1. Let |outerLinks| be the result of [=Parsing a Link Field Value=] from
     |outerLinkHeader|.
-1. If |outerLinks| is null, then return.
+1. If |outerLinks| is empty, then return.
 1. Let |innerLinkHeader| be the result of [=header list/getting=] `` `Link` ``
     from |response|'s [=response/header list=].
 1. If |innerLinkHeader| is null, then return.
 1. Let |innerLinks| be the result of [=Parsing a Link Field Value=] from
     |innerLinkHeader|.
-1. If |innerLinks| is null, then return.
+1. If |innerLinks| is empty, then return.
 1. Let |alternateLinks| be an empty [=list=].
 1. For each |outerLink| of |outerLinks|:
     1. If |outerLink|'s [=Relation Type=] is not 'alternate', then continue.
@@ -548,8 +544,8 @@ The [=process the linked resource=] given a link element |el|, boolean
         |outerLink|'s [=Target Attributes list|Target Attributes=] whose first
         item matches the string `"variant-key"` or the empty string ("") if it
         is not present.
-    1. [=list/Append=] (|linkContext|, |outerLinkVariants|,
-        |outerLinkVariantKey|, |linkTarget|) to |alternateLinks|.
+    1. [=list/Append=] (|linkTarget|, |outerLinkVariants|,
+        |outerLinkVariantKey|, |linkContext|) to |alternateLinks|.
 1. Let |allowedSxgLinks| be an empty [=list=].
 1. For each |innerLink| of |innerLinks|:
     1. If |innerLink|'s [=Relation Type=] is not 'allowed-alt-sxg', then

--- a/loading.bs
+++ b/loading.bs
@@ -500,8 +500,11 @@ In the [=navigation params=], add the following items:
 <h3 algorithm id="mp-link-type-prefetch">Monkeypatch Link type "prefetch"</h3>
 
 Note: To prefetch the [=alternate signed exchanges=] when the UA receives a
-prefetched main resource signed exchange, this section monkeypatchs
-Link type "<{link/rel/prefetch}>".
+prefetched main resource signed exchange, this section monkeypatchs Link type
+"<{link/rel/prefetch}>". This is getting all the [=alternate signed exchange
+links=] from the outer response, and see if they are allowed by the inner
+response's <{link/rel/allowed-alt-sxg}> links, and if they are match with the
+inner response's <{link/rel/preload}> links.
 
 Issue(w3c/resource-hints#77): Currently the behavior of recursive prefetch is
 not defined in the specs. This section monkeypatches Link type
@@ -520,9 +523,9 @@ The [=process the linked resource=] given a link element |el|, boolean
 1. Let |clonedExchange| be the result of creating a new [=exchange=] with the
     first item of |response|'s [=response/URL list=] and the result of
     [=response/cloning=] |response|.
-1. [=map/Set=] |el|'s [=Node/node document=]'s [=Document/prefetched signed
-    exchanges for navigation=][|clonedExchange|'s [=exchange/request URL=]] to
-    |clonedExchange|.
+1. [=map/Set=] |clonedExchange| to |el|'s [=Node/node document=]'s
+    [=Document/prefetched signed exchanges for navigation=][|clonedExchange|'s
+    [=exchange/request URL=]].
 1. Let |outerLinkHeader| be the result of [=header list/getting=] `` `Link` ``
     from |response|'s [=response/signed exchange outer header list=].
 1. If |outerLinkHeader| is null, then return.
@@ -641,8 +644,12 @@ Note: As browsers move toward partitioned HTTP caches, the source document's
 <h3 algorithm id="mp-page-load-processing-model-for-html-fiiles">
 Monkeypatch Page load processing model for HTML files</h3>
 
-Note: To use the prefetched subresource signed exchanges after the navigation,
-this section monkeypatchs [=Page load processing model for HTML files=].
+Note: To use the [=navigation params/prefetched subresource signed exchanges=]
+after the navigation, this section monkeypatchs [=Page load processing model for
+HTML files=]. This is getting all the <{link/rel/allowed-alt-sxg}> links from
+the inner response. And use the [=navigation params/prefetched subresource
+signed exchanges=] if the all allowed signe exchanges for subresources which are
+indicated by the inner response's <{link/rel/preload}> links are prefetched.
 
 Issue(whatwg/html#4224): Currently the processing model of the HTTP <a
 http-header>Link</a> header is not defined in the HTML spec. This section

--- a/loading.bs
+++ b/loading.bs
@@ -161,11 +161,11 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
         for: link; text: href; url: semantics.html#attr-link-href
     type: dfn;
         text: appropriate time; url: semantics.html#processing-the-type-attribute
+        text: creating a potential-cors request; url: urls-and-fetching.html#create-a-potential-cors-request
         text: fetch and process the linked resource; url: semantics.html#fetch-and-process-the-linked-resource
+        text: linked resource fetch setup steps; url: semantics.html#linked-resource-fetch-setup-steps
         text: navigation params; url: browsing-the-web.html#navigation-params
         text: process the linked resource; url: semantics.html#process-the-linked-resource
-        text: creating a potential-cors request; url: urls-and-fetching.html#create-a-potential-cors-request
-        text: linked resource fetch setup steps; url: semantics.html#linked-resource-fetch-setup-steps
 spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf
     type: dfn
         text: SHA-256; url: #
@@ -655,13 +655,17 @@ add the following steps:
                 1. Wait until there is no remaining preload Link header of the main
                     resource to be processed.
 
-                1. If every |el|'s in this step has a matching exchange in the
-                    document's [=Document/transferred subresource signed exchanges=],
-                    set the |request|'s [=request/stashed exchange=] to the exchange.
+                1. If for every |el|'s in this step, document's
+                    [=Document/transferred subresource signed exchanges=]
+                    contains a |matchingExchange| which [=exchange/response=]'s
+                    [=response/header integrity value=] is the same as
+                    |allowedAltSxgLink|'s <{link/header-integrity}> parameter,
+                    then set the |request|'s [=request/stashed exchange=] to
+                    |matchingExchange|.
 
                 1. Return true.
 
-        1. Return true.
+            1. Otherwise, return true.
 
 # Structures # {#structs}
 
@@ -904,6 +908,8 @@ following steps
         |requestUrl|.
 1. Set |parsedExchange|'s [=exchange/response=]'s [=response/came from a signed
     exchange=] to true.
+1. Set |parsedExchange|'s [=exchange/response=]'s [=response/header integrity
+    value=] to the [=SHA-256=] hash of |headerBytes|.
 1. If |parsedSignature| [=exchange signature/does not establish cross-origin
     trust=] for |parsedExchange|, return
     "[=signed exchange report/cert_verification_error=]".
@@ -1234,9 +1240,7 @@ a URL |requestUrl| returns a failure or an [=exchange=] via the following steps:
     |responseHeaders|.
 1. Let |response| be a new [=response=] with [=response/status=] |headers|[1][``
     `:status` ``] and [=response/header list=] |responseHeaders|.
-1. Let |headerIntegrityValue| be the [=SHA-256=] hash of |headerBytes|.
-1. Return an [=exchange=] of |requestUrl|, |response| and
-    |headerIntegrityValue|.
+1. Return an [=exchange=] of |requestUrl| and |response|.
 
     Note: This ignores |requestHeaders|, which can't be encoded in b3 and later.
 
@@ -1264,9 +1268,7 @@ a URL |requestUrl| returns a failure or an [=exchange=] via the following steps:
 1. If |responseHeaders| is a failure, return it.
 1. Let |response| be a new [=response=] with [=response/status=] |headers|[``
     `:status` ``] and [=response/header list=] |responseHeaders|.
-1. Let |headerIntegrityValue| be the [=SHA-256=] hash of |headerBytes|.
-1. Return an [=exchange=] of |requestUrl|, |response| and
-    |headerIntegrityValue|.
+1. Return an [=exchange=] of |requestUrl| and |response|.
 
 <h4 algorithm id="headers-from-map">Converting a map to a header list</h4>
 

--- a/loading.bs
+++ b/loading.bs
@@ -120,9 +120,9 @@ spec: RFC8288; urlPrefix: https://tools.ietf.org/html/rfc8288#
     type: http-header
         text: Link; url: section-3
     type: dfn
-        text: link target; url: section-3.1
+        text: Link Target; url: section-3.1
     type: dfn
-        text: anchor; url: section-3.2
+        text: Link Context; url: section-3.2
 spec: RFC8446; urlPrefix: https://tools.ietf.org/html/draft-ietf-tls-tls13-28#
     text: ecdsa_secp256r1_sha256; type: dfn; url: section-4.2.3
 spec: draft-ietf-httpbis-variants; urlPrefix: https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html#
@@ -340,45 +340,47 @@ the signed exchange's response in the HTTP cache.
 
 # Subresource substitution # {#subresource-substitution}
 
-To let the UA know that subresources of a page it's prenavigating to, can
-be retrieved as signed exchanges from the source site, this section introduces
-an extension to the HTTP Link header.
+When prenavigating to a page held in a signed exchange, it can be useful to
+also prefetch subresources of that page as signed exchanges from the same
+server. To identify those transitive prefetchable resources, this section
+introduces an extension to the HTTP Link header.
 
-* A <dfn dfn-type=dfn>allowed-alt-sxg link</dfn> is a relationship that is used
+* Link type "<dfn dfn-type=dfn>allowed-alt-sxg</dfn>"
+
+    The [=allowed-alt-sxg=] keyword may be used
     in HTTP <a http-header>Link</a> header of inner HTTP response of main
-    resource signed exchange to indicate that the subresource of the
-    [=link target=] can be loaded from different URL as a signed exchange. This
-    link has a
-    [rel](https://html.spec.whatwg.org/multipage/semantics.html#attr-link-rel)
-    parameter contains `allowed-alt-sxg` and a `header-integrity` parameter set
-    to the value of the [=header integrity value=] of the [=alternate signed
-    exchange=] 
-* A <dfn dfn-type=dfn>alternate signed exchange link</dfn> is a relationship
-    that is used in HTTP <a http-header>Link</a> header of outer HTTP response
-    of main resource signed exchange to indicate that the
-    <dfn dfn-type=dfn>alternate signed exchange</dfn> of the [=link target=] can
-    be loaded instead of the subresource  of the URL declared at the [=anchor=]
-    parameter. This link has a
-    [rel](https://html.spec.whatwg.org/multipage/semantics.html#attr-link-rel)
-    parameter contains
-    [alternate](https://html.spec.whatwg.org/multipage/links.html#rel-alternate)
-    keyword and a
-    [type](https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-type)
-    parameter set to the value 'application/signed-exchange' and an [=anchor=]
-    parameter set to the original subresource URL.
-* A <dfn dfn-type=dfn>header integrity value</dfn> is the SHA256 hash value of
-    the |signedHeaders| value from the
-    [application/signed-exchange format](https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#application-signed-exchange)
-    for integrity checking.
+    resource signed exchange to indicate an
+    <dfn dfn-type=dfn>allowed-alt-sxg link</dfn> that the subresource of the
+    [=Link Target=] can be loaded from different URL as a signed exchange. This
+    link has a `header-integrity` parameter set to the value of the
+    [=exchange/header integrity value=] of the [=alternate signed exchange=].
+    <div class="example" id="example-allowed-alt-sxg-link">
+    ```http
+    Link: <https://cdn.publisher.example/lib.js>;
+            rel="preload";
+            as="script"
+    Link: <https://cdn.publisher.example/lib.js>;
+            rel="allowed-alt-sxg";
+            header-integrity="sha256-XXXXXX
+    ```
+    </div>
+* An <dfn>alternate signed exchange link</dfn> is a `` `Link` `` header sent
+    with a signed exchange |S|, with the [=alternate=] link type, the `type`
+    parameter set to `application/signed-exchange`, and a [=Link Context=]. The
+    [=Link Context=] MUST be the [=Link Target=] of a [=preload=] `` `Link` ``
+    header inside the signed content of |S|, and the
+    [=alternate signed exchange link=] means that this resource can also be
+    found inside the <dfn dfn-type=dfn>alternate signed exchange</dfn> at the
+    [=Link Target=] of the [=alternate signed exchange link=].
 
-    Note: This |signedHeaders| is *"the canonical serialization of the CBOR
-    representation of the response headers of the exchange represented by the
-    application/signed-exchange resource, excluding the Signature header
-    field"*. So this value doesn’t change even if the publisher signs the
-    content again or changes the signing key, but it does change if any of the
-    headers or body change. (It catches changes to the body because a valid
-    signed exchange's headers have to include a `Digest` value that covers
-    the body.)
+    <div class="example" id="example-alternate-signed-exchange-link">
+    ```http
+    Link: <https://feed.example/sxg.publisher.example/lib.js.sxg>;
+            rel="alternate";
+            type="application/signed-exchange";
+            anchor="https://cdn.publisher.example/lib.js"
+    ```
+    </div>
 
 <h3 algorithm id="mp-document">
 Monkeypatch Document</h3>
@@ -386,17 +388,17 @@ In the end of
 [the Document object](https://html.spec.whatwg.org/multipage/dom.html#the-document-object)
 section, add the following lines:
 
-The <code>Document</code> has a <dfn dfn-type=dfn>prefetched singed exchanges
-for navigation</dfn>, which is a set of [=exchanges=], initially empty.
+The {{Document}} has a set of <dfn for="Document" dfn-type=dfn>prefetched singed
+exchanges for navigation</dfn>, which is a set of [=exchanges=], initially empty.
 
-The document has a <dfn dfn-for="document-obj" dfn-type=dfn>prefetched
+The {{Document}} has a <dfn dfn-for="Document" dfn-type=dfn>prefetched
 subresource singed exchanges</dfn>, which is a set of [=exchanges=], initially
 empty.
 
-The document has a <dfn dfn-for="document-obj" dfn-type=dfn>transferred
+The {{Document}} has a <dfn dfn-for="Document" dfn-type=dfn>transferred
 subresource singed exchanges</dfn>, which is a set of [=exchanges=], initially empty.
 
-The document has a <dfn dfn-for="document-obj" dfn-type=dfn>allowed alternate
+The {{Document}} has a <dfn dfn-for="Document" dfn-type=dfn>allowed alternate
 subresource signed exchange links</dfn>, which is a set of
 [=allowed-alt-sxg link=], initially empty.
 
@@ -425,7 +427,7 @@ resource is a valid signed exchange:
     1. Let |clonedResponse| be the result of [=response/cloning=] the response.
     1. Create an [=exchange=] with the request URL and |clonedResponse|,
         and store the exchange to the
-        [=prefetched singed exchanges for navigation=] of the Document.
+        [=Document/prefetched singed exchanges for navigation=] of the Document.
 
 The user agent SHOULD prefetch the alternate subresources signed exchanges if
 declared in link headers in the outer and the inner response header of the
@@ -446,12 +448,12 @@ signed exchanges by running the following steps:
         alternate version of the subresource, prefetch the
         [=alternate signed exchange=].
     1. If the resulting [=alternate signed exchange=] is valid and the
-        [=header integrity value=] of it matches the `header-integrity`
+        [=exchange/header integrity value=] of it matches the `header-integrity`
         parameter of the [=allowed-alt-sxg link=], create a [=exchange=]
-        with the URL of the [=allowed-alt-sxg link=]'s [=link target=] URL and
+        with the URL of the [=allowed-alt-sxg link=]'s [=Link Target=] URL and
         the result of [=response/cloning=] the inner response of the
         [=alternate signed exchange=], and store the exchange to the
-        [=document-obj/prefetched subresource singed exchanges=] of the
+        [=Document/prefetched subresource singed exchanges=] of the
         document.
 
 <h3 algorithm id="mp-process-a-navigate-fetch">
@@ -466,7 +468,7 @@ add the following steps:
     9. Let |allowed alternate subresource signed exchange links| be null.
 
     10. If |sourceBrowsingContext|'s [=active document=]'s
-        [=prefetched singed exchanges for navigation=] has a matching exchange
+        [=Document/prefetched singed exchanges for navigation=] has a matching exchange
         for the |request|'s [=request/url=], then:
         
         1. Let |clonedExchange| be the result of creating a new [=exchange=]
@@ -491,7 +493,7 @@ And before
 add the following steps:
 
     19. Copy |sourceBrowsingContext|'s [=active document=]'s
-        [=document-obj/prefetched subresource singed exchanges=]
+        [=Document/prefetched subresource singed exchanges=]
         to navigationParams's
         [=navigation params/prefetched subresource singed exchanges=].
 
@@ -516,10 +518,10 @@ add the following steps:
 
     15. Move the navigationParams's
         [=navigation params/prefetched subresource singed exchanges=] to the
-        document's [=document-obj/transferred subresource singed exchanges=].
+        document's [=Document/transferred subresource singed exchanges=].
 
     16. Set document's
-        [=document-obj/allowed alternate subresource signed exchange links=] to
+        [=Document/allowed alternate subresource signed exchange links=] to
         navigationParams's
         [=navigation params/allowed alternate subresource signed exchange links=].
 
@@ -541,7 +543,7 @@ add the following steps:
 
     5. If |el| is for the main resource's HTTP <a http-header>Link</a> header,
         and the document's
-        [=document-obj/allowed alternate subresource signed exchange links=] 
+        [=Document/allowed alternate subresource signed exchange links=] 
         has a matching link to |request|'s url, then run the following steps in
         parallel:
 
@@ -549,7 +551,7 @@ add the following steps:
             resource to be processed.
 
         1. If every |el|'s in this step has a matching exchange in the 
-            document's [=document-obj/transferred subresource singed exchanges=],
+            document's [=Document/transferred subresource singed exchanges=],
             set the |request|'s [=request/stashed exchange=] to the exchange.
             
         1. Return true.
@@ -564,6 +566,14 @@ An exchange is a [=struct=] with the following items:
 
 * <dfn export>request URL</dfn>, a [=URL=].
 * <dfn export>response</dfn>, a [=response=].
+* <dfn>header integrity value</dfn>, a [=byte sequence=] holding the [=SHA-256=]
+    hash that verified the [=exchange/response=]'s [=response/header list=].
+
+    Note: [=exchange/Header integrity value=] doesn’t change even if the
+    publisher signs the content again or changes the signing key, but it does
+    change if any of the headers or body change. (It catches changes to the body
+    because a valid signed exchange's headers have to include a `Digest` value
+    that covers the body.)
 
 </ul>
 
@@ -1123,7 +1133,9 @@ a URL |requestUrl| returns a failure or an [=exchange=] via the following steps:
     |responseHeaders|.
 1. Let |response| be a new [=response=] with [=response/status=] |headers|[1][``
     `:status` ``] and [=response/header list=] |responseHeaders|.
-1. Return an [=exchange=] of |requestUrl| and |response|.
+1. Let |headerIntegrityValue| be the [=SHA-256=] hash of |headerBytes|.
+1. Return an [=exchange=] of |requestUrl|, |response| and
+    |headerIntegrityValue|.
 
     Note: This ignores |requestHeaders|, which can't be encoded in b3 and later.
 
@@ -1151,7 +1163,9 @@ a URL |requestUrl| returns a failure or an [=exchange=] via the following steps:
 1. If |responseHeaders| is a failure, return it.
 1. Let |response| be a new [=response=] with [=response/status=] |headers|[``
     `:status` ``] and [=response/header list=] |responseHeaders|.
-1. Return an [=exchange=] of |requestUrl| and |response|.
+1. Let |headerIntegrityValue| be the [=SHA-256=] hash of |headerBytes|.
+1. Return an [=exchange=] of |requestUrl|, |response| and
+    |headerIntegrityValue|.
 
 <h4 algorithm id="headers-from-map">Converting a map to a header list</h4>
 

--- a/loading.bs
+++ b/loading.bs
@@ -151,6 +151,16 @@ spec: draft-ietf-httpbis-header-structure; urlPrefix: https://tools.ietf.org/htm
     text: Parsing HTTP1 Header Fields into Structured Headers; type: dfn; url: section-4.2
 spec: http-dig-alg; urlPrefix: https://www.iana.org/assignments/http-dig-alg/http-dig-alg.xhtml#
     type: dfn; text: Digest algorithm; url: http-dig-alg-1
+spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
+    type: attr-value;
+        for: link/rel; text: alternate; url: links.html#rel-alternate
+        for: link/rel; text: prefetch; url: links.html#link-type-prefetch
+        for: link/rel; text: preload; url: links.html#link-type-preload
+    type: dfn;
+        text: appropriate time; url: semantics.html#processing-the-type-attribute
+        text: fetch and process the linked resource; url: semantics.html#fetch-and-process-the-linked-resource
+        text: navigation params; url: browsing-the-web.html#navigation-params
+        text: process the linked resource; url: semantics.html#process-the-linked-resource
 spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf
     type: dfn
         text: SHA-256; url: #
@@ -246,6 +256,23 @@ Rewrite [=request/clone|clone a request=] to run these steps:
 
  <li>Return |newRequest|.
 </ol>
+
+## New response fields {#mp-response}
+
+A [=response=] has an associated <dfn for="response">came from a signed
+exchange</dfn> boolean, which is false by default.
+
+A [=response=] has an associated <dfn for="response">header integrity
+    value</dfn>, either null or, for responses that [=response/came from a
+    signed exchange=], a [=byte sequence=] holding the [=SHA-256=] hash that
+    verified the [=exchange/response=]'s [=response/header list=].
+
+    Note: The [=response/header integrity value=] doesn’t change even if the
+    publisher signs the content again or changes the signing key, but it does
+    change if any of the headers or body change. (It catches changes to the body
+    because a valid signed exchange's headers have to include a `Digest` value
+    that covers the body.)
+
 
 <h3 algorithm id="mp-response-date">Response date</h3>
 
@@ -343,10 +370,47 @@ the signed exchange's response in the HTTP cache.
 When prenavigating to a page held in a signed exchange, it can be useful to
 also prefetch subresources of that page as signed exchanges from the same
 server. To identify those transitive prefetchable resources, this section
-introduces an extension to the HTTP Link header.
+introduces an extension to the HTTP <a http-header>Link</a> header.
 
-* Link type "<dfn dfn-type="attr-value"
-    dfn-for="link/rel">allowed-alt-sxg</dfn>"
+<div class="example" id="example-alternate-signed-exchange-link">
+
+The following is an example HTTP response for
+`https://feed.example/sxg.publisher.example/page.html.wbn` showing the right
+Link headers to let a browser prefetch subresources.
+
+```http
+Content-Type: application/signed-exchange;v=b3
+Link: <https://feed.example/sxg.publisher.example/lib.js.sxg>;
+    rel="alternate";
+    type="application/signed-exchange";
+    anchor="https://cdn.publisher.example/lib.js"
+
+A signed exchange, whose request URL is https://sxg.publisher.example/page.html:
+
+    Content-Type: text/html
+    Link: <https://cdn.publisher.example/lib.js>;
+        rel="preload";
+        as="script"
+    Link: <https://cdn.publisher.example/lib.js>;
+        rel="allowed-alt-sxg";
+        header-integrity="sha256-XXXXXX"
+
+    <html>
+      <head>
+        <script src="https://cdn.publisher.example/lib.js"></script>
+      </head>
+      ...
+    </html>
+```
+
+If another page includes a `<link rel="prefetch"
+href="https://feed.example/sxg.publisher.example/page.html.wbn">`, the above
+response allows it to transitively prefetch a signed exchange that it can use to
+satisfy the `https://cdn.publisher.example/lib.js` `<script>` element.
+
+</div>
+
+* Link type "<dfn attr-value for="link/rel">allowed-alt-sxg</dfn>"
 
     The <{link/rel/allowed-alt-sxg}> keyword may be used in the HTTP
     <a http-header>Link</a> header of the inner HTTP response of the main
@@ -354,112 +418,111 @@ introduces an extension to the HTTP Link header.
     is also available as a particular signed exchange identified by the
     <{link/header-integrity}> parameter.
     The <dfn element-attr for="link">header-integrity</dfn> parameter holds the
-    value of the [=exchange/header integrity value=] of the
+    value of the [=response/header integrity value=] of the
     [=alternate signed exchange=], encoded as a [[CSP]]
     <a grammar>hash-source</a>.
-
-    <div class="example" id="example-allowed-alt-sxg-link">
-    ```http
-    Link: <https://cdn.publisher.example/lib.js>;
-            rel="preload";
-            as="script"
-    Link: <https://cdn.publisher.example/lib.js>;
-            rel="allowed-alt-sxg";
-            header-integrity="sha256-XXXXXX"
-    ```
-    </div>
 * An <dfn>alternate signed exchange link</dfn> is a `` `Link` `` header sent
     with a signed exchange |S|, with the <{link/rel/alternate}> link type, the
-    `type` parameter set to `application/signed-exchange`, and a
-    [=Link Context=]. The [=Link Context=] MUST be the [=Link Target=] of a
-    <{link/rel/preload}> `` `Link` `` header inside the signed content of |S|,
-    and the [=alternate signed exchange link=] means that this resource can also
-    be found inside the <dfn dfn-type=dfn>alternate signed exchange</dfn> at the
-    [=Link Target=] of the [=alternate signed exchange link=].
+    `type` parameter set to `application/signed-exchange`, and a [=Link
+    Context=] (an `anchor` parameter). The [=Link Context=] MUST be the [=Link
+    Target=] of a <{link/rel/preload}> `` `Link` `` header inside the signed
+    content of |S|, and the [=alternate signed exchange link=] means that this
+    resource can also be found inside the <dfn dfn-type=dfn>alternate signed
+    exchange</dfn> at the [=Link Target=] of the [=alternate signed exchange
+    link=].
 
-    <div class="example" id="example-alternate-signed-exchange-link">
-    ```http
-    Link: <https://feed.example/sxg.publisher.example/lib.js.sxg>;
-            rel="alternate";
-            type="application/signed-exchange";
-            anchor="https://cdn.publisher.example/lib.js"
-    ```
-    </div>
 
-<h3 algorithm id="mp-document">
-Monkeypatch Document</h3>
-In the end of
+The [=appropriate time=] to [=fetch and process the linked resource=] for an
+is when the following steps return true:
+
+<ol algorithm="appropriate time for an alternate signed exchange link">
+
+1. Let |R| be the [=response=] created from the signed exchange in the response
+    that held the [=alternate signed exchange link=].
+1. Let |L| be the set of <{link/rel/preload}> <a http-header>Link</a> HTTP
+    headers on |R| whose [=Link Target=] is the same as the [=alternate signed
+    exchange link=]'s [=Link Context=].
+1. If |L| is empty, return false.
+1. Let |allowedSxgs| be the set of <{link/rel/allowed-alt-sxg}> <a
+    http-header>Link</a> HTTP headers on |R| that "match" (TODO, maybe use
+    [[draft-ietf-httpbis-variants]] here) any header in |L|.
+1. If |allowedSxgs| is empty, return false.
+1. Return true.
+
+</ol>
+
+<div algorithm="process the alternate signed exchange linked resource">
+
+The [=process the linked resource=] steps for an [=alternate signed exchange
+link=] , given the Link header |header|, boolean |success|, and [=response=]
+|response|:
+
+1. Do something when |success| is false.
+1. If the |response| [=response/came from a signed exchange=] and the
+    |response|'s [=response/header integrity value=] matches the
+    `header-integrity` parameter of the <{link/rel/allowed-alt-sxg}> link (TODO:
+    find a way to attach the <{link/rel/allowed-alt-sxg}> header to the fetch
+    for |header|), create an [=exchange=] with the URL of the
+    <{link/rel/allowed-alt-sxg}> link's [=Link Target=] URL and the result of
+    [=response/cloning=] the inner response of the [=alternate signed
+    exchange=], and store the exchange to the [=Document/prefetched subresource
+    signed exchanges=] of the document.
+
+</div>
+
+<h3 algorithm id="mp-document">Monkeypatch Document</h3>
+
+At the end of
 [the Document object](https://html.spec.whatwg.org/multipage/dom.html#the-document-object)
 section, add the following lines:
 
-The {{Document}} has a set of <dfn for="Document" dfn-type=dfn>prefetched singed
-exchanges for navigation</dfn>, which is a set of [=exchanges=], initially empty.
+<blockquote dfn-for="Document">
 
-The {{Document}} has a set of <dfn dfn-for="Document" dfn-type=dfn>prefetched
-subresource singed exchanges</dfn>, which is a set of [=exchanges=], initially
+The {{Document}} has a set of <dfn dfn>prefetched signed exchanges for
+navigation</dfn>, which is a set of [=exchanges=], initially empty.  <span
+class="note">This might merge with the set of prefetched resources when
+<{link/rel/prefetch}> is specified more completely.</span>
+
+The {{Document}} has a set of <dfn dfn>prefetched
+subresource signed exchanges</dfn>, which is a set of [=exchanges=], initially
 empty.
 
-The {{Document}} has a set of <dfn dfn-for="Document" dfn-type=dfn>transferred
-subresource singed exchanges</dfn>, which is a set of [=exchanges=], initially
+The {{Document}} has a set of <dfn dfn>transferred
+subresource signed exchanges</dfn>, which is a set of [=exchanges=], initially
 empty.
 
-The {{Document}} has a set of <dfn dfn-for="Document" dfn-type=dfn>allowed
+The {{Document}} has a set of <dfn dfn>allowed
 alternate subresource signed exchange links</dfn>, which is a set of
 <{link/rel/allowed-alt-sxg}> links, initially empty.
 
-<h3 algorithm id="mp-navigation-params">
-Monkeypatch navigation params struct</h3>
-In the
-[navigation params struct](https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params),
-add the following item:
+</blockquote>
+
+<h3 algorithm id="mp-navigation-params">Monkeypatch navigation params struct</h3>
+
+In the [=navigation params=], add the following items:
 
 <dl dfn-for="navigation params">
-: <dfn>prefetched subresource singed exchanges</dfn>
-:: A a set of [=exchanges=], initially empty.
+
+: <dfn>prefetched subresource signed exchanges</dfn>
+:: A set of [=exchanges=], initially empty.
 : <dfn>allowed alternate subresource signed exchange links</dfn>
-:: A a set of <{link/rel/allowed-alt-sxg}> links, initially empty.
+:: A set of <{link/rel/allowed-alt-sxg}> links, initially empty.
 
 </dl>
 
-<h3 algorithm id="mp-fetching-the-resource-hint-link">
-Monkeypatch Fetching the resource hint link</h3>
-In the end of
-[Fetching the resource hint link](https://w3c.github.io/resource-hints/#fetching-the-resource-hint-link)
-section, add the following lines:
+<h3 algorithm id="mp-fetching-the-resource-hint-link">Monkeypatch Fetching the resource hint link</h3>
 
-The user agent SHOULD run the following steps if the response of the prefetched
-resource is a valid signed exchange:
+At the end of the [Fetching the resource hint
+link](https://w3c.github.io/resource-hints/#fetching-the-resource-hint-link)
+section in [[resource-hints]], add the following lines:
+
+The user agent SHOULD run the following steps if the response of a
+<{link/rel/prefetch}>ed resource [=response/came from a signed exchange=]:
+
     1. Let |clonedResponse| be the result of [=response/cloning=] the response.
     1. Create an [=exchange=] with the request URL and |clonedResponse|,
         and store the exchange to the
-        [=Document/prefetched singed exchanges for navigation=] of the Document.
-
-The user agent SHOULD prefetch the alternate subresources signed exchanges if
-declared in link headers in the outer and the inner response header of the
-signed exchanges by running the following steps:
-    1. When the UA detects a "preload" link HTTP header in a signed exchange
-        inner response, check whether a matching <{link/rel/allowed-alt-sxg}>
-        link in the inner HTTP response exists or not.
-
-        Note: multiple <{link/rel/allowed-alt-sxg}> links can be present for the
-        same preload if they include `variants` and `variant-key` attributes. In
-        that case, the UA uses the algorithm written in [HTTP Representation
-        Variants](https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html)
-        spec to find the matching header.)
-    1. If an <{link/rel/allowed-alt-sxg}> link exists, check whether the signed
-        exchange was served with a matching [=alternate signed exchange link=]
-        in the outer HTTP response.
-    1. If there is an [=alternate signed exchange link=] which identify an
-        alternate version of the subresource, prefetch the
-        [=alternate signed exchange=].
-    1. If the resulting [=alternate signed exchange=] is valid and the
-        [=exchange/header integrity value=] of it matches the `header-integrity`
-        parameter of the <{link/rel/allowed-alt-sxg}> link, create an
-        [=exchange=] with the URL of the <{link/rel/allowed-alt-sxg}> link's
-        [=Link Target=] URL and the result of [=response/cloning=] the inner
-        response of the [=alternate signed exchange=], and store the exchange to
-        the [=Document/prefetched subresource singed exchanges=] of the
-        document.
+        [=Document/prefetched signed exchanges for navigation=] of the Document.
 
 <h3 algorithm id="mp-process-a-navigate-fetch">
 Monkeypatch process a navigate fetch</h3>
@@ -473,7 +536,7 @@ add the following steps:
     9. Let |allowed alternate subresource signed exchange links| be null.
 
     10. If |sourceBrowsingContext|'s [=active document=]'s
-        [=Document/prefetched singed exchanges for navigation=] has a matching exchange
+        [=Document/prefetched signed exchanges for navigation=] has a matching exchange
         for the |request|'s [=request/url=], then:
 
         1. Let |clonedExchange| be the result of creating a new [=exchange=]
@@ -498,9 +561,9 @@ And before
 add the following steps:
 
     19. Copy |sourceBrowsingContext|'s [=active document=]'s
-        [=Document/prefetched subresource singed exchanges=]
+        [=Document/prefetched subresource signed exchanges=]
         to navigationParams's
-        [=navigation params/prefetched subresource singed exchanges=].
+        [=navigation params/prefetched subresource signed exchanges=].
 
     20. Set navigationParams's
         [=navigation params/allowed alternate subresource signed exchange links=]
@@ -522,8 +585,8 @@ before
 add the following steps:
 
     15. Move the navigationParams's
-        [=navigation params/prefetched subresource singed exchanges=] to the
-        document's [=Document/transferred subresource singed exchanges=].
+        [=navigation params/prefetched subresource signed exchanges=] to the
+        document's [=Document/transferred subresource signed exchanges=].
 
     16. Set document's
         [=Document/allowed alternate subresource signed exchange links=] to
@@ -555,7 +618,7 @@ add the following steps:
             resource to be processed.
 
         1. If every |el|'s in this step has a matching exchange in the
-            document's [=Document/transferred subresource singed exchanges=],
+            document's [=Document/transferred subresource signed exchanges=],
             set the |request|'s [=request/stashed exchange=] to the exchange.
 
         1. Return true.
@@ -570,14 +633,6 @@ An exchange is a [=struct=] with the following items:
 
 * <dfn export>request URL</dfn>, a [=URL=].
 * <dfn export>response</dfn>, a [=response=].
-* <dfn>header integrity value</dfn>, a [=byte sequence=] holding the [=SHA-256=]
-    hash that verified the [=exchange/response=]'s [=response/header list=].
-
-    Note: [=exchange/Header integrity value=] doesn’t change even if the
-    publisher signs the content again or changes the signing key, but it does
-    change if any of the headers or body change. (It catches changes to the body
-    because a valid signed exchange's headers have to include a `Digest` value
-    that covers the body.)
 
 </ul>
 
@@ -807,6 +862,8 @@ following steps
     : `b3`
     :: the result of [=parsing b3 CBOR headers=] given |headerBytes| and
         |requestUrl|.
+1. Set |parsedExchange|'s [=exchange/response=]'s [=response/came from a signed
+    exchange=] to true.
 1. If |parsedSignature| [=exchange signature/does not establish cross-origin
     trust=] for |parsedExchange|, return
     "[=signed exchange report/cert_verification_error=]".

--- a/loading.bs
+++ b/loading.bs
@@ -263,7 +263,7 @@ Rewrite [=request/clone|clone a request=] to run these steps:
  <li>Return |newRequest|.
 </ol>
 
-## New response fields {#mp-response}
+## New response fields ## {#mp-response}
 
 A [=response=] has an associated <dfn for="response">came from a signed
 exchange</dfn> boolean, which is false by default.

--- a/loading.bs
+++ b/loading.bs
@@ -123,6 +123,11 @@ spec: RFC8288; urlPrefix: https://tools.ietf.org/html/rfc8288#
         text: Link Target; url: section-3.1
     type: dfn
         text: Link Context; url: section-3.2
+    type: dfn
+        text: Target Attributes; url: section-3.4
+spec: RFC5988; urlPrefix: https://tools.ietf.org/html/rfc5988#
+    type: dfn
+        text: semantically equivalent; url: #page-5:~:text=semantically%20equivalent
 spec: RFC8446; urlPrefix: https://tools.ietf.org/html/draft-ietf-tls-tls13-28#
     text: ecdsa_secp256r1_sha256; type: dfn; url: section-4.2.3
 spec: draft-ietf-httpbis-variants; urlPrefix: https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html#
@@ -269,15 +274,15 @@ A [=response=] has an associated <dfn for="response">came from a signed
 exchange</dfn> boolean, which is false by default.
 
 A [=response=] has an associated <dfn for="response">header integrity
-    value</dfn>, either null or, for responses that [=response/came from a
-    signed exchange=], a [=byte sequence=] holding the [=SHA-256=] hash that
-    verified the [=exchange/response=]'s [=response/header list=].
+value</dfn>, either null or, for responses that [=response/came from a signed
+exchange=], a [=byte sequence=] holding the [=SHA-256=] hash that verified the
+[=exchange/response=]'s [=response/header list=].
 
-    Note: The [=response/header integrity value=] doesn’t change even if the
-    publisher signs the content again or changes the signing key, but it does
-    change if any of the headers or body change. (It catches changes to the body
-    because a valid signed exchange's headers have to include a `Digest` value
-    that covers the body.)
+Note: The [=response/header integrity value=] doesn’t change even if the
+publisher signs the content again or changes the signing key, but it does change
+if any of the headers or body change. (It catches changes to the body because a
+valid signed exchange's headers have to include a `Digest` value that covers the
+body.)
 
 
 <h3 algorithm id="mp-response-date">Response date</h3>
@@ -416,13 +421,6 @@ satisfy the `https://cdn.publisher.example/lib.js` `<script>` element.
 
 </div>
 
-* The <{Link}> element.
-
-    The <dfn element-attr for="link">variants</dfn> parameter may be present.
-
-    The <dfn element-attr for="link">variant-key</dfn> parameter may be
-        present.
-
 * Link type "<dfn attr-value for="link/rel">allowed-alt-sxg</dfn>"
 
     The <{link/rel/allowed-alt-sxg}> keyword may be used in the HTTP <a
@@ -433,38 +431,57 @@ satisfy the `https://cdn.publisher.example/lib.js` `<script>` element.
     for="link">header-integrity</dfn> parameter holds the value of the
     [=response/header integrity value=] of the [=alternate signed exchange=],
     encoded as a [[CSP]] <a grammar>hash-source</a>. 
-* An <dfn>alternate signed exchange link</dfn> is a `` `Link` `` header sent
-    with a signed exchange |S|, with the <{link/rel/alternate}> link type, the
-    `type` parameter set to `application/signed-exchange`, and a [=Link
-    Context=] (an `anchor` parameter). The [=Link Context=] MUST be the [=Link
-    Target=] of a <{link/rel/preload}> `` `Link` `` header inside the signed
-    content of |S|, and the [=alternate signed exchange link=] means that this
-    resource can also be found inside the <dfn dfn-type=dfn>alternate signed
-    exchange</dfn> at the [=Link Target=] of the [=alternate signed exchange
-    link=].
+* An <dfn>alternate signed exchange link</dfn> is a <a http-header>Link</a>
+    header sent with a signed exchange |S|, with the <{link/rel/alternate}> link
+    type, the `type` parameter set to `application/signed-exchange`, and a
+    [=Link Context=] (an `anchor` parameter). The [=Link Context=] MUST be the
+    [=Link Target=] of a <{link/rel/preload}> <a http-header>Link</a> header
+    inside the signed content of |S|, and the [=alternate signed exchange link=]
+    means that this resource can also be found inside the <dfn
+    dfn-type=dfn>alternate signed exchange</dfn> at the [=Link Target=] of the
+    [=alternate signed exchange link=].
 
+* New [=Target Attributes=] on the <a http-header>Link</a> header.
+
+    * The <dfn element-attr for="link">variants</dfn> parameter may be present.
+        This parameter is used in <{link/rel/allowed-alt-sxg}> link and
+        [=alternate signed exchange link=] to indicate what representations are
+        available for the resource at the time that the response is produced.
+        This attribute is using the same format as <a
+        http-header>Variants</a> Header Field.
+
+    * The <dfn element-attr for="link">variant-key</dfn> parameter may be
+        present. This parameter is used in <{link/rel/allowed-alt-sxg}> link and
+        [=alternate signed exchange link=] to indicate one or more sets of
+        available-values that identify the representation of the resource.
+        This parameter is using the same format as <a
+        http-header>Variant-Key</a> Header Field.
 
 The [=appropriate time=] to [=fetch and process the linked resource=] for an
 [=alternate signed exchange link=] is when the following steps return true:
 
 <ol algorithm="appropriate time for an alternate signed exchange link">
 
-1. Let |R| be the [=response=] created from the signed exchange in the response
-    that held the [=alternate signed exchange link=].
-1. Let |L| be the set of <{link/rel/allowed-alt-sxg}> <a http-header>Link</a>
-    HTTP headers on |R| whose [=Link Target=] is the same as the [=alternate
-    signed exchange link=]'s [=Link Context=] and whose <{link/variants}>
-    parameter and <{link/variant-key}> parameter are the same as the [=alternate
-    signed exchange link=]'s parameters if they are present.
-1. If |L| is empty, return false.
-1. Let |preload links| be the set of <{link/rel/allowed-alt-sxg}> <a
-    http-header>Link</a> HTTP headers on |R|.
-1. For each |preload link| in |preload links|:
-    1. Let |el| be a semantically equivalent link element to |preload link|.
+1. Let |signedResponse| be the [=response=] created from the signed exchange in
+    the response that held the [=alternate signed exchange link=].
+1. Let |allowedSxgLinks| be the set of <{link/rel/allowed-alt-sxg}> <a
+    http-header>Link</a> HTTP headers on |signedResponse| whose [=Link Target=]
+    is the same as the [=alternate signed exchange link=]'s [=Link Context=] and
+    whose <{link/variants}> parameter and <{link/variant-key}> parameter are the
+    same as the [=alternate signed exchange link=]'s parameters if they are
+    present.
+1. If |allowedSxgLinks| is empty, return false.
+1. Let |preload links| be the set of <{link/rel/preload}> <a
+    http-header>Link</a> HTTP headers on |signedResponse|.
+1. For each |preload link| in |preload links|, use the following steps to
+     resolve the link's actual target, incorporating attributes like
+     <{link/imagesrcset}> and <{link/imagesizes}>:
+    1. Let |el| be a [=semantically equivalent=] link element to |preload link|.
     1. If |el|'s <{link/href}> attribute's value is the empty string, then
         continue.
-    1. Let |url| be the result of applying the [=URL parser=] to |el|'s
-        <{link/href}> attribute's value, with |R|'s [=response/URL=].
+    1. Let |url| be the result of [=URL parser|parsing=] |el|'s <{link/href}>
+        attribute's value, with a base URL of |signedResponse|'s
+        [=response/URL=].
     1. Let |corsAttributeState| be the current state of the |el|'s
         <{link/crossorigin}> content attribute.
     1. Let |request| be the result of [=creating a potential-CORS request=]
@@ -668,6 +685,12 @@ add the following steps:
                 1. Return true.
 
             1. Otherwise, return true.
+
+Issue(whatwg/html#4224): Currently the processing model of the HTTP <a
+http-header>Link</a> header is not defined. In this section, we treat the ``
+`preload` `` <a http-header>Link</a> headers as if their [=semantically
+equivalent=] <{link/rel/preload}> type link elements are generated and
+processed at some point.
 
 # Structures # {#structs}
 

--- a/loading.bs
+++ b/loading.bs
@@ -345,15 +345,19 @@ also prefetch subresources of that page as signed exchanges from the same
 server. To identify those transitive prefetchable resources, this section
 introduces an extension to the HTTP Link header.
 
-* Link type "<dfn dfn-type=dfn>allowed-alt-sxg</dfn>"
+* Link type "<dfn dfn-type="attr-value"
+    dfn-for="link/rel">allowed-alt-sxg</dfn>"
 
-    The [=allowed-alt-sxg=] keyword may be used
-    in HTTP <a http-header>Link</a> header of inner HTTP response of main
-    resource signed exchange to indicate an
-    <dfn dfn-type=dfn>allowed-alt-sxg link</dfn> that the subresource of the
-    [=Link Target=] can be loaded from different URL as a signed exchange. This
-    link has a `header-integrity` parameter set to the value of the
-    [=exchange/header integrity value=] of the [=alternate signed exchange=].
+    The <{link/rel/allowed-alt-sxg}> keyword may be used in the HTTP
+    <a http-header>Link</a> header of the inner HTTP response of the main
+    resource signed exchange to indicate that the content of the [=Link Target=]
+    is also available as a particular signed exchange identified by the
+    <{link/header-integrity}> parameter.
+    The <dfn element-attr for="link">header-integrity</dfn> parameter holds the
+    value of the [=exchange/header integrity value=] of the
+    [=alternate signed exchange=], encoded as a [[CSP]]
+    <a grammar>hash-source</a>.
+
     <div class="example" id="example-allowed-alt-sxg-link">
     ```http
     Link: <https://cdn.publisher.example/lib.js>;
@@ -361,16 +365,16 @@ introduces an extension to the HTTP Link header.
             as="script"
     Link: <https://cdn.publisher.example/lib.js>;
             rel="allowed-alt-sxg";
-            header-integrity="sha256-XXXXXX
+            header-integrity="sha256-XXXXXX"
     ```
     </div>
 * An <dfn>alternate signed exchange link</dfn> is a `` `Link` `` header sent
-    with a signed exchange |S|, with the [=alternate=] link type, the `type`
-    parameter set to `application/signed-exchange`, and a [=Link Context=]. The
-    [=Link Context=] MUST be the [=Link Target=] of a [=preload=] `` `Link` ``
-    header inside the signed content of |S|, and the
-    [=alternate signed exchange link=] means that this resource can also be
-    found inside the <dfn dfn-type=dfn>alternate signed exchange</dfn> at the
+    with a signed exchange |S|, with the <{link/rel/alternate}> link type, the
+    `type` parameter set to `application/signed-exchange`, and a
+    [=Link Context=]. The [=Link Context=] MUST be the [=Link Target=] of a
+    <{link/rel/preload}> `` `Link` `` header inside the signed content of |S|,
+    and the [=alternate signed exchange link=] means that this resource can also
+    be found inside the <dfn dfn-type=dfn>alternate signed exchange</dfn> at the
     [=Link Target=] of the [=alternate signed exchange link=].
 
     <div class="example" id="example-alternate-signed-exchange-link">
@@ -391,16 +395,17 @@ section, add the following lines:
 The {{Document}} has a set of <dfn for="Document" dfn-type=dfn>prefetched singed
 exchanges for navigation</dfn>, which is a set of [=exchanges=], initially empty.
 
-The {{Document}} has a <dfn dfn-for="Document" dfn-type=dfn>prefetched
+The {{Document}} has a set of <dfn dfn-for="Document" dfn-type=dfn>prefetched
 subresource singed exchanges</dfn>, which is a set of [=exchanges=], initially
 empty.
 
-The {{Document}} has a <dfn dfn-for="Document" dfn-type=dfn>transferred
-subresource singed exchanges</dfn>, which is a set of [=exchanges=], initially empty.
+The {{Document}} has a set of <dfn dfn-for="Document" dfn-type=dfn>transferred
+subresource singed exchanges</dfn>, which is a set of [=exchanges=], initially
+empty.
 
-The {{Document}} has a <dfn dfn-for="Document" dfn-type=dfn>allowed alternate
-subresource signed exchange links</dfn>, which is a set of
-[=allowed-alt-sxg link=], initially empty.
+The {{Document}} has a set of <dfn dfn-for="Document" dfn-type=dfn>allowed
+alternate subresource signed exchange links</dfn>, which is a set of
+<{link/rel/allowed-alt-sxg}> links, initially empty.
 
 <h3 algorithm id="mp-navigation-params">
 Monkeypatch navigation params struct</h3>
@@ -412,7 +417,7 @@ add the following item:
 : <dfn>prefetched subresource singed exchanges</dfn>
 :: A a set of [=exchanges=], initially empty.
 : <dfn>allowed alternate subresource signed exchange links</dfn>
-:: A a set of [=allowed-alt-sxg link=], initially empty.
+:: A a set of <{link/rel/allowed-alt-sxg}> links, initially empty.
 
 </dl>
 
@@ -433,27 +438,27 @@ The user agent SHOULD prefetch the alternate subresources signed exchanges if
 declared in link headers in the outer and the inner response header of the
 signed exchanges by running the following steps:
     1. When the UA detects a "preload" link HTTP header in a signed exchange
-        inner response, check whether a matching [=allowed-alt-sxg link=] in the
-        inner HTTP response exists or not.
+        inner response, check whether a matching <{link/rel/allowed-alt-sxg}>
+        link in the inner HTTP response exists or not.
 
-        Note: multiple [=allowed-alt-sxg links=] can be present for the same
-        preload if they include `variants` and `variant-key` attributes. In that
-        case, the UA uses the algorithm written in [HTTP Representation
+        Note: multiple <{link/rel/allowed-alt-sxg}> links can be present for the
+        same preload if they include `variants` and `variant-key` attributes. In
+        that case, the UA uses the algorithm written in [HTTP Representation
         Variants](https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html)
         spec to find the matching header.)
-    1. If an [=allowed-alt-sxg link=] exists, check whether the signed exchange
-        was served with a matching [=alternate signed exchange link=] in the
-        outer HTTP response.
+    1. If an <{link/rel/allowed-alt-sxg}> link exists, check whether the signed
+        exchange was served with a matching [=alternate signed exchange link=]
+        in the outer HTTP response.
     1. If there is an [=alternate signed exchange link=] which identify an
         alternate version of the subresource, prefetch the
         [=alternate signed exchange=].
     1. If the resulting [=alternate signed exchange=] is valid and the
         [=exchange/header integrity value=] of it matches the `header-integrity`
-        parameter of the [=allowed-alt-sxg link=], create a [=exchange=]
-        with the URL of the [=allowed-alt-sxg link=]'s [=Link Target=] URL and
-        the result of [=response/cloning=] the inner response of the
-        [=alternate signed exchange=], and store the exchange to the
-        [=Document/prefetched subresource singed exchanges=] of the
+        parameter of the <{link/rel/allowed-alt-sxg}> link, create an
+        [=exchange=] with the URL of the <{link/rel/allowed-alt-sxg}> link's
+        [=Link Target=] URL and the result of [=response/cloning=] the inner
+        response of the [=alternate signed exchange=], and store the exchange to
+        the [=Document/prefetched subresource singed exchanges=] of the
         document.
 
 <h3 algorithm id="mp-process-a-navigate-fetch">
@@ -470,7 +475,7 @@ add the following steps:
     10. If |sourceBrowsingContext|'s [=active document=]'s
         [=Document/prefetched singed exchanges for navigation=] has a matching exchange
         for the |request|'s [=request/url=], then:
-        
+
         1. Let |clonedExchange| be the result of creating a new [=exchange=]
             with the matching exchange's [=exchange/request URL=] and the result
             of [=response/cloning=] the matching exchange's
@@ -479,7 +484,7 @@ add the following steps:
         1. Move |clonedExchange| to the |request|'s
             [=request/stashed exchange=].
 
-        1. Copy [=allowed-alt-sxg link=] of the exchange's
+        1. Copy <{link/rel/allowed-alt-sxg}> link of the exchange's
             [=exchange/response=]'s inner response to
             |allowed alternate subresource signed exchange links|.
 
@@ -530,10 +535,9 @@ add the following steps:
 Monkeypatch Link type "preload"</h3>
 
 The navigated-to document has a set of preloads for which it uses the
-[=allowed-alt-sxg link=] relation to declare that they can be served by signed
-exchanges. The UA either serves all of them from SXGs prefetched by the previous
-page, or none of them.
-So in the
+<{link/rel/allowed-alt-sxg}> link relation to declare that they can be served by
+signed exchanges. The UA either serves all of them from SXGs prefetched by the
+previous page, or none of them. So in the
 [linked resource fetch setup steps for preload type of linked resource](https://html.spec.whatwg.org/multipage/links.html#link-type-preload:linked-resource-fetch-setup-steps)
 before
 
@@ -543,17 +547,17 @@ add the following steps:
 
     5. If |el| is for the main resource's HTTP <a http-header>Link</a> header,
         and the document's
-        [=Document/allowed alternate subresource signed exchange links=] 
-        has a matching link to |request|'s url, then run the following steps in
+        [=Document/allowed alternate subresource signed exchange links=] has a
+        matching link to |request|'s url, then run the following steps in
         parallel:
 
         1. Wait until there is no remaining preload Link header of the main
             resource to be processed.
 
-        1. If every |el|'s in this step has a matching exchange in the 
+        1. If every |el|'s in this step has a matching exchange in the
             document's [=Document/transferred subresource singed exchanges=],
             set the |request|'s [=request/stashed exchange=] to the exchange.
-            
+
         1. Return true.
 
 # Structures # {#structs}

--- a/loading.bs
+++ b/loading.bs
@@ -116,6 +116,13 @@ spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231#
         text: HTTP media type; url: section-3.1.1.1
     type: http-header
         text: Date; url: section-7.1.1.2
+spec: RFC8288; urlPrefix: https://tools.ietf.org/html/rfc8288#
+    type: http-header
+        text: Link; url: section-3
+    type: dfn
+        text: link target; url: section-3.1
+    type: dfn
+        text: anchor; url: section-3.2
 spec: RFC8446; urlPrefix: https://tools.ietf.org/html/draft-ietf-tls-tls13-28#
     text: ecdsa_secp256r1_sha256; type: dfn; url: section-4.2.3
 spec: draft-ietf-httpbis-variants; urlPrefix: https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html#
@@ -333,64 +340,219 @@ the signed exchange's response in the HTTP cache.
 
 # Subresource substitution # {#subresource-substitution}
 
-To support [Signed Exchange subresource substitution](https://github.com/WICG/webpackage/blob/master/explainers/signed-exchange-subresource-subtitution-explainer.md),
-this secion describes how web browsers prefetch subresource signed exchanges.
+To let the UA know that subresources of a page it's prenavigating to, can
+be retrieved as signed exchanges from the source site, this section introduces
+an extension to the HTTP Link header.
+
+* A <dfn dfn-type=dfn>allowed-alt-sxg link</dfn> is a relationship that is used
+    in HTTP <a http-header>Link</a> header of inner HTTP response of main
+    resource signed exchange to indicate that the subresource of the
+    [=link target=] can be loaded from different URL as a signed exchange. This
+    link has a
+    [rel](https://html.spec.whatwg.org/multipage/semantics.html#attr-link-rel)
+    parameter contains `allowed-alt-sxg` and a `header-integrity` parameter set
+    to the value of the [=header integrity value=] of the [=alternate signed
+    exchange=] 
+* A <dfn dfn-type=dfn>alternate signed exchange link</dfn> is a relationship
+    that is used in HTTP <a http-header>Link</a> header of outer HTTP response
+    of main resource signed exchange to indicate that the
+    <dfn dfn-type=dfn>alternate signed exchange</dfn> of the [=link target=] can
+    be loaded instead of the subresource  of the URL declared at the [=anchor=]
+    parameter. This link has a
+    [rel](https://html.spec.whatwg.org/multipage/semantics.html#attr-link-rel)
+    parameter contains
+    [alternate](https://html.spec.whatwg.org/multipage/links.html#rel-alternate)
+    keyword and a
+    [type](https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-type)
+    parameter set to the value 'application/signed-exchange' and an [=anchor=]
+    parameter set to the original subresource URL.
+* A <dfn dfn-type=dfn>header integrity value</dfn> is the SHA256 hash value of
+    the |signedHeaders| value from the
+    [application/signed-exchange format](https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#application-signed-exchange)
+    for integrity checking.
+
+    Note: This |signedHeaders| is *"the canonical serialization of the CBOR
+    representation of the response headers of the exchange represented by the
+    application/signed-exchange resource, excluding the Signature header
+    field"*. So this value doesn’t change even if the publisher signs the
+    content again or changes the signing key, but it does change if any of the
+    headers or body change. (It catches changes to the body because a valid
+    signed exchange's headers have to include a `Digest` value that covers
+    the body.)
+
+<h3 algorithm id="mp-document">
+Monkeypatch Document</h3>
+In the end of
+[the Document object](https://html.spec.whatwg.org/multipage/dom.html#the-document-object)
+section, add the following lines:
+
+The <code>Document</code> has a <dfn dfn-type=dfn>prefetched singed exchanges
+for navigation</dfn>, which is a set of [=exchanges=], initially empty.
+
+The document has a <dfn dfn-for="document-obj" dfn-type=dfn>prefetched
+subresource singed exchanges</dfn>, which is a set of [=exchanges=], initially
+empty.
+
+The document has a <dfn dfn-for="document-obj" dfn-type=dfn>transferred
+subresource singed exchanges</dfn>, which is a set of [=exchanges=], initially empty.
+
+The document has a <dfn dfn-for="document-obj" dfn-type=dfn>allowed alternate
+subresource signed exchange links</dfn>, which is a set of
+[=allowed-alt-sxg link=], initially empty.
+
+<h3 algorithm id="mp-navigation-params">
+Monkeypatch navigation params struct</h3>
+In the
+[navigation params struct](https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params),
+add the following item:
+
+<dl dfn-for="navigation params">
+: <dfn>prefetched subresource singed exchanges</dfn>
+:: A a set of [=exchanges=], initially empty.
+: <dfn>allowed alternate subresource signed exchange links</dfn>
+:: A a set of [=allowed-alt-sxg link=], initially empty.
+
+</dl>
 
 <h3 algorithm id="mp-fetching-the-resource-hint-link">
 Monkeypatch Fetching the resource hint link</h3>
-In [Fetching the resource hint
-link](https://w3c.github.io/resource-hints/#fetching-the-resource-hint-link),
-add the following lines:
+In the end of
+[Fetching the resource hint link](https://w3c.github.io/resource-hints/#fetching-the-resource-hint-link)
+section, add the following lines:
+
+The user agent SHOULD run the following steps if the response of the prefetched
+resource is a valid signed exchange:
+    1. Let |clonedResponse| be the result of [=response/cloning=] the response.
+    1. Create an [=exchange=] with the request URL and |clonedResponse|,
+        and store the exchange to the
+        [=prefetched singed exchanges for navigation=] of the Document.
 
 The user agent SHOULD prefetch the alternate subresources signed exchanges if
 declared in link headers in the outer and the inner response header of the
 signed exchanges by running the following steps:
     1. When the UA detects a "preload" link HTTP header in a signed exchange
-        inner response, check whether a matching “allowed-alt-sxg” link HTTP
-        header in the inner response exists or not. (Note that multiple
-        `allowed-alt-sxg` links can be present for the same preload if they
-        include `variants` and `variant-key` attributes. In that case, the UA
-        uses the algorithm written in [HTTP Representation
+        inner response, check whether a matching [=allowed-alt-sxg link=] in the
+        inner HTTP response exists or not.
+
+        Note: multiple [=allowed-alt-sxg links=] can be present for the same
+        preload if they include `variants` and `variant-key` attributes. In that
+        case, the UA uses the algorithm written in [HTTP Representation
         Variants](https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html)
         spec to find the matching header.)
-    1. If an `allowed-alt-sxg` link exists, check whether the signed exchange
-        was served with a matching “alternate” link HTTP header.
-    1. If the outer signed exchange did identify an alternate version of the
-        subresource, prefetch the subresource signed exchange.
-    1. If the resulting signed exchange is valid and matches the allowed-alt-sxg
-        link, attach it to the top-level prefetch.
+    1. If an [=allowed-alt-sxg link=] exists, check whether the signed exchange
+        was served with a matching [=alternate signed exchange link=] in the
+        outer HTTP response.
+    1. If there is an [=alternate signed exchange link=] which identify an
+        alternate version of the subresource, prefetch the
+        [=alternate signed exchange=].
+    1. If the resulting [=alternate signed exchange=] is valid and the
+        [=header integrity value=] of it matches the `header-integrity`
+        parameter of the [=allowed-alt-sxg link=], create a [=exchange=]
+        with the URL of the [=allowed-alt-sxg link=]'s [=link target=] URL and
+        the result of [=response/cloning=] the inner response of the
+        [=alternate signed exchange=], and store the exchange to the
+        [=document-obj/prefetched subresource singed exchanges=] of the
+        document.
 
-<h3 algorithm id="mp-navigating-across-documents">
-Monkeypatch Navigating across documents</h3>
-In [navigating across documents](https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigating-across-documents),
-add the following step:
-    1. Copy the signed exchanges that were prefetched above to the target
-        document except for the one that serves the navigation itself.
-- Note that as browsers move toward partitioned HTTP caches, the source
-    document's cache will likely be separate from the target's cache, so
-    we can't just pass prefetched content through the cache.
+<h3 algorithm id="mp-process-a-navigate-fetch">
+Monkeypatch process a navigate fetch</h3>
+In [process a navigate fetch](https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch)
+before
+
+> 9. While true:
+
+add the following steps:
+
+    9. Let |allowed alternate subresource signed exchange links| be null.
+
+    10. If |sourceBrowsingContext|'s [=active document=]'s
+        [=prefetched singed exchanges for navigation=] has a matching exchange
+        for the |request|'s [=request/url=], then:
+        
+        1. Let |clonedExchange| be the result of creating a new [=exchange=]
+            with the matching exchange's [=exchange/request URL=] and the result
+            of [=response/cloning=] the matching exchange's
+            [=exchange/response=].
+
+        1. Move |clonedExchange| to the |request|'s
+            [=request/stashed exchange=].
+
+        1. Copy [=allowed-alt-sxg link=] of the exchange's
+            [=exchange/response=]'s inner response to
+            |allowed alternate subresource signed exchange links|.
+
+
+
+And before
+
+> 17. Run process a navigate response with navigationType, the source browsing
+>     context, and navigationParams.
+
+add the following steps:
+
+    19. Copy |sourceBrowsingContext|'s [=active document=]'s
+        [=document-obj/prefetched subresource singed exchanges=]
+        to navigationParams's
+        [=navigation params/prefetched subresource singed exchanges=].
+
+    20. Set navigationParams's
+        [=navigation params/allowed alternate subresource signed exchange links=]
+        to |allowed alternate subresource signed exchange links|.
+
+Note: As browsers move toward partitioned HTTP caches, the source document's
+    cache will likely be separate from the target's cache, so we can't just pass
+    prefetched content through the cache.
+
+
+<h3 algorithm id="mp-initialise-the-document-object">
+Monkeypatch Initialize a Document object</h3>
+In
+[initialize a Document object](https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object)
+before
+
+> 15. Return document.
+
+add the following steps:
+
+    15. Move the navigationParams's
+        [=navigation params/prefetched subresource singed exchanges=] to the
+        document's [=document-obj/transferred subresource singed exchanges=].
+
+    16. Set document's
+        [=document-obj/allowed alternate subresource signed exchange links=] to
+        navigationParams's
+        [=navigation params/allowed alternate subresource signed exchange links=].
 
 
 <h3 algorithm id="mp-link-type-preload">
 Monkeypatch Link type "preload"</h3>
 
 The navigated-to document has a set of preloads for which it uses the
-allowed-alt-sxg link relation to declare that they can be served by signed
+[=allowed-alt-sxg link=] relation to declare that they can be served by signed
 exchanges. The UA either serves all of them from SXGs prefetched by the previous
 page, or none of them.
-So in [processing](https://www.w3.org/TR/preload/#processing) of [Link type
-"preload"](https://www.w3.org/TR/preload/#link-type-preload) add the following
-step:
-    1. For each preload, use the imagesrcset and imagesizes attributes to pick a
-        single URL to preload.
-    1. Identify the subset |SxgPreloads| of those preloads with an
-        `allowed-alt-sxg` link for that selected URL.
-    1. If every member of |SxgPreloads| has a valid signed exchange that was
-        transferred from the referring document, use the signed contents of
-        those resources to satisfy the preloads. Ignore any other prefetched
-        signed exchanges.
-    1. Otherwise, ignore all prefetched signed exchanges and re-fetch the
-        preloads from their original URLs.
+So in the
+[linked resource fetch setup steps for preload type of linked resource](https://html.spec.whatwg.org/multipage/links.html#link-type-preload:linked-resource-fetch-setup-steps)
+before
+
+> 5. Return true.
+
+add the following steps:
+
+    5. If |el| is for the main resource's HTTP <a http-header>Link</a> header,
+        and the document's
+        [=document-obj/allowed alternate subresource signed exchange links=] 
+        has a matching link to |request|'s url, then run the following steps in
+        parallel:
+
+        1. Wait until there is no remaining preload Link header of the main
+            resource to be processed.
+
+        1. If every |el|'s in this step has a matching exchange in the 
+            document's [=document-obj/transferred subresource singed exchanges=],
+            set the |request|'s [=request/stashed exchange=] to the exchange.
+            
+        1. Return true.
 
 # Structures # {#structs}
 

--- a/loading.bs
+++ b/loading.bs
@@ -119,18 +119,13 @@ spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231#
 spec: RFC8288; urlPrefix: https://tools.ietf.org/html/rfc8288#
     type: dfn
         text: Target Attributes list; url: section-2.2
+        text: Link Target; url: section-3.1
+        text: Link Context; url: section-3.2
+        text: Relation Type; url: section-3.3
+        text: Target Attributes; url: section-3.4
+        text: Parsing a Link Field Value; url: appendix-B.2
     type: http-header
         text: Link; url: section-3
-    type: dfn
-        text: Link Target; url: section-3.1
-    type: dfn
-        text: Link Context; url: section-3.2
-    type: dfn
-        text: Relation Type; url: section-3.3
-    type: dfn
-        text: Target Attributes; url: section-3.4
-    type: dfn
-        text: Parsing a Link Field Value; url: appendix-B.2
 spec: RFC8446; urlPrefix: https://tools.ietf.org/html/draft-ietf-tls-tls13-28#
     text: ecdsa_secp256r1_sha256; type: dfn; url: section-4.2.3
 spec: draft-ietf-httpbis-variants; urlPrefix: https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html#
@@ -501,8 +496,7 @@ In the [=navigation params=], add the following items:
 
 </dl>
 
-<h3 algorithm id="mp-link-type-prefetch">
-Monkeypatch Link type "prefetch"</h3>
+<h3 algorithm id="mp-link-type-prefetch">Monkeypatch Link type "prefetch"</h3>
 
 The [=process the linked resource=] given a link element |el|, boolean
 |success|, and [=response=] |response|:
@@ -530,61 +524,22 @@ The [=process the linked resource=] given a link element |el|, boolean
 1. Let |innerLinks| be the result of [=Parsing a Link Field Value=] from
     |innerLinkHeader|.
 1. If |innerLinks| is empty, then return.
-1. Let |alternateLinks| be an empty [=list=].
-1. For each |outerLink| of |outerLinks|:
-    1. If |outerLink|'s [=Relation Type=] is not 'alternate', then continue.
-    1. If |outerLink|'s [=Target Attributes list|Target Attributes=] doesn't
-        [=list/contain=] (`"type"`,`"application/signed-exchange"`), then
-        continue.
-    1. Let |linkTarget| be |outerLink|'s [=Link Target=].
-    1. Let |linkContext| be |outerLink|'s [=Link Context=].
-    1. Let |outerLinkVariants| be the second item of the first tuple of
-        |outerLink|'s [=Target Attributes list|Target Attributes=] whose first
-        item matches the string `"variants"` or the empty string ("") if it is
-        not present.
-    1. Let |outerLinkVariantKey| be the second item of the first tuple of
-        |outerLink|'s [=Target Attributes list|Target Attributes=] whose first
-        item matches the string `"variant-key"` or the empty string ("") if it
-        is not present.
-    1. [=list/Append=] (|linkTarget|, |outerLinkVariants|,
-        |outerLinkVariantKey|, |linkContext|) to |alternateLinks|.
-1. Let |allowedSxgLinks| be an empty [=list=].
-1. For each |innerLink| of |innerLinks|:
-    1. If |innerLink|'s [=Relation Type=] is not 'allowed-alt-sxg', then
-        continue.
-    1. Let |linkTarget| be |innerLink|'s [=Link Target=].
-    1. Let |innerLinkVariants| be the second item of the first tuple of
-        |innerLink|'s [=Target Attributes list|Target Attributes=] whose first
-        item matches the string `"variants"` or the empty string ("") if it is
-        not present.
-    1. Let |innerLinkVariantKey| be the second item of the first tuple of
-        |innerLink|'s [=Target Attributes list|Target Attributes=] whose first
-        item matches the string `"variant-key"` or the empty string ("") if it
-        is not present.
-    1. Let |headerIntegrity| be the second item of the first tuple of
-        |innerLink|'s [=Target Attributes list|Target Attributes=] whose first
-        item matches the string `"header-integrity"` or continue if it is not
-        present.
-    1. [=list/Append=] (|linkTarget|, |innerLinkVariants|,
-        |innerLinkVariantKey|, |headerIntegrity|) to |allowedSxgLinks|.
+1. Let |alternateLinks| be the result of [=getting alternate signed exchange
+    link info=] from |outerLinks|.
+1. Let |allowedSxgLinks| be the result of [=getting allowed signed exchange link
+    info=] from |innerLink|.
 1. For each |innerLink| of |innerLinks|:
     1. If |innerLink|'s [=Relation Type=] is not 'preload', then continue.
     1. Let |linkTarget| be |innerLink|'s [=Link Target=].
-    1. Let |asAttribute| be the second item of the first tuple of |innerLink|'s
-        [=Target Attributes list|Target Attributes=] whose first item matches
-        the string `"as"` or the empty string ("") if it is not present.
+    1. Let |asAttribute| be |innerLink|'s [=Target Attribute named=] `"as"`.
     1. If |asAttribute| is `"image"`, then:
-        1. Let |imagesrcset| be the second item of the first tuple of
-            |innerLink|'s [=Target Attributes list|Target Attributes=] whose
-            first item matches the string `"imagesrcset"` or the empty string
-            ("") if it is not present.
-        1. Let |imagesizes| be the second item of the first tuple of
-            |innerLink|'s [=Target Attributes list|Target Attributes=] whose
-            first item matches the string `"imagesizes"` or the empty string
-            ("") if it is not present.
-        1. Create a <{link}> element |linkElement| which <{link/href}> attribute
+        1. Let |imagesrcset| be |innerLink|'s [=Target Attribute named=]
+            `"imagesrcset"`.
+        1. Let |imagesizes| be |innerLink|'s [=Target Attribute named=]
+            `"imagesizes"`.
+        1. Create a <{link}> element |linkElement| whose <{link/href}> attribute
             is |linkTarget|, and <{link/imagesrcset}> attribute is
-            |imagesrcset|, and <{link/imagesizes}> is |imagesizes|.
+            |imagesrcset|, and <{link/imagesizes}> attribute is |imagesizes|.
         1. Let |selected source| and <var ignore=''>selected pixel density</var>
             be the URL and pixel density that results from [=selecting an image
             source=] given |linkElement|, respectively.
@@ -592,25 +547,32 @@ The [=process the linked resource=] given a link element |el|, boolean
             of [=URL parser|parsing=] |selected source|, with a base URL of
             |response|'s [=response/URL=].
     1. For each |allowedSxgLink| of |allowedSxgLinks|:
-        1. If the first element isn't the same as |linkTarget|, then continue.
-        1. Let |innerLinkVariants| be the second item of |allowedSxgLink|.
-        1. Let |innerLinkVariantKey| be the third item of |allowedSxgLink|.
+        1. If |allowedSxgLink|'s [=allowed signed exchange link info/target=]
+            isn't the same as |linkTarget|, then continue.
         1. Let |storedExchange| be the result of creating an [=exchange=] with
-            the URL of |linkTarget| and a new [=response=].
-        1. If |innerLinkVariants| is not the empty string (""), [=header
-            list/set=] `` `Variants` ``/|innerLinkVariants| in
-            |storedExchange|'s [=exchange/response=]'s [=response/header list=].
-        1. If |innerLinkVariantKey| is not the empty string (""), [=header
-            list/set=] `` `Variant-Key` ``/|innerLinkVariantKey| in
-            |storedExchange|'s [=exchange/response=]'s [=response/header list=].
+            |linkTarget| and a new [=response=].
+        1. If |allowedSxgLink|'s [=allowed signed exchange link info/variants=]
+            is not null, [=header list/set=] `` `Variants` ``/|allowedSxgLink|'s
+            [=allowed signed exchange link info/variants=] in |storedExchange|'s
+            [=exchange/response=]'s [=response/header list=].
+        1. If |allowedSxgLink|'s [=allowed signed exchange link info/variant
+            key=] is not null, [=header list/set=] `` `Variant-Key`
+            ``/|allowedSxgLink|'s [=allowed signed exchange link info/variant
+            key=] in |storedExchange|'s [=exchange/response=]'s
+            [=response/header list=].
         1. Let |requestForMatch| be the result of [=creating a potential-CORS
             request=] given |linkTarget|, the empty string, and [=No CORS=].
         1. If |requestForMatch| doesn't [=matches the stored exchange=]
             |storedExchange|, then continue.
-        1. Let |alternateSxgUrl| be the first item of the first tuple of
-            |alternateLinks| whose second item matches |innerLinkVariants| and
-            whose third item matches |innerLinkVariantKey| and whose fourth item
-            matches |linkTarget| or continue if it is not present.
+        1. Let |alternateSxgUrl| be [=alternate signed exchange link
+            info/target=] of the first [=alternate signed exchange link info=]
+            of |alternateLinks| whose [=alternate signed exchange link
+            info/variants=] matches |allowedSxgLink|'s [=allowed signed exchange
+            link info/variants=] and whose [=alternate signed exchange link
+            info/variant key=] matches |allowedSxgLink|'s [=allowed signed
+            exchange link info/variant key=] and whose [=alternate signed
+            exchange link info/context=] matches |linkTarget| or continue if it
+            is not present.
         1. Let |sxgRequest| be the result of [=creating a potential-CORS
             request=] given |alternateSxgUrl|, the empty string, and [=No
             CORS=].
@@ -688,48 +650,24 @@ add the following steps:
         1. If |linkHeader| is null, then return.
         1. Let |links| be the result of [=Parsing a Link Field Value=] from
             |linkHeader|.
-        1. Let |allowedSxgLinks| be an empty [=list=].
-        1. For each |link| of |links|:
-            1. If |link|'s [=Relation Type=] is not 'allowed-alt-sxg', then
-                continue.
-            1. Let |linkTarget| be |link|'s [=Link Target=].
-            1. Let |linkVariants| be the second item of the first tuple of
-                |link|'s [=Target Attributes list|Target Attributes=] whose
-                first item matches the string `"variants"` or the empty string
-                ("") if it is not present.
-            1. Let |linkVariantKey| be the second item of the first tuple of
-                |link|'s [=Target Attributes list|Target Attributes=] whose
-                first item matches the string `"variant-key"` or the empty
-                string ("") if it is not present.
-            1. Let |headerIntegrity| be the second item of the first tuple of
-                |link|'s [=Target Attributes list|Target Attributes=] whose
-                first item matches the string `"header-integrity"` or continue
-                if it is not present.
-            1. [=list/Append=] (|linkTarget|, |linkVariants|, |linkVariantKey|,
-                |headerIntegrity|) to |allowedSxgLinks|.
+        1. Let |allowedSxgLinks| be the result of [=getting allowed signed
+            exchange link info=] from |links|.
         1. Let |preloadLinkItems| be an empty [=list=].
         1. Let |canLoadAlternateSxg| be true. 
         1. For each |link| of |links|:
             1. If |link|'s [=Relation Type=] is not 'preload', then continue.
             1. Let |linkTarget| be |link|'s [=Link Target=].
-            1. Let |asAttribute| be the second item of the first tuple of
-                |link|'s [=Target Attributes list|Target Attributes=] whose
-                first item matches the string `"as"` or the empty string ("") if
-                it is not present.
-            1. If |asAttribute| is an empty string, then continue.
+            1. Let |asAttribute| be |link|'s [=Target Attribute named=] `"as"`.
+            1. If |asAttribute| is null, then continue.
             1. If |asAttribute| is `"image"`, then:
-                1. Let |imagesrcset| be the second item of the first tuple of
-                    |link|'s [=Target Attributes list|Target Attributes=] whose
-                    first item matches the string `"imagesrcset"` or the empty
-                    string ("") if it is not present.
-                1. Let |imagesizes| be the second item of the first tuple of
-                    |link|'s [=Target Attributes list|Target Attributes=] whose
-                    first item matches the string `"imagesizes"` or the empty
-                    string ("") if it is not present.
-                1. Create a <{link}> element |linkElement| which <{link/href}>
+                1. Let |imagesrcset| be |link|'s [=Target Attribute named=]
+                    `"imagesrcset"`.
+                1. Let |imagesizes| be |link|'s [=Target Attribute named=]
+                    `"imagesizes"`.
+                1. Create a <{link}> element |linkElement| whose <{link/href}>
                     attribute is |linkTarget|, and <{link/imagesrcset}>
-                    attribute is |imagesrcset|, and <{link/imagesizes}> is
-                    |imagesizes|.
+                    attribute is |imagesrcset|, and <{link/imagesizes}>
+                    attribute is |imagesizes|.
                 1. Let |selected source| and <var ignore=''>selected pixel
                     density</var> be the URL and pixel density that results from
                     [=selecting an image source=] given |linkElement|,
@@ -738,75 +676,75 @@ add the following steps:
                     the result of [=URL parser|parsing=] |selected source|, with
                     a base URL of |navigationParams|'s [=navigation
                     params/response=]'s [=response/URL=].
-            1. Let |headerIntegrity| be an empty string.
+            1. Let |headerIntegrity| be null.
             1. For each |allowedSxgLink| of |allowedSxgLinks|:
-                1. If the first element isn't the same as |linkTarget|, then
-                    continue.
-                1. Let |innerLinkVariants| be the second item of
-                    |allowedSxgLink|.
-                1. Let |innerLinkVariantKey| be the third item of
-                    |allowedSxgLink|.
                 1. Let |storedExchange| be the result of creating an
-                    [=exchange=] with the URL of |linkTarget| and a new
-                    [=response=].
-                1. If |innerLinkVariants| is not the empty string (""), [=header
-                    list/set=] `` `Variants` ``/|innerLinkVariants| in
-                    |storedExchange|'s [=exchange/response=]'s [=response/header
-                    list=].
-                1. If |innerLinkVariantKey| is not the empty string (""),
-                    [=header list/set=] `` `Variant-Key`
-                    ``/|innerLinkVariantKey| in |storedExchange|'s
+                    [=exchange=] with the URL of |allowedSxgLink|'s [=allowed
+                    signed exchange link info/target=] and a new [=response=].
+                1. If |allowedSxgLink|'s [=allowed signed exchange link
+                    info/variants=] is null, [=header list/set=] `` `Variants`
+                    ``/|allowedSxgLink|'s [=allowed signed exchange link
+                    info/variants=] in |storedExchange|'s
+                    [=exchange/response=]'s [=response/header list=].
+                1. If |allowedSxgLink|'s [=allowed signed exchange link
+                    info/variant key=] is not null, [=header list/set=] ``
+                    `Variant-Key` ``/|allowedSxgLink|'s [=allowed signed
+                    exchange link info/variant key=] in |storedExchange|'s
                     [=exchange/response=]'s [=response/header list=].
                 1. Let |requestForMatch| be the result of [=creating a
-                    potential-CORS request=] given |linkTarget|, the empty
-                    string, and [=No CORS=].
+                    potential-CORS request=] given |allowedSxgLink|'s [=allowed
+                    signed exchange link info/target=], the empty string, and
+                    [=No CORS=].
                 1. If |requestForMatch| doesn't [=matches the stored exchange=]
                     |storedExchange|, then continue.
-                1. Set |headerIntegrity| to the fourth item of |allowedSxgLink|.
-            1. Let |alternateSXG| be null.
+                1. Set |headerIntegrity| to |allowedSxgLink|'s [=allowed signed
+                    exchange link info/header integrity=].
+            1. Let |prefetched alternate exchange| be null.
             1. For each |sxg| of |navigationParams|'s [=navigation
                 params/prefetched subresource signed exchanges=]:
                 1. If |headerIntegrity| is the same as the value of |sxg|'s
                     [=exchange/response=]'s [=response/header integrity value=]
                     encoded as a [[CSP]] <a grammar>hash-source</a>, then set
-                    |alternateSXG| to |sxg|.
-            1. If |headerIntegrity| is not an empty string and |alternateSXG| is
-                null, then set |canLoadAlternateSxg| to false.
-            1. [=list/Append=] (|link|, |linkTarget|, |headerIntegrity|,
-                |alternateSXG|) to |preloadLinkItems|.
+                    |prefetched alternate exchange| to |sxg|.
+            1. If |headerIntegrity| is not null and |prefetched alternate
+                exchange| is null, then set |canLoadAlternateSxg| to false.
+                
+                Note: This means that there is a matching
+                <{link/rel/allowed-alt-sxg}> link for the <{link/rel/preload}>
+                |link|, but the matching signed exchange has not been
+                prefetched. In this case the UA MUST NOT use the prefetched
+                subresource signed exchanges for other  <{link/rel/preload}>
+                links. This is intended to prevent the referrer page from
+                encoding a tracking ID into the set of subresources it
+                prefetches.
+            1. [=list/Append=] the [=alternate signed exchange peload info=]
+                (|link|, |linkTarget|, |prefetched alternate exchange|) to
+                |preloadLinkItems|.
         1. For each |preloadLinkItem| of |preloadLinkItems|:
-            1. Let |link| be the first item of |preloadLinkItem|.
-            1. Let |linkTarget| be the second item of |preloadLinkItem|.
-            1. Let |headerIntegrity| be the third item of |preloadLinkItem|.
-            1. Let |alternateSXG| be the fourth item of |preloadLinkItem|.
-            1. Let |corsAttribute| be the [=CORS settings attribute=] of the
-                second item of the first tuple of |link|'s [=Target Attributes
-                list|Target Attributes=] whose first item matches the string
-                `"crossorigin"` or [=No CORS=] if it is not present.
+            1. Let |corsAttribute| be the [=CORS settings attribute=] of
+                |preloadLinkItem|'s [=alternate signed exchange peload
+                info/link=]'s [=Target Attribute named=] `"crossorigin"`.
             1. Let |request| be the result of [=creating a potential-CORS
-                request=] given |linkTarget|, the empty string, and
-                |corsAttribute|.
+                request=] given |preloadLinkItem|'s [=alternate signed exchange
+                peload info/target=], the empty string, and |corsAttribute|.
             1. Set |request|'s [=request/synchronous flag=].
             1. Set |request|'s [=request/client=] to |document|.
-            1. Set |request|'s [=request/cryptographic nonce metadata=] to be
-                the second item of the first tuple of |link|'s [=Target
-                Attributes list|Target Attributes=] whose first item matches the
-                string `"nonce"` if it is present.
-            1. Set |request|'s [=request/integrity metadata=] to be the second
-                item of the first tuple of |link|'s [=Target Attributes
-                list|Target Attributes=] whose first item matches the string
-                `"integrity"` if it is present.
+            1. Set |request|'s [=request/cryptographic nonce metadata=] to
+                |preloadLinkItem|'s [=alternate signed exchange peload
+                info/link=]'s [=Target Attribute named=] `"nonce"`.
+            1. Set |request|'s [=request/integrity metadata=] to
+                |preloadLinkItem|'s [=alternate signed exchange peload
+                info/link=]'s [=Target Attribute named=] `"integrity"`.
             1. Set |request|'s [=request/referrer policy=] to be the [=referrer
-                policy attribute=] of second item of the first tuple of |link|'s
-                [=Target Attributes list|Target Attributes=] whose first item
-                matches the string `"referrerpolicy"` if it is present.
-            1. Set |request|'s [=request/destination=] to the second item of the
-                first tuple of |link|'s [=Target Attributes list|Target
-                Attributes=] whose first item matches the string `"as"` or the
-                empty string ("") if it is not present.
-            1. If |canLoadAlternateSxg| is true and |alternateSXG| is not null,
-                then set |request|'s [=request/stashed exchange=] to
-                |alternateSXG|.
+                policy attribute=] of |preloadLinkItem|'s [=alternate signed
+                exchange peload info/link=]'s [=Target Attribute named=]
+                `"referrerpolicy"`.
+            1. Set |request|'s [=request/destination=] to |preloadLinkItem|'s
+                [=alternate signed exchange peload info/link=]'s [=Target
+                Attribute named=] `"as"`.
+            1. If |canLoadAlternateSxg| is true, then set |request|'s
+                [=request/stashed exchange=] to |preloadLinkItem|'s [=alternate
+                signed exchange peload info/prefetched alternate exchange=].
             1. [=Fetch=] |request| in parallel.
 
 Issue(whatwg/html#4224): Currently the processing model of the HTTP <a
@@ -935,6 +873,61 @@ An exchange signature is a [=struct=] with the following items:
 :: The POSIX time at which the signature stops being valid.
 
 </dl>
+
+<h3 dfn-type=dfn export>Allowed signed exchange link info</h3>
+
+An allowed signed exchange link info is a [=struct=] with the following items:
+
+<dl dfn-for="allowed signed exchange link info">
+: <dfn>target</dfn>
+:: A [=Link Target=] of the link.
+: <dfn>header integrity</dfn>
+:: A [=string=] holding the value of the link's of [=Target Attributes
+    list|Target Attribute=] named `"header-integrity"`.
+: <dfn>variants</dfn>
+:: A [=string=] holding the value of the link's of [=Target Attributes
+    list|Target Attribute=] named `"variants"`, or null.
+: <dfn>variant key</dfn>
+:: A [=string=] holding the value of the link's of [=Target Attributes
+    list|Target Attribute=] named `"varivariant keyants"`, or null.
+
+</dl>
+
+<h3 dfn-type=dfn export>Alternate signed exchange link info</h3>
+
+An alternate signed exchange link info is a [=struct=] with the following items:
+
+<dl dfn-for="alternate signed exchange link info">
+: <dfn>target</dfn>
+:: A [=Link Target=] of the link.
+: <dfn>context</dfn>
+:: A [=string=] holding the value of the link's of [=Link Context=].
+: <dfn>variants</dfn>
+:: A [=string=] holding the value of the link's of [=Target Attributes
+    list|Target Attribute=] named `"variants"`, or null.
+: <dfn>variant key</dfn>
+:: A [=string=] holding the value of the link's of [=Target Attributes
+    list|Target Attribute=] named `"varivariant keyants"`, or null.
+
+</dl>
+
+<h3 dfn-type=dfn export>Alternate signed exchange peload info</h3>
+
+An alternate signed exchange peload info is a [=struct=] with the following items:
+
+<dl dfn-for="alternate signed exchange peload info">
+: <dfn>link</dfn>
+:: A link object [=Parsing a Link Field Value|parsed=] from a HTTP <a
+    http-header>Link</a> header.
+: <dfn>target</dfn>
+:: A URL to be preloaded. <span class="note">This MAY be different from
+    [=alternate signed exchange peload info/link=]'s [=Link Target=], when
+    `"imagesrcset"` is used for image preload.</span>
+: <dfn>prefetched alternate exchange</dfn>
+:: A [=exchange=] of the prefetched [=alternate signed exchange=], or null.
+
+</dl>
+
 
 # Algorithms # {#algorithms}
 
@@ -1770,6 +1763,59 @@ To <dfn for="read buffer">Dump</dfn> a [=read buffer=] |input| to a
         :: [=ReadableStream/Error=] |output| with reason |e|.
 
         </dl>
+
+<h4 algorithm id="dump-value-of-target-attributes">Get value of [=Target
+Attributes list|Target Attributes=]</h4>
+
+A link header value |link|'s <dfn noexport>Target Attribute named</dfn> |name|
+is the second item of the first tuple of |link|'s [=Target Attributes
+list|Target Attributes=] whose first item matches the string |name|, or null if
+no such tuple is present.
+
+
+<h4 algorithm id="get-allowed-signed-exchange-links">Get allowed signed exchange
+link info</h4>
+
+The result of <dfn>getting allowed signed exchange link info</dfn> from a
+[=list=] |links| is returned by the following steps:
+
+1. Let |allowedSxgLinks| be an empty [=list=].
+1. For each |link| of |links|:
+    1. If |link|'s [=Relation Type=] is not 'allowed-alt-sxg', then continue.
+    1. Let |linkTarget| be |link|'s [=Link Target=].
+    1. Let |headerIntegrity| be |link|'s [=Target Attribute named=]
+        `"header-integrity"`.
+    1. If |headerIntegrity| is null, then continue.
+    1. Let |linkVariants| be |link|'s [=Target Attribute named=] `"variants"`.
+    1. Let |linkVariantKey| be |link|'s [=Target Attribute named=]
+        `"variant-key"`.
+    1. [=list/Append=] the [=allowed signed exchange link info=] (|linkTarget|,
+        |headerIntegrity|, |linkVariants|, |linkVariantKey|) to
+        |allowedSxgLinks|.
+1. Return |allowedSxgLinks|.
+
+<h4 algorithm id="get-alternate-signed-exchange-links">Get alternate signed 
+exchange link info</h4>
+
+The result of <dfn>getting alternate signed exchange link info</dfn> from a
+[=list=] |links| is returned by the following steps:
+
+1. Let |alternateSxgLinks| be an empty [=list=].
+1. For each |link| of |links|:
+    1. If |link|'s [=Relation Type=] is not 'alternate', then continue.
+    1. If |link|'s [=Target Attributes list|Target Attributes=] doesn't
+        [=list/contain=] (`"type"`,`"application/signed-exchange"`), then
+        continue.
+    1. Let |linkTarget| be |link|'s [=Link Target=].
+    1. Let |linkContext| be |link|'s [=Link Context=].
+    1. Let |linkVariants| be |link|'s [=Target Attribute named=] `"variants"`.
+    1. Let |linkVariantKey| be |link|'s [=Target Attribute named=]
+        `"variant-key"`.
+    1. [=list/Append=] the [=alternate signed exchange link info=]
+        (|linkTarget|, |linkContext|, |linkVariants|, |linkVariantKey|) to
+        |alternateSxgLinks|.
+1. Return |alternateSxgLinks|.
+
 
 # Security Considerations # {#seccons}
 

--- a/loading.bs
+++ b/loading.bs
@@ -156,11 +156,16 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
         for: link/rel; text: alternate; url: links.html#rel-alternate
         for: link/rel; text: prefetch; url: links.html#link-type-prefetch
         for: link/rel; text: preload; url: links.html#link-type-preload
+    type: element-attr;
+        for: link; text: crossorigin; url: semantics.html#attr-link-crossorigin
+        for: link; text: href; url: semantics.html#attr-link-href
     type: dfn;
         text: appropriate time; url: semantics.html#processing-the-type-attribute
         text: fetch and process the linked resource; url: semantics.html#fetch-and-process-the-linked-resource
         text: navigation params; url: browsing-the-web.html#navigation-params
         text: process the linked resource; url: semantics.html#process-the-linked-resource
+        text: creating a potential-cors request; url: urls-and-fetching.html#create-a-potential-cors-request
+        text: linked resource fetch setup steps; url: semantics.html#linked-resource-fetch-setup-steps
 spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf
     type: dfn
         text: SHA-256; url: #
@@ -168,6 +173,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
 <pre class='link-defaults'>
 spec:fetch; type:dfn; for:/; text:response
 spec:streams; type:interface; text:ReadableStream
+spec:html; type:element; text:link
 </pre>
 
 <section class="non-normative">
@@ -410,17 +416,23 @@ satisfy the `https://cdn.publisher.example/lib.js` `<script>` element.
 
 </div>
 
+* The <{Link}> element.
+
+    The <dfn element-attr for="link">variants</dfn> parameter may be present.
+
+    The <dfn element-attr for="link">variant-key</dfn> parameter may be
+        present.
+
 * Link type "<dfn attr-value for="link/rel">allowed-alt-sxg</dfn>"
 
-    The <{link/rel/allowed-alt-sxg}> keyword may be used in the HTTP
-    <a http-header>Link</a> header of the inner HTTP response of the main
-    resource signed exchange to indicate that the content of the [=Link Target=]
-    is also available as a particular signed exchange identified by the
-    <{link/header-integrity}> parameter.
-    The <dfn element-attr for="link">header-integrity</dfn> parameter holds the
-    value of the [=response/header integrity value=] of the
-    [=alternate signed exchange=], encoded as a [[CSP]]
-    <a grammar>hash-source</a>.
+    The <{link/rel/allowed-alt-sxg}> keyword may be used in the HTTP <a
+    http-header>Link</a> header of the inner HTTP response of the main resource
+    signed exchange to indicate that the content of the [=Link Target=] is also
+    available as a particular signed exchange identified by the
+    <{link/header-integrity}> parameter. The <dfn element-attr
+    for="link">header-integrity</dfn> parameter holds the value of the
+    [=response/header integrity value=] of the [=alternate signed exchange=],
+    encoded as a [[CSP]] <a grammar>hash-source</a>. 
 * An <dfn>alternate signed exchange link</dfn> is a `` `Link` `` header sent
     with a signed exchange |S|, with the <{link/rel/alternate}> link type, the
     `type` parameter set to `application/signed-exchange`, and a [=Link
@@ -433,40 +445,49 @@ satisfy the `https://cdn.publisher.example/lib.js` `<script>` element.
 
 
 The [=appropriate time=] to [=fetch and process the linked resource=] for an
-is when the following steps return true:
+[=alternate signed exchange link=] is when the following steps return true:
 
 <ol algorithm="appropriate time for an alternate signed exchange link">
 
 1. Let |R| be the [=response=] created from the signed exchange in the response
     that held the [=alternate signed exchange link=].
-1. Let |L| be the set of <{link/rel/preload}> <a http-header>Link</a> HTTP
-    headers on |R| whose [=Link Target=] is the same as the [=alternate signed
-    exchange link=]'s [=Link Context=].
+1. Let |L| be the set of <{link/rel/allowed-alt-sxg}> <a http-header>Link</a>
+    HTTP headers on |R| whose [=Link Target=] is the same as the [=alternate
+    signed exchange link=]'s [=Link Context=] and whose <{link/variants}>
+    parameter and <{link/variant-key}> parameter are the same as the [=alternate
+    signed exchange link=]'s parameters if they are present.
 1. If |L| is empty, return false.
-1. Let |allowedSxgs| be the set of <{link/rel/allowed-alt-sxg}> <a
-    http-header>Link</a> HTTP headers on |R| that "match" (TODO, maybe use
-    [[draft-ietf-httpbis-variants]] here) any header in |L|.
-1. If |allowedSxgs| is empty, return false.
-1. Return true.
+1. Let |preload links| be the set of <{link/rel/allowed-alt-sxg}> <a
+    http-header>Link</a> HTTP headers on |R|.
+1. For each |preload link| in |preload links|:
+    1. Let |el| be a semantically equivalent link element to |preload link|.
+    1. If |el|'s <{link/href}> attribute's value is the empty string, then
+        continue.
+    1. Let |url| be the result of applying the [=URL parser=] to |el|'s
+        <{link/href}> attribute's value, with |R|'s [=response/URL=].
+    1. Let |corsAttributeState| be the current state of the |el|'s
+        <{link/crossorigin}> content attribute.
+    1. Let |request| be the result of [=creating a potential-CORS request=]
+        given |url|, the empty string, and |corsAttributeState|.
+    1. Run the [=linked resource fetch setup steps=], given |el| and |request|.
+        If the result is false, then continue.
+    1. If |request|'s [=request/URL=] is same as the same as the [=alternate
+        signed exchange link=]'s [=Link Context=], return true.
+1. Return false.
 
 </ol>
 
 <div algorithm="process the alternate signed exchange linked resource">
 
 The [=process the linked resource=] steps for an [=alternate signed exchange
-link=] , given the Link header |header|, boolean |success|, and [=response=]
-|response|:
+link=] , given boolean |success|, and [=response=] |response|:
 
-1. Do something when |success| is false.
-1. If the |response| [=response/came from a signed exchange=] and the
-    |response|'s [=response/header integrity value=] matches the
-    `header-integrity` parameter of the <{link/rel/allowed-alt-sxg}> link (TODO:
-    find a way to attach the <{link/rel/allowed-alt-sxg}> header to the fetch
-    for |header|), create an [=exchange=] with the URL of the
-    <{link/rel/allowed-alt-sxg}> link's [=Link Target=] URL and the result of
-    [=response/cloning=] the inner response of the [=alternate signed
-    exchange=], and store the exchange to the [=Document/prefetched subresource
-    signed exchanges=] of the document.
+1. If |success| is false, return.
+1. If the |response| [=response/came from a signed exchange=], create an
+    [=exchange=] with the URL of the <{link/rel/allowed-alt-sxg}> link's [=Link
+    Target=] URL and the result of [=response/cloning=] the inner response of
+    the [=alternate signed exchange=], and store the exchange to the
+    [=Document/prefetched subresource signed exchanges=] of the document.
 
 </div>
 
@@ -608,18 +629,37 @@ before
 
 add the following steps:
 
-    5. If |el| is for the main resource's HTTP <a http-header>Link</a> header,
-        and the document's
-        [=Document/allowed alternate subresource signed exchange links=] has a
-        matching link to |request|'s url, then run the following steps in
-        parallel:
+    1. If |el| is for the main resource's HTTP <a http-header>Link</a> header,
+        then:
 
-        1. Wait until there is no remaining preload Link header of the main
-            resource to be processed.
+        1.  For each |allowedAltSxgLink| in [=Document/allowed alternate subresource signed exchange links=]:
 
-        1. If every |el|'s in this step has a matching exchange in the
-            document's [=Document/transferred subresource signed exchanges=],
-            set the |request|'s [=request/stashed exchange=] to the exchange.
+            1. Let |storedExchange| be the result of creating an [=exchange=]
+                with the URL of the |allowedAltSxgLink| link's [=Link Target=]
+                URL and a new [=response=].
+                
+            1. If |allowedAltSxgLink| has <{link/variants}> parameter,
+                [=header list/set=] `` `Variants` ``/|allowedAltSxgLink|'s
+                <{link/variants}> in |storedExchange|'s [=exchange/response=]'s
+                [=response/header list=].
+                
+            1. If |allowedAltSxgLink| has <{link/variant-key}> parameter,
+                [=header list/set=] `` `Variant-Key` ``/|allowedAltSxgLink|'s
+                <{link/variant-key}> in |storedExchange|'s [=exchange/response=]'s
+                [=response/header list=].
+
+
+            1. If |request| [=matches the stored exchange=] |storedExchange|,
+                then run the following steps in parallel:
+
+                1. Wait until there is no remaining preload Link header of the main
+                    resource to be processed.
+
+                1. If every |el|'s in this step has a matching exchange in the
+                    document's [=Document/transferred subresource signed exchanges=],
+                    set the |request|'s [=request/stashed exchange=] to the exchange.
+
+                1. Return true.
 
         1. Return true.
 


### PR DESCRIPTION
I'd like to update the "Loading Signed Exchanges" spec to support Signed Exchange subresource substitution.
The logic is copied from "Algorithm sketch" section of the explainer of [Signed Exchange subresource substitution](https://github.com/WICG/webpackage/blob/master/explainers/signed-exchange-subresource-subtitution-explainer.md#algorithm-sketch).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/horo-t/webpackage/pull/591.html" title="Last updated on Sep 4, 2020, 12:29 AM UTC (8466393)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webpackage/591/7d82584...horo-t:8466393.html" title="Last updated on Sep 4, 2020, 12:29 AM UTC (8466393)">Diff</a>