### PR TITLE
Add a boilerplate for subresource-loading spec #708

### DIFF
--- a/.github/workflows/spec-prod.yml
+++ b/.github/workflows/spec-prod.yml
@@ -7,11 +7,17 @@ jobs:
   main:
     name: Build, Validate and Deploy
     runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      matrix:
+        include:
+          - source: loading.bs
+          - source: subresource-loading.bs
     steps:
       - uses: actions/checkout@v2
       - uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages
           TOOLCHAIN: bikeshed
-          SOURCE: loading.bs
+          SOURCE: ${{ matrix.source }}
           BUILD_FAIL_ON: warning

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pulls.json
 draft-yasskin-dispatch-web-packaging.xml
 /lib
 loading.html
+subresource-loading.html

--- a/subresource-loading.bs
+++ b/subresource-loading.bs
@@ -1,0 +1,37 @@
+<pre class="metadata">
+Title: Subresource Loading with WebBundles
+Shortname: web-package-subresource-loading
+Level: none
+Status: CG-DRAFT
+Group: WICG
+Repository: WICG/webpackage
+URL: https://wicg.github.io/webpackage/subresource-loading.html
+Editor: Hayato Ito, Google Inc. https://google.com/, hayato@google.com
+Abstract: How UAs load subresources from Web Bundles.
+
+Complain About: accidental-2119 yes, missing-example-ids yes
+Markup Shorthands: markdown yes, css no
+Assume Explicit For: yes
+</pre>
+<pre class="link-defaults">
+spec:fetch; type:dfn; for:/; text:response
+spec:html; type:element; text:link
+</pre>
+
+<section class="non-normative">
+
+# Introduction # {#intro}
+
+<em>This section is non-normative.</em>
+
+The Subresource Loading with Web Bundles specification describes a way to load a
+large number of resources efficiently using a format that allows a format that
+allows multiple resources to be bundled,
+[Web Bundles](https://web.dev/web-bundles/). This specification describes how
+web browsers load those resources. It is expressed as several monkeypatches to
+the [[HTML]] and [[FETCH]] specification which call algorithms defined here.
+
+<p class="note">
+  This specification is under construct. See
+  <a href="https://github.com/WICG/webpackage/issues/708">#708</a>.
+</p>

--- a/subresource-loading.bs
+++ b/subresource-loading.bs
@@ -25,11 +25,11 @@ spec:html; type:element; text:link
 <em>This section is non-normative.</em>
 
 The Subresource Loading with Web Bundles specification describes a way to load a
-large number of resources efficiently using a format that allows a format that
-allows multiple resources to be bundled,
-[Web Bundles](https://web.dev/web-bundles/). This specification describes how
-web browsers load those resources. It is expressed as several monkeypatches to
-the [[HTML]] and [[FETCH]] specification which call algorithms defined here.
+large number of resources efficiently using a format that allows multiple
+resources to be bundled, [Web Bundles](https://web.dev/web-bundles/). This
+specification describes how web browsers load those resources. It is expressed
+as several monkeypatches to the [[HTML]] and [[FETCH]] specification which call
+algorithms defined here.
 
 <p class="note">
   This specification is under construct. See


### PR DESCRIPTION
This is just a starting boilerplate of subresource-loading spec,
tracked in #708.

Also updates GitHub workflow to know whether we can generate *.html
from *.bs correctly or not.