### PR TITLE
Remove use of Request's synchronous flag.

### DIFF
--- a/loading.bs
+++ b/loading.bs
@@ -790,7 +790,6 @@ add the following steps:
             preload info/target=], a destination of the result of
             [=destination/translating=] |asAttribute|, and a corsAttributeState
             of |corsAttributeState|.
-        1. Set |request|'s [=request/synchronous flag=].
         1. Set |request|'s [=request/client=] to |document|.
         1. Set |request|'s [=request/cryptographic nonce metadata=] to
             |preloadLinkItem|'s [=alternate signed exchange preload


### PR DESCRIPTION
whatwg/fetch#1165 removed the flag.

Since this algorithm runs the requests in parallel anyway, I think we never needed to set the synchronous flag?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/webpackage/pull/628.html" title="Last updated on Feb 24, 2021, 12:04 AM UTC (d9e967c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webpackage/628/d3e87eb...jyasskin:d9e967c.html" title="Last updated on Feb 24, 2021, 12:04 AM UTC (d9e967c)">Diff</a>