### PR TITLE
Specify the HTML spec integration

### DIFF
--- a/subresource-loading.bs
+++ b/subresource-loading.bs
@@ -7,6 +7,7 @@ Group: WICG
 Repository: WICG/webpackage
 URL: https://wicg.github.io/webpackage/subresource-loading.html
 Editor: Hayato Ito, Google Inc. https://google.com/, hayato@google.com
+Editor: Hiroshige Hayashizaki, Google https://google.com/, hiroshige@google.com
 Abstract: How UAs load subresources from Web Bundles.
 Complain About: accidental-2119 yes, missing-example-ids yes
 Indent: 2
@@ -59,41 +60,286 @@ Note: This specification is under construction. See
 A <dfn>fetched web bundle</dfn> is a representation of a web bundle format
 defined in [[draft-ietf-wpack-bundled-responses-latest]].
 
+A <dfn>web bundle fetch entry</dfn> is a [=struct=] with the following
+[=struct/items=]:
+
+- <dfn for="web bundle fetch entry">source</dfn>, a [=URL=] of a web bundle.
+- <dfn for="web bundle fetch entry">credentials</dfn>, a [=request/credentials
+  mode=].
+- <dfn for="web bundle fetch entry">state</dfn>, an internal state which is
+  "fetching", "fetched", or "failed". Initially "fetching".
+- <dfn for="web bundle fetch entry">fetched bundle</dfn>, a [=fetched web
+  bundle=] or null.
+
+ISSUE: A better name for [=web bundle fetch entry=]?
+
+A [=web bundle fetch entry=] |entry| is <dfn for="web bundle fetch entry">used
+by a registration</dfn> in [=Document=] |document| if |document|'s
+[=Document/web bundle registration list=] [=list/contains=] a [=web bundle
+registration=] whose [=web bundle registration/fetch entry=] is |entry|.
+
 A <dfn>bundle rule</dfn> is a [=struct=] with the following [=struct/items=]:
 
-- <dfn for="bundle rule">source</dfn>, a [=URL=] of a web bundle.
-- <dfn for="bundle rule">credentials</dfn>, a [=request/credentials mode=].
 - <dfn for="bundle rule">resources</dfn>, a [=list=] of [=URLs=].
 - <dfn for="bundle rule">scopes</dfn>, a [=list=] of [=URLs=].
 
-A <dfn>web bundle</dfn> is a [=struct=] with the following [=struct/items=]:
+A <dfn>web bundle registration</dfn> is a [=struct=] with the following
+[=struct/items=]:
 
-- <dfn for="web bundle">fetched bundle</dfn>, a [=fetched web bundle=] or null.
-- <dfn for="web bundle">rule</dfn>, a [=bundle rule=].
-- <dfn for="web bundle">state</dfn>, an internal state which is "fetching",
-  "fetched", or "failed". Initially "fetching".
+- <dfn for="web bundle registration">fetch entry</dfn>, a [=web bundle fetch
+  entry=].
+- <dfn for="web bundle registration">rule</dfn>, a [=bundle rule=].
+
+A <dfn>web bundle parse result</dfn> is a [=struct=] with the following
+[=struct/items=]:
+
+- <dfn for="web bundle parse result">source</dfn>, a [=URL=] of a web bundle.
+- <dfn for="web bundle parse result">credentials</dfn>, a [=request/credentials
+  mode=].
+- <dfn for="web bundle parse result">rule</dfn>, a [=bundle rule=].
 
 Each [=environment settings object=] will get a
-<dfn for="environment settings object">web bundle list</dfn> algorithm, which
-returns a [=list=] of [=web bundles=].
+<dfn for="environment settings object">web bundle registration list</dfn>
+algorithm, which returns a [=list=] of [=web bundle registrations=].
 
-A {{Document}} has a <dfn for=Document>web bundle list</dfn>, which is a
-[=list=] of [=web bundles=]. It is initially empty.
+A {{Document}} has a <dfn for=Document>web bundle registration list</dfn>, which
+is a [=list=] of [=web bundle registrations=]. It is initially empty.
 
 In <a spec="html">set up a window environment settings object</a>,
 <var ignore>settings object</var>'s [=environment settings object/web bundle
-list=] returns the [=Document/web bundle list=] of <var ignore>window</var>'s
-<a>associated <code>Document</code></a>.
+registration list=] returns the [=Document/web bundle registration list=] of
+<var ignore>window</var>'s <a>associated <code>Document</code></a>.
 
 In <a spec="html">set up a worker environment settings object</a>,
 <var ignore>settings object</var>'s [=environment settings object/web bundle
-list=] returns an empty [=list=].
+registration list=] returns an empty [=list=].
+
+A {{Document}} has a <dfn for=Document>web bundle fetch entry list</dfn>, which
+is a [=list=] of [=web bundle fetch entries=]. It is initially empty.
+
+ISSUE: While [=list=] is used for [=Document/web bundle fetch entry list=], the
+order shouldn't be important.
 
 ISSUE: Not supported for workers.
 
 # HTML monkeypatches # {#html-monkeypatches}
 
-Note: TODO. This section uses [=fetch web bundle=].
+To process web bundles in the <a spec="html">prepare a script</a> algorithm
+consistently with existing script types (i.e. classic or module), we make the
+following changes:
+
+- Introduce <dfn>web bundle result</dfn>, which is a [=struct=] with two
+  [=struct/items=]:
+  - a <dfn for="web bundle result">registration</dfn>, a [=web bundle
+    registration=]; and
+  - an <dfn for="web bundle result">error to rethrow</dfn>, a JavaScript value
+    representing a parse error when non-null.
+- Add "`webbundle`" to a possible value of <a spec="html">the script's type</a>.
+- Rename <a spec="html">the script's script</a> to <dfn>the script's
+  result</dfn>, which can be either a
+  <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script">script</a>
+  or a [=web bundle result=].
+
+Note: Because we don't make [=web bundle result=] a new subclass of
+<a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script">script</a>,
+other script execution-related specs are left unaffected.
+
+## Prepare a script ## {#integration-prepare-a-script}
+
+Inside the <a spec="html">prepare a script</a> algorithm, we make the following
+changes:
+
+- Insert the following step to [=prepare a script=] step 8, under "Determine the
+  script's type as follows:":
+  - If the script block's type string is an [=ASCII case-insensitive=] match for
+    the string "`webbundle`", <a spec="html">the script's type</a> is
+    "`webbundle`".
+- Insert the following case to <a spec="html">prepare a script</a> step 26.7:
+
+  - "`webbundle`":
+
+    1. [=Queue a task=] to [=fire an event=] named `error` at the element, and
+       return.
+
+       Note: `<script type="webbundle" src=...>` is not supported. There are no
+       specific requirements for the error handling here, so currently an
+       `error` event is fired similarly to the case of an empty `src` attribute.
+
+- Insert the following case to <a spec="html">prepare a script</a> step 27.2:
+
+  - "`webbundle`":
+
+    1. [=Prepare a web bundle=] given <var ignore>element</var>,
+       <var ignore>source text</var> and <var ignore>base URL</var>.
+
+- Insert the following case to <a spec="html">prepare a script</a> step 28:
+
+  - If <a spec="html">the script's type</a> is "`webbundle`":
+
+    1. Assert: <a spec="html">the script is ready</a>.
+    1. [=In parallel=], [=process events for a web bundle=] given
+       <var ignore>element</var>.
+
+NOTE: CSPs are applied to inline web bundles at Step 15 of
+<a spec="html">prepare a script</a>, just like applied to classic/module
+scripts.
+
+To <dfn>prepare a web bundle</dfn>, given an {{HTMLScriptElement}} |element|, a
+[=string=] |sourceText| and a [=URL=] |baseURL|:
+
+1. Let |parse result| be the result of [=parse a web bundle string=] given
+   |sourceText| and |baseURL|.
+1. If this throws an exception:
+   1. Set [=the script's result=] to a new [=web bundle result=] with its [=web
+      bundle result/registration=] is null and its [=web bundle result/error to
+      rethrow=] is the exception thrown.
+   1. <a spec="html">The script is ready</a>.
+   1. Return.
+1. Let |document| be |element|'s <a spec="html">node document</a>.
+1. Set |fetch entry| to null.
+1. For each |r| in |document|'s [=Document/web bundle fetch entry list=]:
+
+   1. If |r|'s [=web bundle fetch entry/source=] is |parse result|'s [=web
+      bundle parse result/source=] and |r|'s [=web bundle fetch
+      entry/credentials=] is |parse result|'s [=web bundle parse
+      result/credentials=], then:
+
+      1. If |r| is not [=web bundle fetch entry/used by a registration=] in
+         |document|, then set |fetch entry| to |r|.
+
+         NOTE: This implies that another script element whose [=the script's
+         result=]'s [=web bundle result/registration=]'s [=web bundle
+         registration/fetch entry=] is |r| was removed. This is to ensure that
+         [=web bundle fetch entries=] are not destructed and re-fetched when
+         {{HTMLScriptElement}}s with the same web bundle [=web bundle fetch
+         entry/source=] and [=web bundle fetch entry/credentials=] are removed
+         and added.
+
+1. If |fetch entry| is null:
+   1. Set |fetch entry| to a new [=web bundle fetch entry=] with its [=web
+      bundle fetch entry/source=] is |parse result|'s [=web bundle parse
+      result/source=], its [=web bundle fetch entry/credentials=] is |parse
+      result|'s [=web bundle parse result/credentials=], its [=web bundle fetch
+      entry/state=] is "fetching", and its [=web bundle fetch entry/fetched
+      bundle=] is null.
+   1. [=list/Append=] |fetch entry| to |document|'s [=Document/web bundle fetch
+      entry list=].
+   1. [=In parallel=], [=fetch a web bundle=] |fetch entry|.
+1. Let |registration| be a new [=web bundle registration=] with its [=web bundle
+   registration/fetch entry=] is |fetch entry| and its [=web bundle
+   registration/rule=] is |parse result|'s [=web bundle parse result/rule=].
+1. [=list/Append=] |registration| to |document|'s [=Document/web bundle
+   registration list=].
+1. Set [=the script's result=] to a new [=web bundle result=] with its [=web
+   bundle result/registration=] is |registration| and its [=web bundle
+   result/error to rethrow=] is null.
+1. <a spec="html">The script is ready</a>.
+
+## Firing events ## {#firing-events}
+
+In <a spec="html">execute a script block</a>, add the following case to Step 6:
+
+- "`webbundle`":
+
+      1. Assert: Never reached.
+
+         Note: Web bundles are processed by [=process events for a web bundle=] instead of <a spec="html">execute a script block</a>.
+
+To <dfn>process events for a web bundle</dfn> given an {{HTMLScriptElement}}
+|element|:
+
+1. Let |result| be [=the script's result=] of |element|.
+1. Assert: |element|'s <a spec="html">the script's type</a> is "`webbundle`".
+1. Assert: |result| is an [=web bundle result=].
+1. Await asynchronously until either of the following conditions met:
+
+   - |result|'s [=web bundle result/error to rethrow=] is not null, or
+   - |result|'s [=web bundle result/registration=] is not null and |result|'s
+     [=web bundle result/registration=]'s [=web bundle registration/fetch
+     entry=]'s [=web bundle fetch entry/state=] becomes "fetched" or "failed".
+
+   Note: Unlike other script types, we wait asynchronously here for [=fetch web
+   bundle=] before firing `load` events at {{HTMLScriptElement}}. We don't
+   <a spec="html">delay the load event</a> here, because <a spec="html">the
+   script is ready</a> synchronously in [=prepare a script=]. This is
+   intentional because [=fetch a web bundle=] is similar to preloading.
+
+1. If [=the script's result=] of |element| is null, then return.
+
+   Note: This can happen when |element| was
+   <a spec="html" href="https://html.spec.whatwg.org/multipage/infrastructure.html#remove-an-element-from-a-document">removed
+   from the document</a> during the previous step.
+
+   Note: This is specified consistently with
+   <a href="https://github.com/whatwg/html/pull/2673">whatwg/html#2673</a>.
+   Currently we don't fire `error` events in this case. If we change the
+   decision at
+   <a href="https://github.com/whatwg/html/pull/2673">whatwg/html#2673</a> to
+   fire `error` events, then change this step accordingly.
+
+1. Assert: |element|'s <a spec="html">node document</a> is equal to |element|'s
+   <a href="spec">preparation-time document</a>.
+1. If |result|'s [=web bundle result/error to rethrow=] is not null, then:
+
+   1. <a spec="html">Report the exception</a> given |result|'s [=web bundle
+      result/error to rethrow=].
+
+      ISSUE: There are no relevant
+      <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script">script</a>,
+      because [=web bundle result=] isn't a
+      <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script">script</a>.
+      This needs to wait for
+      <a href="https://github.com/whatwg/html/issues/958">whatwg/html#958</a>
+      before it is fixable.
+
+   1. Return.
+
+1. Assert: |result|'s [=web bundle result/registration=] is not null.
+1. If |result|'s [=web bundle result/registration=]'s [=web bundle
+   registration/fetch entry=]'s [=web bundle fetch entry/state=] is "failed":
+   1. [=Fire an event=] named `error` at |element|.
+   1. Return.
+1. Assert: |result|'s [=web bundle result/registration=]'s [=web bundle
+   registration/fetch entry=]'s [=web bundle fetch entry/state=] is "fetched".
+1. [=Fire an event=] named `load` at |element|.
+
+## Removing ## {#removing}
+
+If `script` element is
+<a spec="html" href="https://html.spec.whatwg.org/multipage/infrastructure.html#remove-an-element-from-a-document">removed
+from the document</a>, user agents must run the following algorithm:
+
+1. If <a spec="html">the script's type</a> is not "`webbundle`", then return.
+1. If [=the script's result=] is null, then return.
+1. Assert: [=the script's result=] is an [=web bundle result=].
+1. Let |registration| be [=the script's result=]'s [=web bundle
+   result/registration=].
+1. Set [=the script's result=] to null.
+1. If |registration| is null, then return.
+1. Let |document| be the <a spec="html">node document</a>.
+1. Assert: |document|'s [=Document/web bundle registration list=]
+   [=list/contains=] |registration|.
+1. [=list/Remove=] |registration| from |document|'s [=Document/web bundle
+   registration list=].
+1. [=Queue a microtask=] to perform the following steps:
+
+   1. Let |fetch entry| be |registration|'s [=web bundle registration/fetch
+      entry=].
+   1. If |fetch entry| is [=web bundle fetch entry/used by a registration=] in
+      |document|, then return.
+
+   1. [=list/Remove=] |fetch entry| from |document|'s [=Document/web bundle
+      fetch entry list=].
+
+      Note: It is possible that |document|'s [=Document/web bundle fetch entry
+      list=] doesn't [=list/contain=] |fetch entry| even before this step, if
+      |fetch entry| is used by [=web bundle registrations=] of multiple `script`
+      elements and the `script elements` are removed.
+
+      Note: At this point, |fetch entry| can no longer used by subsequent
+      subresource fetches nor subsequent [=prepare a web bundle=] calls, but its
+      [=web bundle fetch entry/fetched bundle=] can be still in use by ongoing
+      fetches.
 
 # Fetch monkeypatches # {#fetch-monkeypatches}
 
@@ -118,8 +364,8 @@ In <a spec="fetch">HTTP-network-or-cache fetch</a>, before
 
 add the following steps:
 
-22. Set the |response| to the result of [=fetch from web bundle=], given
-    |httpRequest|.
+22. Set the |response| to the result of [=fetch a subresource from web bundle=],
+    given |httpRequest|.
 
     1. If |response| is [=network error=], return [=network error=].
 
@@ -141,11 +387,11 @@ Rewrite
 
 2. If |url|'s [=url/scheme=] is "`uuid-in-package`", then:
 
-   1. Let |web bundle| be the result of running [=find matching web bundle=]
-      given |request|.
+   1. Let |registration| be the result of running [=find a matching web bundle
+      registration=] given |request|.
 
-   2. If |web bundle| is not null, then set |url| to |web bundle|'s [=web
-      bundle/rule=]'s [=bundle rule/source=].
+   2. If |registration| is not null, then set |url| to |registration|'s [=web
+      bundle registration/fetch entry=]'s [=web bundle fetch entry/source=].
 
 3. Returns the result of executing
    <a href="https://w3c.github.io/webappsec-csp/#match-url-to-source-list">Does
@@ -168,11 +414,11 @@ Rewrite
 
 2. If |url|'s [=url/scheme=] is "`uuid-in-package`", then:
 
-   1. Let |web bundle| be the result of running [=find matching web bundle=]
-      given |request|.
+   1. Let |registration| be the result of running [=find a matching web bundle
+      registration=] given |request|.
 
-   2. If |web bundle| is not null, then set |url| to |web bundle|'s [=web
-      bundle/rule=]'s [=bundle rule/source=].
+   2. If |registration| is not null, then set |url| to |registration|'s [=web
+      bundle registration/fetch entry=]'s [=web bundle fetch entry/source=].
 
 3. Returns the result of executing
    <a href="https://w3c.github.io/webappsec-csp/#match-url-to-source-list">Does
@@ -187,17 +433,32 @@ detailed motivation.
 
 # Algorithms # {#algorithms}
 
-## Fetch web bundle ## {#fetch-web-bundle}
+## Parsing ## {#parsing}
 
-To <dfn id="concept-fetch-web-bundle">fetch web bundle</dfn> given [=web
-bundle=] |web bundle| and [=fetch params=] |fetch params|:
+To <dfn>parse a web bundle string</dfn>, given a [=string=] |sourceText| and a
+[=URL=] |baseURL|:
 
-1. Assert: |web bundle|'s [=web bundle/state=] is "fetching".
+1. Let |parsed| be the result of [=parse JSON into Infra values|parsing JSON
+   into Infra values=] given |sourceText|.
+1. If |parsed| is not a [=map=], then throw a {{TypeError}} indicating that the
+   top-level value needs to be a JSON object.
+1. Create a [=web bundle parse result=] from |parsed| and |baseURL|, and return
+   the [=web bundle parse result=].
+
+ISSUE: Specify the details. Throw a {{TypeError}} etc. on a parse error.
+Relative URLs are resolved on |baseURL|.
+
+## Fetching a web bundle ## {#fetching-web-bundle}
+
+To <dfn>fetch a web bundle</dfn> given [=web bundle fetch entry=] |fetch entry|
+and [=fetch params=] |fetch params|:
+
+1. Assert: |fetch entry|'s [=web bundle fetch entry/state=] is "fetching".
 
 1. Let |request| be |fetch params|'s [=request=].
 
-1. Set |request|'s [=request/url=] to |web bundle|'s [=web bundle/rule=]'s
-   [=bundle rule/source=].
+1. Set |request|'s [=request/url=] to |fetch entry|'s [=web bundle fetch
+   entry/source=].
 
    Note: Source URL is resolved on document's base URL.
 
@@ -205,8 +466,8 @@ bundle=] |web bundle| and [=fetch params=] |fetch params|:
 
 1. Set |request|'s [=request/mode=] to "cors",
 
-1. Set |request|'s [=request/credentials mode=] to |web bundle|'s [=web
-   bundle/rule=]'s [=bundle rule/credentials=].
+1. Set |request|'s [=request/credentials mode=] to |fetch entry|'s [=web bundle
+   fetch entry/credentials=].
 
 1. Append a [=header=], a tuple of ("Accept", "application/webbundle;v=b2"), to
    |request|'s [=request/header list=].
@@ -216,7 +477,7 @@ bundle=] |web bundle| and [=fetch params=] |fetch params|:
    browsers, which still uses draft versions.
 
 1. [=Fetch=] |request| with [=processResponse=] algorithm set to [=process web
-   bundle response=] which is partially applied with |web bundle|.
+   bundle response=] which is partially applied with |fetch entry|.
 
    Note: Chromium's current implementation doesn't allow a nested bundle. A
    Web bundle is never fetched from other web bundles.
@@ -224,7 +485,8 @@ bundle=] |web bundle| and [=fetch params=] |fetch params|:
 ## Process web bundle response ## {#process-web-bundle-response}
 
 To <dfn id="concept-process-web-bundle-response">process web bundle
-response</dfn> given [=web bundle=] |web bundle| and [=response=] |response|:
+response</dfn> given [=web bundle fetch entry=] |fetch entry| and [=response=]
+|response|:
 
 1. If |response|'s [=response/status=] is an [=ok status=],
 
@@ -239,26 +501,28 @@ response</dfn> given [=web bundle=] |web bundle| and [=response=] |response|:
       as a web bundle format version number
       ([[draft-ietf-wpack-bundled-responses-latest]]).
 
-   2. When the parse algorithm asynchronously completes, set |web bundle|'s
-      [=web bundle/fetched bundle=] to the result of parsing and |web bundle|'s
-      [=web bundle/state=] be "fetched". If parsing fails, or any other
-      conformance is violated, set [=web bundle/fetched bundle=] to null and
-      [=web bundle/state=] to "failed".
+   2. When the parse algorithm asynchronously completes, set |fetch entry|'s
+      [=web bundle fetch entry/fetched bundle=] to the result of parsing and
+      |fetch entry|'s [=web bundle fetch entry/state=] be "fetched". If parsing
+      fails, or any other conformance is violated, set [=web bundle fetch
+      entry/fetched bundle=] to null and [=web bundle fetch entry/state=] to
+      "failed".
 
-2. Otherwise, set |web bundle|'s [=web bundle/state=] to "failed".
+1. Otherwise, set |fetch entry|'s [=web bundle fetch entry/state=] to "failed".
 
-## Fetch from web bundle ## {#fetch-from-web-bundle}
+## Fetching subresources from a web bundle ## {#fetching-subresources}
 
-To <dfn id="concept-fetch-from-web-bundle">fetch from web bundle</dfn> given
-[=request=] |httpRequest|:
+To <dfn>fetch a subresource from web bundle</dfn> given [=request=]
+|httpRequest|:
 
-1. Let |web bundle| be the result of running [=find matching web bundle=] given
-   |httpRequest|.
+1. Let |registration| be the result of running [=find a matching web bundle
+   registration=] given |httpRequest|.
 
-2. If |web bundle| is not null:
+2. If |registration| is not null:
 
-   1. Let |response| be the result of [=get response from web bundle=] given
-      |httpRequest|'s [=request/url=] and |web bundle|.
+   1. Let |response| be the result of [=get response from web bundle fetch
+      entry=] given |httpRequest|'s [=request/url=] and |registration|'s [=web
+      bundle registration/fetch entry=].
 
    2. If |response| is null, return a [=network error=].
 
@@ -272,45 +536,47 @@ To <dfn id="concept-fetch-from-web-bundle">fetch from web bundle</dfn> given
 Note: Returning null here can fallback to HTTP cache and ordinal network fetch,
 unlike returning a [=network error=] above.
 
-## Find matching web bundle ## {#find-matching-web-bundle}
+To <dfn>get response from web bundle fetch entry</dfn> given [=url=] |url| and
+[=web bundle fetch entry=] |fetch entry|:
 
-To <dfn id="concept-find-matching-web-bundle">find matching web bundle</dfn>
-given [=request=] |httpRequest|:
+1. If |fetch entry|'s [=web bundle fetch entry/state=] is "fetching", await
+   until [=web bundle fetch entry/state=] becomes "fetched" or "failed"
+   asynchronously.
+
+2. If |fetch entry|'s [=web bundle fetch entry/state=] is "failed", return null.
+
+3. Assert: |fetch entry|'s [=web bundle fetch entry/fetched bundle=] is
+   non-null.
+
+4. Returns [=response=] from |fetch entry|'s [=web bundle fetch entry/fetched
+   bundle=] given |url| ([[draft-ietf-wpack-bundled-responses-latest]]). If a
+   representation of |url| is not found in [=web bundle fetch entry/fetched
+   bundle=], return null.
+
+## Finding a matching registration ## {#matching-registration}
+
+To <dfn>find a matching web bundle registration</dfn> given [=request=]
+|httpRequest|:
 
 1. Let |url| be |httpRequest|'s [=request/url=].
 
-2. For each |web bundle| of |httpRequest|'s [=request/client=]'s [=environment
-   settings object/web bundle list=]:
+2. For each |registration| of |httpRequest|'s [=request/client=]'s [=environment
+   settings object/web bundle registration list=]:
 
-   1. Let |rule| be |web bundle|'s [=web bundle/rule=].
+   1. Let |rule| be |registration|'s [=web bundle registration/rule=].
 
-   2. If |url| doesn't meet a path restriction rule, given |rule|'s [=bundle
-      rule/source=], then return false.
+   2. If |url| doesn't meet a path restriction rule, given |registration|'s
+      [=web bundle registration/fetch entry=]'s [=web bundle fetch
+      entry/source=], then return null.
 
       Issue: Clarify path restriction rule in algorithm.
 
    3. If |rule|'s [=bundle rule/resources=] [=list/contains=] |url|, then return
-      |web bundle|.
+      |registration|.
 
    4. If |url|'s prefix matches any of |rule|'s [=bundle rule/scopes=], then
-      return |web bundle|.
+      return |registration|.
 
       Issue: Clarify prefix match rule in algorithm.
 
 3. Return null.
-
-## Get response from web bundle ## {#get-response-from-web-bundle}
-
-To <dfn id="concept-get-response-from-web-bundle">get response from web
-bundle</dfn> given [=url=] |url| and [=web bundle=] |web bundle|:
-
-1. If |web bundle|'s [=web bundle/state=] is "fetching", await until [=web
-   bundle/state=] becomes "fetched" or "failed" asynchronously.
-
-2. If |web bundle|'s [=web bundle/state=] is "failed", return null.
-
-3. Assert: |web bundle|'s [=web bundle/fetched bundle=] is non-null.
-
-4. Returns [=response=] from |web bundle|'s [=web bundle/fetched bundle=] given
-   |url| ([[draft-ietf-wpack-bundled-responses-latest]]). If a representation of
-   |url| is not found in [=web bundle/fetched bundle=], return null.


### PR DESCRIPTION
- Fill the HTML monkeypatches section.
- Introduce `web bundle fetch entry` that tracks fetching and reusing fetched bundles. `source` and `credentials` are moved from `bundle rule`, because they are associated with fetched bundles rather than rules.
- Rename `web bundle` to `web bundle registration`, to distinguish it more clearly from `web bundle fetch entry`.
- Adjust existing parts of the spec accordingly.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hiroshige-g/webpackage/pull/721.html" title="Last updated on Apr 6, 2022, 9:44 PM UTC (a24a068)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webpackage/721/dffb601...hiroshige-g:a24a068.html" title="Last updated on Apr 6, 2022, 9:44 PM UTC (a24a068)">Diff</a>