### PR TITLE
sign-bundle: Enable signing b2 bundles

### DIFF
--- a/go/bundle/version/version.go
+++ b/go/bundle/version/version.go
@@ -85,7 +85,7 @@ func ParseMagicBytes(r io.Reader) (Version, error) {
 
 func (v Version) MiceEncoding() mice.Encoding {
 	switch v {
-	case VersionB1:
+	case VersionB1, VersionB2:
 		return mice.Draft03Encoding
 	default:
 		panic("not reached")


### PR DESCRIPTION
Before this, sign-bundle panicked when attempted to sign a bundle in b2 format. After this, sign-bundle can sign b2 bundles, using the same body encoding as b1 (i.e. `mi-sha256-03`).