### PR TITLE
Add a precaution note to the "from HAR file" bundle generation method

### DIFF
--- a/go/bundle/README.md
+++ b/go/bundle/README.md
@@ -40,7 +40,12 @@ These command-line flags are common to all the three options:
 
 #### From a HAR file
 
-One convenient way to generate HAR file is via Chrome Devtools. Navigate to "Network" panel, and right-click on any resource and select "Save as HAR with content" (before saving, make sure that the "Disable cache" option is checked in the same "Network" panel).
+One convenient way to generate HAR file is via Chrome Devtools:
+
+1. Open DevTools, navigate to Network panel.
+2. Make sure that "Disable cache" box is checked.
+3. Reload the page.
+4. Right click on any resource and select "Save as HAR with content".
 ![generating har with devtools](https://raw.githubusercontent.com/WICG/webpackage/main/go/bundle/har-devtools.png)
 
 Once you have the har file, generate the web bundle via:

--- a/go/bundle/README.md
+++ b/go/bundle/README.md
@@ -40,7 +40,7 @@ These command-line flags are common to all the three options:
 
 #### From a HAR file
 
-One convenient way to generate HAR file is via Chrome Devtools. Navigate to "Network" panel, and right-click on any resource and select "Save as HAR with content".
+One convenient way to generate HAR file is via Chrome Devtools. Navigate to "Network" panel, and right-click on any resource and select "Save as HAR with content" (before saving, make sure that the "Disable cache" option is checked in the same "Network" panel).
 ![generating har with devtools](https://raw.githubusercontent.com/WICG/webpackage/main/go/bundle/har-devtools.png)
 
 Once you have the har file, generate the web bundle via:

--- a/go/bundle/README.md
+++ b/go/bundle/README.md
@@ -46,6 +46,7 @@ One convenient way to generate HAR file is via Chrome Devtools:
 2. Make sure that "Disable cache" box is checked.
 3. Reload the page.
 4. Right click on any resource and select "Save as HAR with content".
+
 ![generating har with devtools](https://raw.githubusercontent.com/WICG/webpackage/main/go/bundle/har-devtools.png)
 
 Once you have the har file, generate the web bundle via:


### PR DESCRIPTION
As per issue #663 we're adding a small note to the bundle generation instructions from a HAR file.