### PR TITLE
subresource-loading: Fix the build error

### DIFF
--- a/subresource-loading.bs
+++ b/subresource-loading.bs
@@ -353,7 +353,7 @@ from the document</a>, user agents must run the following algorithm:
 
 In <a spec="fetch">fetch</a>, before
 
-> 2. Let |taskDestination| be null.
+> 2. Let taskDestination be null.
 
 add the following step:
 


### PR DESCRIPTION
Fix the build error:

> WARNING: The following <var>s were only used once in the document:
>        'taskDestination'


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hayatoito/webpackage/pull/753.html" title="Last updated on May 30, 2022, 3:34 AM UTC (ba99f6b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webpackage/753/a4f5db2...hayatoito:ba99f6b.html" title="Last updated on May 30, 2022, 3:34 AM UTC (ba99f6b)">Diff</a>