### PR TITLE
Update README.md to reflect the latest status

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,22 +61,25 @@ The specifications come in several layers:
      is an Internet Draft, and a [draft of the next
      snapshot](https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html)
      is in this repository.
-1. [Web Bundles (previously called Bundled HTTP exchanges)](https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.html)
-   ([IETF draft](https://tools.ietf.org/html/draft-yasskin-wpack-bundled-exchanges)):
+1. Web Bundles (previously called Bundled HTTP exchanges):
    A collection of HTTP resources, each of which could be signed or unsigned, with
    some metadata describing how to interpret the bundle as a whole. This
    specification has an initial draft in a PR, but isn't finished yet. This work
    may proceed through either the IETF or the W3C/WHATWG.
+
+   *Update*: This work was moved to the [wpack-wg/bundled-responses](https://github.com/wpack-wg/bundled-responses)
+    repository ([Web Bundles (IETF draft)](https://wpack-wg.github.io/bundled-responses/draft-ietf-wpack-bundled-responses.html)) .
 1. [Loading](https://wicg.github.io/webpackage/loading.html): A description of
    how browsers load signed exchanges. This is initially specified
    here, and will eventually merge into the appropriate specs, e.g.
    [Fetch](https://fetch.spec.whatwg.org/), that live in either the W3C or
    WHATWG. Currently this only covers signed exchanges.
-1. [Subresource Loading](https://wicg.github.io/webpackage/subresource-loading.html):
-   A description of how browsers load a large number of resources
-   efficiently with Web Bundles (unsigned). This is initially
-   specified here, and will eventually merge into the appropriate
-   specs.
+1. [Subresource Loading](https://wicg.github.io/webpackage/subresource-loading.html)
+   ([Explainer](https://github.com/WICG/webpackage/blob/main/explainers/subresource-loading.md)):
+   A description of how browsers load a large number of resources efficiently with
+   [Web Bundles](https://wpack-wg.github.io/bundled-responses/draft-ietf-wpack-bundled-responses.html).
+   This is initially specified here, and will eventually merge into
+   the appropriate specs.
 
 A previous draft of the format combined layers 1 and 2 into a single format for
 signed packages:


### PR DESCRIPTION
Clarify that the Web Bundles format is now under wpack-wg/bundled-responses
reepository.