### PR TITLE
Check the bundle URL for CSP while loading urn:uuid resources

### DIFF
--- a/explainers/subresource-loading-opaque-origin-iframes.md
+++ b/explainers/subresource-loading-opaque-origin-iframes.md
@@ -101,7 +101,12 @@ Note:
   allowed when "\*" is set in the CSP
   [source expression](https://w3c.github.io/webappsec-csp/#source-expression).
   This is different from the CSP behavior that `data:` and `blob:` schemes are
-  excluded from matching a policy of "\*".
+  excluded from matching a policy of "\*". Loading `urn:uuid` resources from web
+  bundles is safer than using `data:` or `blob:` URL resources which are
+  directly under the control of the page, because a urn:uuid resource is a
+  reference to a component of something with a globally-accessible URL. So we
+  don't need to exclude `urn:uuid` resources in a web bundle from matching the
+  policy of "\*".
 - See an issue [#651](https://github.com/WICG/webpackage/issues/651) for the
   detailed motivation.  
 

--- a/explainers/subresource-loading-opaque-origin-iframes.md
+++ b/explainers/subresource-loading-opaque-origin-iframes.md
@@ -1,6 +1,6 @@
 # Subresource loading with Web Bundles: Support opaque origin iframes
 
-Last updated: Apr 2021
+Last updated: May 2021
 
 This is an extension to [Subresource loading with Web Bundles]. This extension
 allows a bundle to include `urn:uuid:` URL resources, which will be used to
@@ -65,36 +65,43 @@ Note:
   also used for `urn:uuid:` resources. For example, `scopes=urn:` allows all
   `urn:` resources.
 
-### Content Security Policy (CSP)
+### Content Security Policy (CSP) for `urn:uuid` resources
 
-To allow `urn:uuid` resources in CSP, the `urn:` scheme must be explicitly
-specified. "`*`" source expression does not match `urn:uuid` resources according
-to the CSP's
-[matching rule](https://w3c.github.io/webappsec-csp/#match-url-to-source-expression).
+Using the `urn:uuid` URLs in CSP's
+[matching rule](https://w3c.github.io/webappsec-csp/#match-url-to-source-expression)
+is almost useless from a security standpoint, because anyone can use arbitrary
+`urn:uuid` URLs.
+So the CSP restrictions must be evaluated against the source of the bundle
+instead of to the `urn:uuid` URL.
 
 For example, given this CSP header,
 
 ```
-Content-Security-Policy: script-src https://example.com/script/ urn:; frame-src *
+Content-Security-Policy: script-src https://cdn.example; frame-src https://cdn.example
 ```
 
-In the following, the first and third `<script>` will be loaded, and the second
-`<script>` and the `<iframe>` will be blocked:
+the page can load `urn:uuid` resources in web bundles served from
+`https://cdn.example`.
 
 ```
 <link rel="webbundle"
-  href="https://example.com/subresources.wbn"
-  resources="https://example.com/script/a.js
-             https://example.com/b.js
-             urn:uuid:429fcc4e-0696-4bad-b099-ee9175f023ae
+  href="https://cdn.example/subresources.wbn"
+  resources="urn:uuid:429fcc4e-0696-4bad-b099-ee9175f023ae
              urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
 />
 
-<script src=”https://example.com/script/a.js”></script>
-<script src=”https://example.com/b.js”></script>
-<script src=”urn:uuid:429fcc4e-0696-4bad-b099-ee9175f023ae”></script>
+<script src="urn:uuid:429fcc4e-0696-4bad-b099-ee9175f023ae"></script>
 <iframe src="urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6"></iframe>
 ```
+
+Note:
+- Loading `urn:uuid` resources from web bundles served from HTTPS server is
+  allowed when "\*" is set in the CSP
+  [source expression](https://w3c.github.io/webappsec-csp/#source-expression).
+  This is different from the CSP behavior that `data:` and `blob:` schemes are
+  excluded from matching a policy of "\*".
+- See an issue [#651](https://github.com/WICG/webpackage/issues/651) for the
+  detailed motivation.  
 
 [subresource loading with web bundles]:
   https://github.com/WICG/webpackage/blob/main/explainers/subresource-loading.md

--- a/explainers/subresource-loading-opaque-origin-iframes.md
+++ b/explainers/subresource-loading-opaque-origin-iframes.md
@@ -103,7 +103,7 @@ Note:
   This is different from the CSP behavior that `data:` and `blob:` schemes are
   excluded from matching a policy of "\*". Loading `urn:uuid` resources from web
   bundles is safer than using `data:` or `blob:` URL resources which are
-  directly under the control of the page, because a urn:uuid resource is a
+  directly under the control of the page, because a `urn:uuid` resource is a
   reference to a component of something with a globally-accessible URL. So we
   don't need to exclude `urn:uuid` resources in a web bundle from matching the
   policy of "\*".

--- a/explainers/subresource-loading-opaque-origin-iframes.md
+++ b/explainers/subresource-loading-opaque-origin-iframes.md
@@ -95,6 +95,8 @@ the page can load `urn:uuid` resources in web bundles served from
 ```
 
 Note:
+- When loading `HTTPS` resources from web bundles, the CSP restrictions must be
+  evaluated against the resource URL, not against the bundle URL.
 - Loading `urn:uuid` resources from web bundles served from HTTPS server is
   allowed when "\*" is set in the CSP
   [source expression](https://w3c.github.io/webappsec-csp/#source-expression).


### PR DESCRIPTION
I created this pull request on @hayatoito 's behalf (PR https://github.com/WICG/webpackage/pull/653 for Issue https://github.com/WICG/webpackage/issues/651), because he is busy on other tasks.

Here is the Chromium side CL: https://crrev.com/c/2886721

