### PR TITLE
Subresource loading spec: Add uuid-in-package to fetch scheme

### DIFF
--- a/subresource-loading.bs
+++ b/subresource-loading.bs
@@ -90,6 +90,18 @@ Note: TODO. This section uses [=fetch web bundle=].
 
 # Fetch monkeypatches # {#fetch-monkeypatches}
 
+## Monkeypatch fetch scheme ## {#monkeypatch-fetch-scheme}
+
+Add "`uuid-in-package`" to the schemes listed in <a spec="fetch">fetch
+scheme</a>.
+
+Note: This ensures that the <a spec="html">navigate</a> algorithm uses the
+<a spec="html">process a navigate fetch</a> algorithm for `uuid-in-package:`
+URLs.
+
+Note: The [=url/origin=] of a URL whose scheme is "`uuid-in-package`" is an
+opaque origin.
+
 ## Monkeypatch HTTP-network-or-cache fetch ## {#monkeypatch-http-network-or-cache-fetch}
 
 In <a spec="fetch">HTTP-network-or-cache fetch</a>, before


### PR DESCRIPTION
This monkeypatches the "fetch scheme" definition in Fetch spec adding "uuid-in-package" scheme, so that (monkeypatched) HTTP-network-or-cache fetch will be used for uuid-in-package: URLs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/irori/webpackage/pull/719.html" title="Last updated on Mar 16, 2022, 1:48 AM UTC (a177940)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webpackage/719/de8d025...irori:a177940.html" title="Last updated on Mar 16, 2022, 1:48 AM UTC (a177940)">Diff</a>