### PR TITLE
js/bundle: Support Primary URL optional section in b2

### DIFF
--- a/js/bundle/README.md
+++ b/js/bundle/README.md
@@ -72,11 +72,11 @@ This module supports creating and parsing Web Bundles that follow different draf
 - version `b2` follows [the latest version of the Web Bundles spec](https://datatracker.ietf.org/doc/html/draft-yasskin-wpack-bundled-exchanges-04) (default)
 - version `b1` follows [the previous version of the Web Bundles spec](https://datatracker.ietf.org/doc/html/draft-yasskin-wpack-bundled-exchanges-03)
 
-To create a new bundle with the `b1` format, pass the version value and the primary URL to the constructor:
+To create a new bundle with the `b1` format, pass the version value to the constructor:
 
 ```javascript
-const primaryURL = 'https://example.com/';
-const builder = (new wbn.BundleBuilder('b1', primaryURL))
+const builder = (new wbn.BundleBuilder('b1'))
+  .setPrimaryURL('https://example.com/')
   .setManifestURL('https://example.com/manifest.json')
   .addExchange(...);
 

--- a/js/bundle/src/cli.ts
+++ b/js/bundle/src/cli.ts
@@ -20,12 +20,16 @@ if (!options.baseURL.endsWith('/')) {
 if (options.formatVersion === undefined || options.formatVersion === 'b2') {
   // webbundle format version b2
   const builder = new BundleBuilder();
+  if (options.primaryURL) {
+    builder.setPrimaryURL(options.primaryURL);
+  }
   builder.addFilesRecursively(options.baseURL, options.dir);
   fs.writeFileSync(options.output, builder.createBundle());
 } else if (options.formatVersion === 'b1') {
   // webbundle format version b1
   const primaryURL = options.primaryURL || options.baseURL;
-  const builder = new BundleBuilder('b1', primaryURL);
+  const builder = new BundleBuilder('b1');
+  builder.setPrimaryURL(primaryURL);
   if (options.manifestURL) {
     builder.setManifestURL(options.manifestURL);
   }

--- a/js/bundle/src/decoder.ts
+++ b/js/bundle/src/decoder.ts
@@ -8,6 +8,7 @@ const knownSections = [
   'critical',
   'index',
   'manifest', // only defined in version b1, might be present anyway
+  'primary',
   'responses',
   'signatures',
 ];
@@ -97,10 +98,11 @@ export class Bundle {
   get primaryURL(): string | null {
     if (this.version === 'b1') {
       return this.b1PrimaryURL;
-    } else {
-      // TODO format version does not support a primary URL, should we throw an error?
-      return null;
     }
+    if (this.sections['primary']) {
+      return asString(this.sections['primary']);
+    }
+    return null;
   }
 
   getResponse(url: string): Response {

--- a/js/bundle/tests/decoder_test.js
+++ b/js/bundle/tests/decoder_test.js
@@ -7,6 +7,7 @@ const path = require('path');
 describe('Bundle', () => {
   const bundleBuffer = (() => {
     const builder = new wbn.BundleBuilder();
+    builder.setPrimaryURL('https://example.com/');
     builder.addExchange(
       'https://example.com/',
       200,
@@ -26,6 +27,7 @@ describe('Bundle', () => {
     const b = new wbn.Bundle(bundleBuffer);
     expect(b.version).toBe('b2');
     expect(b.urls).toEqual(['https://example.com/', 'https://example.com/ja/']);
+    expect(b.primaryURL).toBe('https://example.com/');
   });
 
   describe('getResponse', () => {
@@ -55,6 +57,7 @@ describe('Bundle', () => {
   it('parses pregenerated bundle', () => {
     const buf = fs.readFileSync(path.resolve(__dirname, 'testdata/hello_b2.wbn'));
     const b = new wbn.Bundle(buf);
+    expect(b.primaryURL).toBe(null);
     expect(b.urls).toEqual(['https://example.com/hello.html']);
     const resp = b.getResponse('https://example.com/hello.html');
     expect(resp.status).toBe(200);

--- a/js/bundle/tests/decoder_test_version_b1.js
+++ b/js/bundle/tests/decoder_test_version_b1.js
@@ -6,7 +6,8 @@ const path = require('path');
 
 describe('Bundle', () => {
   const bundleBuffer = (() => {
-    const builder = new wbn.BundleBuilder('b1', 'https://example.com/');
+    const builder = new wbn.BundleBuilder('b1');
+    builder.setPrimaryURL('https://example.com/');
     builder.setManifestURL('https://example.com/manifest.json');
     builder.addExchange(
       'https://example.com/',
@@ -70,7 +71,8 @@ describe('Bundle', () => {
   });
 
   it('throws if an unknown section is marked as critical', () => {
-    const builder = new wbn.BundleBuilder('b1', 'https://example.com/');
+    const builder = new wbn.BundleBuilder('b1');
+    builder.setPrimaryURL('https://example.com/');
     builder.addExchange(
       'https://example.com/',
       200,
@@ -83,7 +85,8 @@ describe('Bundle', () => {
   });
 
   it('does not throw if all names in the critical section are known', () => {
-    const builder = new wbn.BundleBuilder('b1', 'https://example.com/');
+    const builder = new wbn.BundleBuilder('b1');
+    builder.setPrimaryURL('https://example.com/');
     expect(builder.formatVersion).toBe('b1');
     builder.addExchange(
       'https://example.com/',

--- a/js/bundle/tests/encoder_test.js
+++ b/js/bundle/tests/encoder_test.js
@@ -128,6 +128,28 @@ describe('Bundle Builder', () => {
     });
   });
 
+  describe('setPrimaryURL', () => {
+    it('returns the builder itself', () => {
+      const builder = new wbn.BundleBuilder();
+      expect(builder.setPrimaryURL(exampleURL)).toBe(builder);
+    });
+
+    it('rejects invalid URLs', () => {
+      const builder = new wbn.BundleBuilder();
+      invalidURLs.forEach(url => {
+        expect(() => builder.setPrimaryURL(url)).toThrowError();
+      });
+    });
+
+    it('rejects double call', () => {
+      const builder = new wbn.BundleBuilder();
+      builder.setPrimaryURL(exampleURL);
+      expect(() =>
+        builder.setPrimaryURL(exampleURL)
+      ).toThrowError();
+    });
+  });
+
   it('builds large bundle', () => {
     const builder = new wbn.BundleBuilder();
     builder.addExchange(exampleURL, 200, defaultHeaders, new Uint8Array(1024 * 1024));

--- a/js/bundle/tests/encoder_test_version_b1.js
+++ b/js/bundle/tests/encoder_test_version_b1.js
@@ -17,29 +17,26 @@ describe('Bundle Builder', () => {
   ];
 
   it('builds', () => {
-    const builder = new wbn.BundleBuilder('b1', primaryURL);
+    const builder = new wbn.BundleBuilder('b1');
+    builder.setPrimaryURL(primaryURL);
     builder.addExchange(primaryURL, 200, defaultHeaders, defaultContent);
     const buf = builder.createBundle();
     // Just checks the result is a valid CBOR array.
     expect(CBOR.decode(buf)).toBeInstanceOf(Array);
   });
 
-  it('rejects invalid primary URLs', () => {
-    invalidURLs.forEach(url => {
-      expect(() => new wbn.BundleBuilder('b1', url)).toThrowError();
-    });
-  });
-
   describe('addExchange', () => {
     it('returns the builder itself', () => {
-      const builder = new wbn.BundleBuilder('b1', primaryURL);
+      const builder = new wbn.BundleBuilder('b1');
+      builder.setPrimaryURL(primaryURL);
       expect(
         builder.addExchange(primaryURL, 200, defaultHeaders, defaultContent)
       ).toBe(builder);
     });
 
     it('rejects invalid URLs', () => {
-      const builder = new wbn.BundleBuilder('b1', primaryURL);
+      const builder = new wbn.BundleBuilder('b1');
+      builder.setPrimaryURL(primaryURL);
       invalidURLs.forEach(url => {
         expect(() =>
           builder.addExchange(url, 200, defaultHeaders, defaultContent)
@@ -48,7 +45,8 @@ describe('Bundle Builder', () => {
     });
 
     it('requires content-type for non-empty resources', () => {
-      const builder = new wbn.BundleBuilder('b1', primaryURL);
+      const builder = new wbn.BundleBuilder('b1');
+      builder.setPrimaryURL(primaryURL);
       expect(() =>
         builder.addExchange(primaryURL, 200, {}, defaultContent)
       ).toThrowError();
@@ -59,17 +57,20 @@ describe('Bundle Builder', () => {
   describe('addFile', () => {
     it('returns the builder itself', () => {
       const file = path.resolve(__dirname, 'testdata/encoder_test/index.html');
-      const builder = new wbn.BundleBuilder('b1', primaryURL);
+      const builder = new wbn.BundleBuilder('b1');
+      builder.setPrimaryURL(primaryURL);
       expect(builder.addFile(primaryURL, file)).toBe(builder);
     });
 
     it('adds an exchange as expected', () => {
       const file = path.resolve(__dirname, 'testdata/encoder_test/index.html');
-      const builder = new wbn.BundleBuilder('b1', primaryURL);
+      const builder = new wbn.BundleBuilder('b1');
+      builder.setPrimaryURL(primaryURL);
       builder.addFile(primaryURL, file);
       const generated = builder.createBundle();
 
-      const refBuilder = new wbn.BundleBuilder('b1', primaryURL);
+      const refBuilder = new wbn.BundleBuilder('b1');
+      refBuilder.setPrimaryURL(primaryURL);
       refBuilder.addExchange(
         primaryURL,
         200,
@@ -83,7 +84,8 @@ describe('Bundle Builder', () => {
 
     it('throws on nonexistent file', () => {
       const file = path.resolve(__dirname, 'testdata/hello/nonexistent.html');
-      const builder = new wbn.BundleBuilder('b1', primaryURL);
+      const builder = new wbn.BundleBuilder('b1');
+      builder.setPrimaryURL(primaryURL);
       expect(() => builder.addFile(primaryURL, file)).toThrowError();
     });
   });
@@ -91,7 +93,8 @@ describe('Bundle Builder', () => {
   describe('addFilesRecursively', () => {
     it('returns the builder itself', () => {
       const dir = path.resolve(__dirname, 'testdata/encoder_test');
-      const builder = new wbn.BundleBuilder('b1', primaryURL);
+      const builder = new wbn.BundleBuilder('b1');
+      builder.setPrimaryURL(primaryURL);
       expect(builder.addFilesRecursively(primaryURL, dir)).toBe(builder);
     });
 
@@ -99,11 +102,13 @@ describe('Bundle Builder', () => {
       const dir = path.resolve(__dirname, 'testdata/encoder_test');
       const baseURL = 'https://example.com/';
 
-      const builder = new wbn.BundleBuilder('b1', baseURL);
+      const builder = new wbn.BundleBuilder('b1');
+      builder.setPrimaryURL(baseURL);
       builder.addFilesRecursively(baseURL, dir);
       const generated = builder.createBundle();
 
-      const refBuilder = new wbn.BundleBuilder('b1', baseURL);
+      const refBuilder = new wbn.BundleBuilder('b1');
+      refBuilder.setPrimaryURL(baseURL);
       refBuilder.addExchange(
         baseURL,
         200,
@@ -130,26 +135,59 @@ describe('Bundle Builder', () => {
     it('throws if baseURL does not end with a slash', () => {
       const dir = path.resolve(__dirname, 'testdata/hello');
       const url = 'https://example.com/hello.html';
-      const builder = new wbn.BundleBuilder('b1', url);
+      const builder = new wbn.BundleBuilder('b1');
+      builder.setPrimaryURL(url);
       expect(() => builder.addFilesRecursively(url, dir)).toThrowError();
+    });
+  });
+
+  describe('setPrimaryURL', () => {
+    it('returns the builder itself', () => {
+      const builder = new wbn.BundleBuilder('b1');
+      expect(builder.setPrimaryURL(primaryURL)).toBe(builder);
+    });
+
+    it('must be called before createBundle', () => {
+      invalidURLs.forEach(url => {
+        const builder = new wbn.BundleBuilder('b1');
+        expect(() => builder.createBundle()).toThrowError();
+      });
+    });
+
+    it('rejects invalid URLs', () => {
+      invalidURLs.forEach(url => {
+        const builder = new wbn.BundleBuilder('b1');
+        expect(() => builder.setPrimaryURL(url)).toThrowError();
+      });
+    });
+
+    it('rejects double call', () => {
+      const builder = new wbn.BundleBuilder('b1');
+      builder.setPrimaryURL(primaryURL);
+      expect(() =>
+        builder.setPrimaryURL(primaryURL)
+      ).toThrowError();
     });
   });
 
   describe('setManifestURL', () => {
     it('returns the builder itself', () => {
-      const builder = new wbn.BundleBuilder('b1', primaryURL);
+      const builder = new wbn.BundleBuilder('b1');
+      builder.setPrimaryURL(primaryURL);
       expect(builder.setManifestURL(primaryURL)).toBe(builder);
     });
 
     it('rejects invalid URLs', () => {
-      const builder = new wbn.BundleBuilder('b1', primaryURL);
+      const builder = new wbn.BundleBuilder('b1');
+      builder.setPrimaryURL(primaryURL);
       invalidURLs.forEach(url => {
         expect(() => builder.setManifestURL(url)).toThrowError();
       });
     });
 
     it('rejects double call', () => {
-      const builder = new wbn.BundleBuilder('b1', primaryURL);
+      const builder = new wbn.BundleBuilder('b1');
+      builder.setPrimaryURL(primaryURL);
       builder.setManifestURL('https://example.com/manifest.json');
       expect(() =>
         builder.setManifestURL('https://example.com/manifest.json')
@@ -158,7 +196,8 @@ describe('Bundle Builder', () => {
   });
 
   it('builds large bundle', () => {
-    const builder = new wbn.BundleBuilder('b1', primaryURL);
+    const builder = new wbn.BundleBuilder('b1');
+    builder.setPrimaryURL(primaryURL);
     builder.addExchange(primaryURL, 200, defaultHeaders, new Uint8Array(1024 * 1024));
     const buf = builder.createBundle();
     // Just checks the result is a valid CBOR array.


### PR DESCRIPTION
This adds support for the "primary" section, defined in this extension:
https://github.com/WICG/webpackage/blob/main/extensions/primary-section.md

Now primary URL is set by BundleBuilder.setPrimaryURL(), rather than a constructor argument.