### PR TITLE
[subresource loading] Use |source| as the base URL

### DIFF
--- a/subresource-loading.bs
+++ b/subresource-loading.bs
@@ -457,12 +457,12 @@ To <dfn>parse a web bundle string</dfn>, given a [=string=] |sourceText| and a
 1.  If |parsed|["`resources`"] [=map/exists=], then:
     1. If |parsed|["`resources`"] is not a [=list=], then throw a {{TypeError}}.
     1. Set |resources| to the result of [=parsing a url list=] given
-       |parsed|["`resources`"] and |baseURL|.
+       |parsed|["`resources`"] and |source|.
 1.  Let |scopes| be an empty [=list=].
 1.  If |parsed|["`scopes`"] [=map/exists=], then:
     1. If |parsed|["`scopes`"] is not a [=list=], then throw a {{TypeError}}.
     1. Set |scopes| to the result of [=parsing a url list=] given
-       |parsed|["`scopes`"] and |baseURL|.
+       |parsed|["`scopes`"] and |source|.
 1.  If |parsed|'s [=map/get the keys|keys=] [=set/contains=] any items besides
     "`source`", "`credentials`", "`resources`" or "`scopes`", [=report a warning
     to the console=] that an invalid top-level key was present in the web bundle


### PR DESCRIPTION
PR #733 uses |baseURL| as the base URL in parsing a URL list.
This is wrong. We should use |source| as the base URL.

Related issues: #728.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hayatoito/webpackage/pull/734.html" title="Last updated on Apr 22, 2022, 5:37 AM UTC (06de640)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webpackage/734/d20d171...hayatoito:06de640.html" title="Last updated on Apr 22, 2022, 5:37 AM UTC (06de640)">Diff</a>