### PR TITLE
Enable PR preview for subresource loading spec

### DIFF
--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,5 +1,5 @@
 {
-    "src_file": "loading.bs",
+    "src_file": "subresource-loading.bs",
     "type": "bikeshed",
     "params": {
         "force": 1


### PR DESCRIPTION
This enables [PR preview](https://github.com/tobie/pr-preview) for future changes in the subresource loading spec. ([like this](https://github.com/WICG/webpackage/pull/691))

Unfortunately `pr-preview` [does not support multiple specifications in single repo](https://github.com/tobie/pr-preview/issues/18), so this means we will not get PR previews for `loading.bs` after this change.

I think this is still beneficial, because we anticipate many changes to `subresource-loading.bs` for some time to come, while `loading.bs` is pretty stable these days.