### PR TITLE
Use the header-integrity of the first matching allowed-alt-sxg link.

### DIFF
--- a/loading.bs
+++ b/loading.bs
@@ -751,10 +751,11 @@ add the following steps:
                 [=allowed signed exchange link info/target=], a destination of
                 the result of [=destination/translating=] |asAttribute|, and a
                 corsAttributeState of [=No CORS=].
-            1. If |requestForMatch| [=doesn't match the stored exchange=]
-                |storedExchange|, then continue.
-            1. Set |headerIntegrity| to |allowedSxgLink|'s [=allowed signed
-                exchange link info/header integrity=].
+            1. If |requestForMatch| [=matches the stored exchange=]
+                |storedExchange|, then:
+                1. Set |headerIntegrity| to |allowedSxgLink|'s [=allowed signed
+                    exchange link info/header integrity=].
+                1. Break out of the |allowedSxgLinks| loop.
         1. Let |prefetched alternate exchange| be null.
         1. For each |sxg| of |navigationParams|'s [=navigation
             params/prefetched subresource signed exchanges=]:


### PR DESCRIPTION
Instead of the last.

Based on https://github.com/WICG/webpackage/pull/591#discussion_r484225955, I believe this more accurately describes the implemented behavior.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/webpackage/pull/598.html" title="Last updated on Sep 10, 2020, 6:44 PM UTC (12ea1bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webpackage/598/bfd1640...jyasskin:12ea1bd.html" title="Last updated on Sep 10, 2020, 6:44 PM UTC (12ea1bd)">Diff</a>