### PR TITLE
Fix "Update Editor's Copy" workflow

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -39,6 +39,13 @@ jobs:
     - name: "Build Drafts"
       uses: martinthomson/i-d-template@v1
 
+    - name: "Build Extra Pages"
+      run: |
+        pip3 install bikeshed
+        bikeshed update
+        bikeshed spec loading.bs
+        bikeshed spec subresource-loading.bs
+
     - name: "Update GitHub Pages"
       uses: martinthomson/i-d-template@v1
       if: ${{ github.event_name == 'push' }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GHPAGES_EXTRA := loading.html
+GHPAGES_EXTRA := loading.html subresource-loading.html
 
 LIBDIR := lib
 include $(LIBDIR)/main.mk
@@ -11,6 +11,3 @@ else
 	git clone -q --depth 10 $(CLONE_ARGS) \
 	    -b main https://github.com/martinthomson/i-d-template $(LIBDIR)
 endif
-
-%.html: %.bs
-	bikeshed spec $<


### PR DESCRIPTION
Fixes #704.

It was failing because bikeshed was not installed in the `martinthomson/i-d-template@v1` docker image. Installing bikeshed in it is not trivial (that needs to build native extensions but the docker image does not have gcc), so this patch lets bikeshed run outside the docker environment.

This also makes this action publish `subresource-loading.html`.