### PR TITLE
Add fetch monkeypatches to subresource-loading spec #708

### DIFF
--- a/subresource-loading.bs
+++ b/subresource-loading.bs
@@ -9,6 +9,7 @@ URL: https://wicg.github.io/webpackage/subresource-loading.html
 Editor: Hayato Ito, Google Inc. https://google.com/, hayato@google.com
 Abstract: How UAs load subresources from Web Bundles.
 Complain About: accidental-2119 yes, missing-example-ids yes
+Indent: 2
 Markup Shorthands: markdown yes, css no
 Assume Explicit For: yes
 </pre>
@@ -22,8 +23,8 @@ Assume Explicit For: yes
 </pre>
 <pre class='anchors'>
 spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/#
-    type: dfn
-        text: fetch params; url: fetch-params
+  type: dfn
+    text: fetch params; url: fetch-params
 </pre>
 <pre class="link-defaults">
 spec:fetch; type:dfn; for:/; text:request
@@ -43,15 +44,15 @@ specification describes how web browsers load those resources. It is expressed
 as several monkeypatches to the [[HTML]] and [[FETCH]] specification which call
 algorithms defined here.
 
-Note: This specification is under construction. See <a href="https://github.com/WICG/webpackage/issues/708">#708</a>.
+Note: This specification is under construction. See
+<a href="https://github.com/WICG/webpackage/issues/708">#708</a>.
 
 # Structures # {#structures}
 
 A <dfn>fetched web bundle</dfn> is a representation of a web bundle format
 defined in [[draft-ietf-wpack-bundled-responses-latest]].
 
-A <dfn>bundle rule</dfn> is a [=struct=] with the following
-[=struct/items=]:
+A <dfn>bundle rule</dfn> is a [=struct=] with the following [=struct/items=]:
 
 - <dfn for="bundle rule">source</dfn>, a [=URL=].
 - <dfn for="bundle rule">credentials</dfn>, a [=request/mode=].
@@ -62,11 +63,13 @@ A <dfn>web bundle</dfn> is a [=struct=] with the following [=struct/items=]:
 
 - <dfn for="web bundle">fetched bundle</dfn>, a [=fetched web bundle=] or null.
 - <dfn for="web bundle">rule</dfn>, a [=bundle rule=].
-- <dfn for="web bundle">state</dfn>, an internal state which is "fetching", "fetched", or "failed". Initially "fetching".
+- <dfn for="web bundle">state</dfn>, an internal state which is "fetching",
+  "fetched", or "failed". Initially "fetching".
 
-A {{Document}} has a <dfn for=document>web bundle list</dfn>, which is a list of [=web bundles=].
+A {{Document}} has a <dfn for=document>web bundle list</dfn>, which is a list of
+[=web bundles=].
 
-# HTML monkeypatches  # {#html-monkeypatches}
+# HTML monkeypatches # {#html-monkeypatches}
 
 Note: TODO. This section uses [=fetch web bundle=].
 
@@ -76,100 +79,124 @@ Note: TODO. This section uses [=fetch web bundle=].
 
 In <a spec="fetch">HTTP-network-or-cache fetch</a>, before
 
-> 8.22. Set httpCache to the result of determining the HTTP cache partition, given |httpRequest|.
+> 8.22. Set httpCache to the result of determining the HTTP cache partition,
+> given |httpRequest|.
 
 add the following steps:
 
-22.  Set the |response| to the result of [=fetch from web bundle=], given |httpRequest|.
+22. Set the |response| to the result of [=fetch from web bundle=], given
+    |httpRequest|.
 
     1. If |response| is [=network error=], return [=network error=].
 
     2. If |response| is non-null, skip the steps 8.22-8.24 and goto the step 9.
 
-        Note: That means a subresource from a webbundle never interacts with HttpCache.
-        We plan to support HttpCache as a feature enhancement in the future.
+       Note: That means a subresource from a webbundle never interacts with
+       HttpCache. We plan to support HttpCache as a feature enhancement in the
+       future.
 
 # Algorithms # {#algorithms}
 
 ## Fetch web bundle ## {#fetch-web-bundle}
 
-To <dfn id="concept-fetch-web-bundle">fetch web bundle</dfn> given [=web bundle=] |web bundle| and [=fetch params=] |fetch params|:
+To <dfn id="concept-fetch-web-bundle">fetch web bundle</dfn> given [=web
+bundle=] |web bundle| and [=fetch params=] |fetch params|:
 
-1. Assert:  |web bundle|'s [=web bundle/state=] is "fetching".
+1. Assert: |web bundle|'s [=web bundle/state=] is "fetching".
 
 1. Let |request| be |fetch params|'s [=request=].
 
-1. Set |request|'s [=request/url=] to |web bundle|'s [=web bundle/rule=]'s [=bundle rule/source=].
+1. Set |request|'s [=request/url=] to |web bundle|'s [=web bundle/rule=]'s
+   [=bundle rule/source=].
 
-     Note: Source URL is resolved on document's base URL.
+   Note: Source URL is resolved on document's base URL.
 
 1. Set |request|'s [=request/destination=] to "webbundle",
 
 1. Set |request|'s [=request/mode=] to "cors",
 
-1. Set |request|'s [=request/credentials mode=] to |web bundle|'s [=web bundle/rule=]'s [=bundle rule/credentials=].
+1. Set |request|'s [=request/credentials mode=] to |web bundle|'s [=web
+   bundle/rule=]'s [=bundle rule/credentials=].
 
-1. Append a [=header=], a tuple of ("Accept", "application/webbundle;v=1"), to |request|'s [=request/header list=].
+1. Append a [=header=], a tuple of ("Accept", "application/webbundle;v=b2"), to
+   |request|'s [=request/header list=].
 
-    Note: Chromium's experimental implementation uses "application/webbundle;v=b2" as a header value.
-    Once the web bundle format ([[draft-ietf-wpack-bundled-responses-latest]]) goes RFC, Chromium would use "1" as a version number.
+   Note: The final [draft-yasskin-http-origin-signed-responses] will use a
+   version of `1`, but this specification tracks what’s actually implemented in
+   browsers, which still uses draft versions.
 
-1. Let |response| be the result of running <a spec="fetch">HTTP-network-or-cache fetch</a> given |fetch params|.
+1. Let |response| be the result of running <a spec="fetch">HTTP-network-or-cache
+   fetch</a> given |fetch params|.
 
-    Note: Chromium's current implementation doesn't allow a *nested bundle*.
-    A Web bundle is never fetched from other web bundles.
+   Note: Chromium's current implementation doesn't allow a _nested bundle_. A
+   Web bundle is never fetched from other web bundles.
 
 1. If |response|'s [=response/status=] is 200,
 
-    1. Set |web bundle|'s [=web bundle/fetched bundle=] to the result of parsing |response|'s body ([[draft-ietf-wpack-bundled-responses-latest]]) and |web bundle|'s [=web bundle/state=] be "fetched". If parsing fails, or any other conformance is violated, set [=web bundle/fetched bundle=] to null and [=web bundle/state=] to "failed".
+   1. Set |web bundle|'s [=web bundle/fetched bundle=] to the result of parsing
+      |response|'s body ([[draft-ietf-wpack-bundled-responses-latest]]) and |web
+      bundle|'s [=web bundle/state=] be "fetched". If parsing fails, or any
+      other conformance is violated, set [=web bundle/fetched bundle=] to null
+      and [=web bundle/state=] to "failed".
 
-        Note: In parsing, Chromium's experimental implementation only accepts "b2" as a web bundle format version number ([[draft-ietf-wpack-bundled-responses-latest]]).
-        Once the web bundle format goes RFC, Chromium would accept "1" as a web bundle format version number.
+      Note: In parsing, Chromium's experimental implementation only accepts "b2"
+      as a web bundle format version number
+      ([[draft-ietf-wpack-bundled-responses-latest]]).
 
 1. Otherwise, set |web bundle|'s [=web bundle/state=] to "failed".
 
 ## Fetch from web bundle ## {#fetch-from-web-bundle}
 
-To <dfn id="concept-fetch-from-web-bundle">fetch from web bundle</dfn> given [=request=] |httpRequest|:
+To <dfn id="concept-fetch-from-web-bundle">fetch from web bundle</dfn> given
+[=request=] |httpRequest|:
 
- 1. For each |web bundle| of [=document=]'s [=document/web bundle list=]:
+1. For each |web bundle| of [=document=]'s [=document/web bundle list=]:
 
-    1. If the result of running [=match url with web bundle=] given |httpRequest|'s [=request/url=] and |web bundle| is true:
+   1. If the result of running [=match url with web bundle=] given
+      |httpRequest|'s [=request/url=] and |web bundle| is true:
 
-        1. Let |response| be the result of [=get response from web bundle=] given |httpRequest|'s [=request/url=] and |web bundle|.
+      1. Let |response| be the result of [=get response from web bundle=] given
+         |httpRequest|'s [=request/url=] and |web bundle|.
 
-        2. If |response| is null, return a [=network error=].
+      2. If |response| is null, return a [=network error=].
 
-            Note: This means a browser does not fallback to fetch a subresource from network.
+         Note: This means a browser does not fallback to fetch a subresource
+         from network.
 
-        3. Otherwise, return |response|.
+      3. Otherwise, return |response|.
 
 2. Return null.
 
 ## Match url with web bundle ## {#match-url-with-web-bundle}
 
-To <dfn id="concept-match-url-with-web-bundle">match url with web bundle</dfn> given [=url=] |url| and [=web bundle=] |web bundle|:
+To <dfn id="concept-match-url-with-web-bundle">match url with web bundle</dfn>
+given [=url=] |url| and [=web bundle=] |web bundle|:
 
-1. If |url| doesn't meet a path restriction rule, given |web bundle|'s [=web bundle/rule=]'s [=bundle rule/source=], then return false.
+1. If |url| doesn't meet a path restriction rule, given |web bundle|'s [=web
+   bundle/rule=]'s [=bundle rule/source=], then return false.
 
-    Issue: Clarify path restriction rule in algorithm.
+   Issue: Clarify path restriction rule in algorithm.
 
+2. If |url| matches any of |web bundle|'s [=web bundle/rule=]'s [=bundle
+   rule/resources=], then return true.
 
-2. If |url| matches any of |web bundle|'s [=web bundle/rule=]'s [=bundle rule/resources=], then return true.
-
-3. If |url|'s prefix matches any of |web bundle|'s [=web bundle/rule=]'s [=bundle rule/scopes=], then return true.
+3. If |url|'s prefix matches any of |web bundle|'s [=web bundle/rule=]'s
+   [=bundle rule/scopes=], then return true.
 
 4. Otherwise, return false.
 
-
 ## Get response from web bundle ## {#get-response-from-web-bundle}
 
-To <dfn id="concept-get-response-from-web-bundle">get response from web bundle</dfn> given [=url=] |url| and [=web bundle=] |web bundle|:
+To <dfn id="concept-get-response-from-web-bundle">get response from web
+bundle</dfn> given [=url=] |url| and [=web bundle=] |web bundle|:
 
-1. If |web bundle|'s [=web bundle/state=] is "fetching", await until [=web bundle/state=] becomes "fetched" or "failed" asynchronously.
+1. If |web bundle|'s [=web bundle/state=] is "fetching", await until [=web
+   bundle/state=] becomes "fetched" or "failed" asynchronously.
 
 2. If |web bundle|'s [=web bundle/state=] is "failed", return null.
 
 3. Assert: |web bundle|'s [=web bundle/fetched bundle=] is non-null.
 
-4. Returns [=response=] from |web bundle|'s [=web bundle/fetched bundle=] given |url| ([[draft-ietf-wpack-bundled-responses-latest]]).  If a representation of |url| is not found in [=web bundle/fetched bundle=], return null.
+4. Returns [=response=] from |web bundle|'s [=web bundle/fetched bundle=] given
+   |url| ([[draft-ietf-wpack-bundled-responses-latest]]). If a representation of
+   |url| is not found in [=web bundle/fetched bundle=], return null.

--- a/subresource-loading.bs
+++ b/subresource-loading.bs
@@ -121,14 +121,14 @@ bundle=] |web bundle| and [=fetch params=] |fetch params|:
 1. Append a [=header=], a tuple of ("Accept", "application/webbundle;v=b2"), to
    |request|'s [=request/header list=].
 
-   Note: The final [draft-yasskin-http-origin-signed-responses] will use a
+   Note: The final [[draft-yasskin-http-origin-signed-responses]] will use a
    version of `1`, but this specification tracks what’s actually implemented in
    browsers, which still uses draft versions.
 
 1. Let |response| be the result of running <a spec="fetch">HTTP-network-or-cache
    fetch</a> given |fetch params|.
 
-   Note: Chromium's current implementation doesn't allow a _nested bundle_. A
+   Note: Chromium's current implementation doesn't allow a *nested bundle*. A
    Web bundle is never fetched from other web bundles.
 
 1. If |response|'s [=response/status=] is 200,

--- a/subresource-loading.bs
+++ b/subresource-loading.bs
@@ -8,17 +8,29 @@ Repository: WICG/webpackage
 URL: https://wicg.github.io/webpackage/subresource-loading.html
 Editor: Hayato Ito, Google Inc. https://google.com/, hayato@google.com
 Abstract: How UAs load subresources from Web Bundles.
-
 Complain About: accidental-2119 yes, missing-example-ids yes
 Markup Shorthands: markdown yes, css no
 Assume Explicit For: yes
 </pre>
+<pre class='biblio'>
+{
+  "draft-yasskin-wpack-bundled-exchanges": {
+    "href": "https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.html",
+    "title": "Web Bundles"
+  }
+}
+</pre>
+<pre class='anchors'>
+spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/#
+    type: dfn
+        text: fetch params; url: fetch-params
+</pre>
 <pre class="link-defaults">
+spec:fetch; type:dfn; for:/; text:request
 spec:fetch; type:dfn; for:/; text:response
 spec:html; type:element; text:link
+spec:url; type:dfn; for:/; text:url
 </pre>
-
-<section class="non-normative">
 
 # Introduction # {#intro}
 
@@ -31,7 +43,143 @@ specification describes how web browsers load those resources. It is expressed
 as several monkeypatches to the [[HTML]] and [[FETCH]] specification which call
 algorithms defined here.
 
-<p class="note">
-  This specification is under construct. See
-  <a href="https://github.com/WICG/webpackage/issues/708">#708</a>.
-</p>
+Note: This specification is under construct. See <a href="https://github.com/WICG/webpackage/issues/708">#708</a>.
+
+# Structures # {#structures}
+
+A <dfn>fetched web bundle</dfn> is a representation of a web bundle format
+defined in [[draft-yasskin-wpack-bundled-exchanges]].
+
+A <dfn>bundle rule</dfn> is a [=struct=] with the following
+[=struct/items=]:
+
+- <dfn for="bundle rule">source</dfn>, a [=URL=].
+- <dfn for="bundle rule">credentials</dfn>, a [=request/mode=].
+- <dfn for="bundle rule">resources</dfn>, a list of [=URLs=].
+- <dfn for="bundle rule">scopes</dfn>, a list of [=URLs=].
+
+A <dfn>web bundle</dfn> is a [=struct=] with the following [=struct/items=]:
+
+- <dfn for="web bundle">fetched bundle</dfn>, a [=fetched web bundle=] or null.
+- <dfn for="web bundle">rule</dfn>, a [=bundle rule=].
+- <dfn for="web bundle">state</dfn>, an internal state which is "fetching", "fetched", or "failed". Initially "fetching".
+
+# New Document fields # {#new-document-fields}
+
+A {{Document}} has a <dfn for=document>web bundle list</dfn>, which is a list of [=web bundles=].
+
+# Fetch web bundle # {#fetch-web-bundle-section}
+
+<div algorithm>
+To <dfn>fetch web bundle</dfn> given [=web bundle=] |web bundle| and [=fetch params=] |fetch params|:
+
+1. Assert:  |webbundle|'s [=web bundle/state=] is "fetching".
+
+1. Let |request| be |fetch params|'s [=request=].
+
+1. Let |request|'s [=request/url=] is |webbundle|'s [=web bundle/rule=]'s [=bundle rule/source=].
+
+     Note: Source URL is resolved on document's base URL.
+
+1. Let |request|'s [=request/destination=] is "webbundle",
+
+1. Let |request|'s [=request/mode=] is "cors",
+
+1. Let |request|'s [=request/credentials mode=] be |web bundle|'s [=web bundle/rule=]'s [=bundle rule/credentials=] if [=bundle rule/credentials=] is non-null. Otherwise "same-origin"
+
+1. Append a [=header=], a tuple of ("Accept", "application/webbundle;v=1"), to |request|'s [=request/header list=].
+
+    Note: Chromium's experimental implementation uses "application/webbundle;v=b2" as a header value.
+    Once the web bundle format ([[draft-yasskin-wpack-bundled-exchanges]]) goes RFC, Chromium would use "1" as a version number.
+
+1. Let |response| be the result of running <a spec="fetch">HTTP-network-or-cache fetch</a> given |fetch params|.
+
+    Note: Chromium's current implementation doesn't allow a *nested bundle*.
+    A Web bundle is never fetched from other web bundles.
+
+1. If |response|'s [=response/status=] is 200,
+
+    1. Let |webbundle|'s [=web bundle/fetched bundle=] be the result of parsing |response|'s body ([[draft-yasskin-wpack-bundled-exchanges]]) and |webbundle|' [=web bundle/state=] be "fetched". If parsing fails, or any other conformance is violated, let [=web bundle/fetched bundle=] be null and [=web bundle/state=] be "failed".
+
+        Note: In parsing, Chromium's experimental implementation only accepts "b2" as a web bundle format version number ([[draft-yasskin-wpack-bundled-exchanges]]).
+        Once the web bundle format goes RFC, Chromium would accept "1" as a web bundle format version number.
+
+1. Otherwise, let |webbundle|' [=web bundle/state=] be "failed".
+
+</div>
+
+# HTML monkeypatches  # {#html-monkeypatches}
+
+## Script ## {#script}
+
+Note: TODO. This section uses [=fetch web bundle=].
+
+# Fetch monkeypatches # {#fetch-monkeypatches}
+
+## Fetch subresource from web bundle  ## {#fetch-subresource-from-web-bundle}
+
+In <a spec="fetch">HTTP-network-or-cache fetch</a>, before
+
+> 8.22. Set httpCache to the result of determining the HTTP cache partition, given|httpRequest|.
+
+add the following steps:
+
+22.  Set the |response| to the result of [=fetch from web bundle=], given |httpRequest|.
+
+    1. If |response| is [=network error=], return [=network error=].
+
+    2. If |response| is non-null, skip the steps 8.22-8.24 and goto the step 9.
+
+        Note: That means a subresource from a webbundle never interacts with HttpCache.
+        We plan to support HttpCache as a feature enhancement in the future.
+
+<div algorithm>
+To <dfn>fetch from web bundle</dfn> given [=request=] |httpRequest|:
+
+    1. For each |web bundle| of [=document=]'s [=document/web bundle list=]:
+
+        1. If the result of running [=match url with web bundle=] given |httpRequest|'s [=request/url=] and |web bundle| is true:
+
+            1. Let |response| be the result of [=get response from web bundle=] given |httpRequest|'s [=request/url=] and |web bundle|.
+
+            2. If |response| is null, return a [=network error=].
+
+                Note: This means a browser does not fallback to fetch a subresource from network.
+
+            3. Otherwise, return |response|.
+
+    2. Return null.
+
+</div>
+
+<div algorithm>
+  To <dfn>match url with web bundle</dfn> given [=url=] |url| and [=web bundle=] |web bundle|:
+
+    1. If |url| doesn't meet a path restriction rule, given |web bundle|'s [=web bundle/rule=]'s [=bundle rule/source=], then return false.
+
+        Issue: Clarify path restriction rule in algorithm.
+
+
+    2. If |url| matches any of |web bundle|'s [=web bundle/rule=]'s [=bundle rule/resources=], then return true.
+
+    2. If |url|'s prefix matches any of |web bundle|'s [=web bundle/rule=]'s [=bundle rule/scopes=], then return true.
+
+    3. Otherwise, return false.
+
+</div>
+
+<div algorithm>
+  To <dfn>get response from web bundle</dfn> given [=url=] |url| and [=web bundle=] |web bundle|:
+
+    1. If |web bundle|'s [=web bundle/state=] is "fetching", await until [=web bundle/state=] becomes "fetched" or "failed" asynchronously.
+
+    1. If |web bundle|'s [=web bundle/state=] is "failed", return null.
+
+    2. Assert: |web bundle|'s [=web bundle/fetched bundle=] is non-null.
+
+    3. Returns [=response=] from |web bundle|'s [=web bundle/fetched bundle=] given |url| ([[draft-yasskin-wpack-bundled-exchanges]]).  If a representation of |url| is not found in [=web bundle/fetched bundle=], return null.
+</div>
+
+## Navigation ## {#navigation}
+
+Note: TODO

--- a/subresource-loading.bs
+++ b/subresource-loading.bs
@@ -121,7 +121,7 @@ bundle=] |web bundle| and [=fetch params=] |fetch params|:
 1. Append a [=header=], a tuple of ("Accept", "application/webbundle;v=b2"), to
    |request|'s [=request/header list=].
 
-   Note: The final [[draft-yasskin-http-origin-signed-responses]] will use a
+   Note: The final [[draft-ietf-wpack-bundled-responses-latest]] will use a
    version of `1`, but this specification tracks what’s actually implemented in
    browsers, which still uses draft versions.
 

--- a/subresource-loading.bs
+++ b/subresource-loading.bs
@@ -1,5 +1,5 @@
 <pre class="metadata">
-Title: Subresource Loading with WebBundles
+Title: Subresource Loading with Web Bundles
 Shortname: web-package-subresource-loading
 Level: none
 Status: CG-DRAFT
@@ -14,8 +14,8 @@ Assume Explicit For: yes
 </pre>
 <pre class='biblio'>
 {
-  "draft-yasskin-wpack-bundled-exchanges": {
-    "href": "https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.html",
+  "draft-ietf-wpack-bundled-responses-latest": {
+    "href": "https://wpack-wg.github.io/bundled-responses/draft-ietf-wpack-bundled-responses.html",
     "title": "Web Bundles"
   }
 }
@@ -43,12 +43,12 @@ specification describes how web browsers load those resources. It is expressed
 as several monkeypatches to the [[HTML]] and [[FETCH]] specification which call
 algorithms defined here.
 
-Note: This specification is under construct. See <a href="https://github.com/WICG/webpackage/issues/708">#708</a>.
+Note: This specification is under construction. See <a href="https://github.com/WICG/webpackage/issues/708">#708</a>.
 
 # Structures # {#structures}
 
 A <dfn>fetched web bundle</dfn> is a representation of a web bundle format
-defined in [[draft-yasskin-wpack-bundled-exchanges]].
+defined in [[draft-ietf-wpack-bundled-responses-latest]].
 
 A <dfn>bundle rule</dfn> is a [=struct=] with the following
 [=struct/items=]:
@@ -76,7 +76,7 @@ Note: TODO. This section uses [=fetch web bundle=].
 
 In <a spec="fetch">HTTP-network-or-cache fetch</a>, before
 
-> 8.22. Set httpCache to the result of determining the HTTP cache partition, given|httpRequest|.
+> 8.22. Set httpCache to the result of determining the HTTP cache partition, given |httpRequest|.
 
 add the following steps:
 
@@ -99,20 +99,20 @@ To <dfn id="concept-fetch-web-bundle">fetch web bundle</dfn> given [=web bundle=
 
 1. Let |request| be |fetch params|'s [=request=].
 
-1. Let |request|'s [=request/url=] is |web bundle|'s [=web bundle/rule=]'s [=bundle rule/source=].
+1. Set |request|'s [=request/url=] to |web bundle|'s [=web bundle/rule=]'s [=bundle rule/source=].
 
      Note: Source URL is resolved on document's base URL.
 
-1. Let |request|'s [=request/destination=] is "webbundle",
+1. Set |request|'s [=request/destination=] to "webbundle",
 
-1. Let |request|'s [=request/mode=] is "cors",
+1. Set |request|'s [=request/mode=] to "cors",
 
-1. Let |request|'s [=request/credentials mode=] be |web bundle|'s [=web bundle/rule=]'s [=bundle rule/credentials=] if [=bundle rule/credentials=] is non-null. Otherwise "same-origin".
+1. Set |request|'s [=request/credentials mode=] to |web bundle|'s [=web bundle/rule=]'s [=bundle rule/credentials=].
 
 1. Append a [=header=], a tuple of ("Accept", "application/webbundle;v=1"), to |request|'s [=request/header list=].
 
     Note: Chromium's experimental implementation uses "application/webbundle;v=b2" as a header value.
-    Once the web bundle format ([[draft-yasskin-wpack-bundled-exchanges]]) goes RFC, Chromium would use "1" as a version number.
+    Once the web bundle format ([[draft-ietf-wpack-bundled-responses-latest]]) goes RFC, Chromium would use "1" as a version number.
 
 1. Let |response| be the result of running <a spec="fetch">HTTP-network-or-cache fetch</a> given |fetch params|.
 
@@ -121,12 +121,12 @@ To <dfn id="concept-fetch-web-bundle">fetch web bundle</dfn> given [=web bundle=
 
 1. If |response|'s [=response/status=] is 200,
 
-    1. Let |web bundle|'s [=web bundle/fetched bundle=] be the result of parsing |response|'s body ([[draft-yasskin-wpack-bundled-exchanges]]) and |web bundle|'s [=web bundle/state=] be "fetched". If parsing fails, or any other conformance is violated, let [=web bundle/fetched bundle=] be null and [=web bundle/state=] be "failed".
+    1. Set |web bundle|'s [=web bundle/fetched bundle=] to the result of parsing |response|'s body ([[draft-ietf-wpack-bundled-responses-latest]]) and |web bundle|'s [=web bundle/state=] be "fetched". If parsing fails, or any other conformance is violated, set [=web bundle/fetched bundle=] to null and [=web bundle/state=] to "failed".
 
-        Note: In parsing, Chromium's experimental implementation only accepts "b2" as a web bundle format version number ([[draft-yasskin-wpack-bundled-exchanges]]).
+        Note: In parsing, Chromium's experimental implementation only accepts "b2" as a web bundle format version number ([[draft-ietf-wpack-bundled-responses-latest]]).
         Once the web bundle format goes RFC, Chromium would accept "1" as a web bundle format version number.
 
-1. Otherwise, let |web bundle|'s [=web bundle/state=] be "failed".
+1. Otherwise, set |web bundle|'s [=web bundle/state=] to "failed".
 
 ## Fetch from web bundle ## {#fetch-from-web-bundle}
 
@@ -172,4 +172,4 @@ To <dfn id="concept-get-response-from-web-bundle">get response from web bundle</
 
 3. Assert: |web bundle|'s [=web bundle/fetched bundle=] is non-null.
 
-4. Returns [=response=] from |web bundle|'s [=web bundle/fetched bundle=] given |url| ([[draft-yasskin-wpack-bundled-exchanges]]).  If a representation of |url| is not found in [=web bundle/fetched bundle=], return null.
+4. Returns [=response=] from |web bundle|'s [=web bundle/fetched bundle=] given |url| ([[draft-ietf-wpack-bundled-responses-latest]]).  If a representation of |url| is not found in [=web bundle/fetched bundle=], return null.

--- a/subresource-loading.bs
+++ b/subresource-loading.bs
@@ -64,59 +64,15 @@ A <dfn>web bundle</dfn> is a [=struct=] with the following [=struct/items=]:
 - <dfn for="web bundle">rule</dfn>, a [=bundle rule=].
 - <dfn for="web bundle">state</dfn>, an internal state which is "fetching", "fetched", or "failed". Initially "fetching".
 
-# New Document fields # {#new-document-fields}
-
 A {{Document}} has a <dfn for=document>web bundle list</dfn>, which is a list of [=web bundles=].
 
-# Fetch web bundle # {#fetch-web-bundle-section}
-
-<div algorithm>
-To <dfn>fetch web bundle</dfn> given [=web bundle=] |web bundle| and [=fetch params=] |fetch params|:
-
-1. Assert:  |webbundle|'s [=web bundle/state=] is "fetching".
-
-1. Let |request| be |fetch params|'s [=request=].
-
-1. Let |request|'s [=request/url=] is |webbundle|'s [=web bundle/rule=]'s [=bundle rule/source=].
-
-     Note: Source URL is resolved on document's base URL.
-
-1. Let |request|'s [=request/destination=] is "webbundle",
-
-1. Let |request|'s [=request/mode=] is "cors",
-
-1. Let |request|'s [=request/credentials mode=] be |web bundle|'s [=web bundle/rule=]'s [=bundle rule/credentials=] if [=bundle rule/credentials=] is non-null. Otherwise "same-origin"
-
-1. Append a [=header=], a tuple of ("Accept", "application/webbundle;v=1"), to |request|'s [=request/header list=].
-
-    Note: Chromium's experimental implementation uses "application/webbundle;v=b2" as a header value.
-    Once the web bundle format ([[draft-yasskin-wpack-bundled-exchanges]]) goes RFC, Chromium would use "1" as a version number.
-
-1. Let |response| be the result of running <a spec="fetch">HTTP-network-or-cache fetch</a> given |fetch params|.
-
-    Note: Chromium's current implementation doesn't allow a *nested bundle*.
-    A Web bundle is never fetched from other web bundles.
-
-1. If |response|'s [=response/status=] is 200,
-
-    1. Let |webbundle|'s [=web bundle/fetched bundle=] be the result of parsing |response|'s body ([[draft-yasskin-wpack-bundled-exchanges]]) and |webbundle|' [=web bundle/state=] be "fetched". If parsing fails, or any other conformance is violated, let [=web bundle/fetched bundle=] be null and [=web bundle/state=] be "failed".
-
-        Note: In parsing, Chromium's experimental implementation only accepts "b2" as a web bundle format version number ([[draft-yasskin-wpack-bundled-exchanges]]).
-        Once the web bundle format goes RFC, Chromium would accept "1" as a web bundle format version number.
-
-1. Otherwise, let |webbundle|' [=web bundle/state=] be "failed".
-
-</div>
-
 # HTML monkeypatches  # {#html-monkeypatches}
-
-## Script ## {#script}
 
 Note: TODO. This section uses [=fetch web bundle=].
 
 # Fetch monkeypatches # {#fetch-monkeypatches}
 
-## Fetch subresource from web bundle  ## {#fetch-subresource-from-web-bundle}
+## Monkeypatch HTTP-network-or-cache fetch ## {#monkeypatch-http-network-or-cache-fetch}
 
 In <a spec="fetch">HTTP-network-or-cache fetch</a>, before
 
@@ -133,53 +89,87 @@ add the following steps:
         Note: That means a subresource from a webbundle never interacts with HttpCache.
         We plan to support HttpCache as a feature enhancement in the future.
 
-<div algorithm>
-To <dfn>fetch from web bundle</dfn> given [=request=] |httpRequest|:
+# Algorithms # {#algorithms}
 
-    1. For each |web bundle| of [=document=]'s [=document/web bundle list=]:
+## Fetch web bundle ## {#fetch-web-bundle}
 
-        1. If the result of running [=match url with web bundle=] given |httpRequest|'s [=request/url=] and |web bundle| is true:
+To <dfn id="concept-fetch-web-bundle">fetch web bundle</dfn> given [=web bundle=] |web bundle| and [=fetch params=] |fetch params|:
 
-            1. Let |response| be the result of [=get response from web bundle=] given |httpRequest|'s [=request/url=] and |web bundle|.
+1. Assert:  |web bundle|'s [=web bundle/state=] is "fetching".
 
-            2. If |response| is null, return a [=network error=].
+1. Let |request| be |fetch params|'s [=request=].
 
-                Note: This means a browser does not fallback to fetch a subresource from network.
+1. Let |request|'s [=request/url=] is |web bundle|'s [=web bundle/rule=]'s [=bundle rule/source=].
 
-            3. Otherwise, return |response|.
+     Note: Source URL is resolved on document's base URL.
 
-    2. Return null.
+1. Let |request|'s [=request/destination=] is "webbundle",
 
-</div>
+1. Let |request|'s [=request/mode=] is "cors",
 
-<div algorithm>
-  To <dfn>match url with web bundle</dfn> given [=url=] |url| and [=web bundle=] |web bundle|:
+1. Let |request|'s [=request/credentials mode=] be |web bundle|'s [=web bundle/rule=]'s [=bundle rule/credentials=] if [=bundle rule/credentials=] is non-null. Otherwise "same-origin".
 
-    1. If |url| doesn't meet a path restriction rule, given |web bundle|'s [=web bundle/rule=]'s [=bundle rule/source=], then return false.
+1. Append a [=header=], a tuple of ("Accept", "application/webbundle;v=1"), to |request|'s [=request/header list=].
 
-        Issue: Clarify path restriction rule in algorithm.
+    Note: Chromium's experimental implementation uses "application/webbundle;v=b2" as a header value.
+    Once the web bundle format ([[draft-yasskin-wpack-bundled-exchanges]]) goes RFC, Chromium would use "1" as a version number.
+
+1. Let |response| be the result of running <a spec="fetch">HTTP-network-or-cache fetch</a> given |fetch params|.
+
+    Note: Chromium's current implementation doesn't allow a *nested bundle*.
+    A Web bundle is never fetched from other web bundles.
+
+1. If |response|'s [=response/status=] is 200,
+
+    1. Let |web bundle|'s [=web bundle/fetched bundle=] be the result of parsing |response|'s body ([[draft-yasskin-wpack-bundled-exchanges]]) and |web bundle|'s [=web bundle/state=] be "fetched". If parsing fails, or any other conformance is violated, let [=web bundle/fetched bundle=] be null and [=web bundle/state=] be "failed".
+
+        Note: In parsing, Chromium's experimental implementation only accepts "b2" as a web bundle format version number ([[draft-yasskin-wpack-bundled-exchanges]]).
+        Once the web bundle format goes RFC, Chromium would accept "1" as a web bundle format version number.
+
+1. Otherwise, let |web bundle|'s [=web bundle/state=] be "failed".
+
+## Fetch from web bundle ## {#fetch-from-web-bundle}
+
+To <dfn id="concept-fetch-from-web-bundle">fetch from web bundle</dfn> given [=request=] |httpRequest|:
+
+ 1. For each |web bundle| of [=document=]'s [=document/web bundle list=]:
+
+    1. If the result of running [=match url with web bundle=] given |httpRequest|'s [=request/url=] and |web bundle| is true:
+
+        1. Let |response| be the result of [=get response from web bundle=] given |httpRequest|'s [=request/url=] and |web bundle|.
+
+        2. If |response| is null, return a [=network error=].
+
+            Note: This means a browser does not fallback to fetch a subresource from network.
+
+        3. Otherwise, return |response|.
+
+2. Return null.
+
+## Match url with web bundle ## {#match-url-with-web-bundle}
+
+To <dfn id="concept-match-url-with-web-bundle">match url with web bundle</dfn> given [=url=] |url| and [=web bundle=] |web bundle|:
+
+1. If |url| doesn't meet a path restriction rule, given |web bundle|'s [=web bundle/rule=]'s [=bundle rule/source=], then return false.
+
+    Issue: Clarify path restriction rule in algorithm.
 
 
-    2. If |url| matches any of |web bundle|'s [=web bundle/rule=]'s [=bundle rule/resources=], then return true.
+2. If |url| matches any of |web bundle|'s [=web bundle/rule=]'s [=bundle rule/resources=], then return true.
 
-    2. If |url|'s prefix matches any of |web bundle|'s [=web bundle/rule=]'s [=bundle rule/scopes=], then return true.
+3. If |url|'s prefix matches any of |web bundle|'s [=web bundle/rule=]'s [=bundle rule/scopes=], then return true.
 
-    3. Otherwise, return false.
+4. Otherwise, return false.
 
-</div>
 
-<div algorithm>
-  To <dfn>get response from web bundle</dfn> given [=url=] |url| and [=web bundle=] |web bundle|:
+## Get response from web bundle ## {#get-response-from-web-bundle}
 
-    1. If |web bundle|'s [=web bundle/state=] is "fetching", await until [=web bundle/state=] becomes "fetched" or "failed" asynchronously.
+To <dfn id="concept-get-response-from-web-bundle">get response from web bundle</dfn> given [=url=] |url| and [=web bundle=] |web bundle|:
 
-    1. If |web bundle|'s [=web bundle/state=] is "failed", return null.
+1. If |web bundle|'s [=web bundle/state=] is "fetching", await until [=web bundle/state=] becomes "fetched" or "failed" asynchronously.
 
-    2. Assert: |web bundle|'s [=web bundle/fetched bundle=] is non-null.
+2. If |web bundle|'s [=web bundle/state=] is "failed", return null.
 
-    3. Returns [=response=] from |web bundle|'s [=web bundle/fetched bundle=] given |url| ([[draft-yasskin-wpack-bundled-exchanges]]).  If a representation of |url| is not found in [=web bundle/fetched bundle=], return null.
-</div>
+3. Assert: |web bundle|'s [=web bundle/fetched bundle=] is non-null.
 
-## Navigation ## {#navigation}
-
-Note: TODO
+4. Returns [=response=] from |web bundle|'s [=web bundle/fetched bundle=] given |url| ([[draft-yasskin-wpack-bundled-exchanges]]).  If a representation of |url| is not found in [=web bundle/fetched bundle=], return null.


### PR DESCRIPTION
This is a starting point of writing "fetch monkeypatches".

There are still many TODOs remaining, but we can refine iteratively.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hayatoito/webpackage/pull/715.html" title="Last updated on Mar 7, 2022, 6:39 AM UTC (d9d8e08)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webpackage/715/87e5b4a...hayatoito:d9d8e08.html" title="Last updated on Mar 7, 2022, 6:39 AM UTC (d9d8e08)">Diff</a>