### PR TITLE
Subresource loading: Allow ok status (fix #722)

### DIFF
--- a/subresource-loading.bs
+++ b/subresource-loading.bs
@@ -217,7 +217,7 @@ bundle=] |web bundle| and [=fetch params=] |fetch params|:
    Note: Chromium's current implementation doesn't allow a *nested bundle*. A
    Web bundle is never fetched from other web bundles.
 
-1. If |response|'s [=response/status=] is 200,
+1. If |response|'s [=response/status=] is an [=ok status=],
 
    1. Set |web bundle|'s [=web bundle/fetched bundle=] to the result of parsing
       |response|'s body ([[draft-ietf-wpack-bundled-responses-latest]]) and |web


### PR DESCRIPTION
Allow all 2XX (i.e. https://fetch.spec.whatwg.org/#ok-status).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hayatoito/webpackage/pull/724.html" title="Last updated on Mar 30, 2022, 4:00 AM UTC (0754f5f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webpackage/724/17be49d...hayatoito:0754f5f.html" title="Last updated on Mar 30, 2022, 4:00 AM UTC (0754f5f)">Diff</a>