### PR TITLE
Support relative URLs in bundle in subresource loading

### DIFF
--- a/explainers/subresource-loading.md
+++ b/explainers/subresource-loading.md
@@ -134,6 +134,11 @@ Suppose that the bundle, `subresources.wbn`, includes the following resources:
 - … (omitted)
 ```
 
+A URL of the resource in the bundle can be a [relative
+URL](https://url.spec.whatwg.org/#syntax-url-relative) to the bundle.
+A browser must [parse a URL](https://html.spec.whatwg.org/#parse-a-url)
+using bundle's URL.
+
 ### The main document
 
 ```html


### PR DESCRIPTION
This is intended to support the second idea "using the bundle's URL as the base." in @jyasskin 's [comment](https://github.com/WICG/webpackage/issues/647#issuecomment-816005302) in subresource bundle.