### PR TITLE
[subresource loading] Skip service workers (Fix #676)

### DIFF
--- a/subresource-loading.bs
+++ b/subresource-loading.bs
@@ -349,6 +349,20 @@ from the document</a>, user agents must run the following algorithm:
 
 # Fetch monkeypatches # {#fetch-monkeypatches}
 
+## Monkeypatch fetch ## {#monkeypatch-fetch}
+
+In <a spec="fetch">fetch</a>, before
+
+> 2. Let |taskDestination| be null.
+
+add the following step:
+
+2. If the result of [=find a matching web bundle registration=] given |request|
+   is null, set |request|'s [=request/service-workers mode=] to "`none`".
+
+Note: This means that no service workers will get events for a subresource
+loading from a webbundle.
+
 ## Monkeypatch fetch scheme ## {#monkeypatch-fetch-scheme}
 
 Add "`uuid-in-package`" to the schemes listed in <a spec="fetch">fetch
@@ -514,6 +528,8 @@ and [=fetch params=] |fetch params|:
 
 1. Set |request|'s [=request/credentials mode=] to |fetch entry|'s [=web bundle
    fetch entry/credentials=].
+
+1. Set |request|'s [=request/service-workers mode=] to "`none`".
 
 1. Append a [=header=], a tuple of ("Accept", "application/webbundle;v=b2"), to
    |request|'s [=request/header list=].


### PR DESCRIPTION
Fix #676. Skip service workers.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hayatoito/webpackage/pull/743.html" title="Last updated on May 16, 2022, 6:20 AM UTC (6786dc2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webpackage/743/5dfe4a2...hayatoito:6786dc2.html" title="Last updated on May 16, 2022, 6:20 AM UTC (6786dc2)">Diff</a>