### PR TITLE
Split sign-bundle logic into 2 with signType flag

### DIFF
--- a/go/bundle/cmd/sign-bundle/integrityblock.go
+++ b/go/bundle/cmd/sign-bundle/integrityblock.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"crypto"
+)
+
+func SignIntegrityBlock(privKey crypto.PrivateKey) error {
+	// TODO(sonkkeli): Actual logic.
+
+	return nil
+}

--- a/go/bundle/cmd/sign-bundle/main.go
+++ b/go/bundle/cmd/sign-bundle/main.go
@@ -1,19 +1,11 @@
 package main
 
 import (
-	"crypto"
+	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
-	"net/url"
-	"os"
 	"time"
-
-	"github.com/WICG/webpackage/go/bundle"
-	"github.com/WICG/webpackage/go/bundle/signature"
-	"github.com/WICG/webpackage/go/signedexchange"
-	"github.com/WICG/webpackage/go/signedexchange/certurl"
 )
 
 var (
@@ -25,111 +17,29 @@ var (
 	flagDate         = flag.String("date", "", "Datetime for the signature in RFC3339 format (2006-01-02T15:04:05Z). (default: current time)")
 	flagExpire       = flag.Duration("expire", 1*time.Hour, "Validity duration of the signature")
 	flagMIRecordSize = flag.Int("miRecordSize", 4096, "Record size of Merkle Integrity Content Encoding")
+	flagSignType     = flag.String("signType", "signedexchange", "Type for signing: signedexchange or integrityblock. Defaulting to signedexchange.")
 )
 
-func readCertChainFromFile(path string) (certurl.CertChain, error) {
-	fi, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer fi.Close()
-	return certurl.ReadCertChain(fi)
-}
-
-func readPrivateKeyFromFile(path string) (crypto.PrivateKey, error) {
-	privkeytext, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	return signedexchange.ParsePrivateKey(privkeytext)
-}
-
-func readBundleFromFile(path string) (*bundle.Bundle, error) {
-	fi, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer fi.Close()
-	return bundle.Read(fi)
-}
-
-func writeBundleToFile(b *bundle.Bundle, path string) error {
-	fo, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-	if err != nil {
-		return err
-	}
-	defer fo.Close()
-	_, err = b.WriteTo(fo)
-	return err
-}
-
-func addSignature(b *bundle.Bundle, signer *signature.Signer) error {
-	for _, e := range b.Exchanges {
-		if !signer.CanSignForURL(e.Request.URL) {
-			continue
-		}
-		payloadIntegrityHeader, err := e.AddPayloadIntegrity(b.Version, *flagMIRecordSize)
-		if err != nil {
-			return err
-		}
-		if err := signer.AddExchange(e, payloadIntegrityHeader); err != nil {
-			return err
-		}
-	}
-
-	newSignatures, err := signer.UpdateSignatures(b.Signatures)
-	if err != nil {
-		return err
-	}
-	b.Signatures = newSignatures
-	return nil
-}
+const (
+	signTypeExchange       = "signedexchange"
+	signTypeIntegrityBlock = "integrityblock"
+)
 
 func run() error {
-	certs, err := readCertChainFromFile(*flagCertificate)
-	if err != nil {
-		return fmt.Errorf("%s: %v", *flagCertificate, err)
-	}
-
 	privKey, err := readPrivateKeyFromFile(*flagPrivateKey)
 	if err != nil {
 		return fmt.Errorf("%s: %v", *flagPrivateKey, err)
 	}
 
-	validityUrl, err := url.Parse(*flagValidityUrl)
-	if err != nil {
-		return fmt.Errorf("failed to parse validity URL %q: %v", *flagValidityUrl, err)
-	}
+	if *flagSignType == signTypeExchange {
+		return SignExchanges(privKey)
 
-	var date time.Time
-	if *flagDate == "" {
-		date = time.Now()
+	} else if *flagSignType == signTypeIntegrityBlock {
+		return SignIntegrityBlock(privKey)
+
 	} else {
-		var err error
-		date, err = time.Parse(time.RFC3339, *flagDate)
-		if err != nil {
-			return fmt.Errorf("failed to parse date %q: %v", *flagDate, err)
-		}
+		return errors.New("Unknown signType, approved flag values are \"signedexchange\" or \"integrityblock\".")
 	}
-
-	b, err := readBundleFromFile(*flagInput)
-	if err != nil {
-		return fmt.Errorf("%s: %v", *flagInput, err)
-	}
-
-	signer, err := signature.NewSigner(b.Version, certs, privKey, validityUrl, date, *flagExpire)
-	if err != nil {
-		return err
-	}
-
-	if err := addSignature(b, signer); err != nil {
-		return err
-	}
-
-	if err := writeBundleToFile(b, *flagOutput); err != nil {
-		return fmt.Errorf("%s: %v", *flagOutput, err)
-	}
-	return nil
 }
 
 func main() {

--- a/go/bundle/cmd/sign-bundle/signedexchange.go
+++ b/go/bundle/cmd/sign-bundle/signedexchange.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"crypto"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/WICG/webpackage/go/bundle"
+	"github.com/WICG/webpackage/go/bundle/signature"
+	"github.com/WICG/webpackage/go/signedexchange"
+	"github.com/WICG/webpackage/go/signedexchange/certurl"
+)
+
+func readCertChainFromFile(path string) (certurl.CertChain, error) {
+	fi, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer fi.Close()
+	return certurl.ReadCertChain(fi)
+}
+
+func readPrivateKeyFromFile(path string) (crypto.PrivateKey, error) {
+	privkeytext, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return signedexchange.ParsePrivateKey(privkeytext)
+}
+
+func readBundleFromFile(path string) (*bundle.Bundle, error) {
+	fi, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer fi.Close()
+	return bundle.Read(fi)
+}
+
+func writeBundleToFile(b *bundle.Bundle, path string) error {
+	fo, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer fo.Close()
+	_, err = b.WriteTo(fo)
+	return err
+}
+
+func addSignature(b *bundle.Bundle, signer *signature.Signer) error {
+	for _, e := range b.Exchanges {
+		if !signer.CanSignForURL(e.Request.URL) {
+			continue
+		}
+		payloadIntegrityHeader, err := e.AddPayloadIntegrity(b.Version, *flagMIRecordSize)
+		if err != nil {
+			return err
+		}
+		if err := signer.AddExchange(e, payloadIntegrityHeader); err != nil {
+			return err
+		}
+	}
+
+	newSignatures, err := signer.UpdateSignatures(b.Signatures)
+	if err != nil {
+		return err
+	}
+	b.Signatures = newSignatures
+	return nil
+}
+
+func SignExchanges(privKey crypto.PrivateKey) error {
+	certs, err := readCertChainFromFile(*flagCertificate)
+	if err != nil {
+		return fmt.Errorf("%s: %v", *flagCertificate, err)
+	}
+
+	validityUrl, err := url.Parse(*flagValidityUrl)
+	if err != nil {
+		return fmt.Errorf("failed to parse validity URL %q: %v", *flagValidityUrl, err)
+	}
+
+	var date time.Time
+	if *flagDate == "" {
+		date = time.Now()
+	} else {
+		var err error
+		date, err = time.Parse(time.RFC3339, *flagDate)
+		if err != nil {
+			return fmt.Errorf("failed to parse date %q: %v", *flagDate, err)
+		}
+	}
+
+	b, err := readBundleFromFile(*flagInput)
+	if err != nil {
+		return fmt.Errorf("%s: %v", *flagInput, err)
+	}
+
+	signer, err := signature.NewSigner(b.Version, certs, privKey, validityUrl, date, *flagExpire)
+	if err != nil {
+		return err
+	}
+
+	if err := addSignature(b, signer); err != nil {
+		return err
+	}
+
+	if err := writeBundleToFile(b, *flagOutput); err != nil {
+		return fmt.Errorf("%s: %v", *flagOutput, err)
+	}
+	return nil
+}


### PR DESCRIPTION
This only moves the code related to signed exchange (zero changes in the logic) into its own file and adds a new flag -signType which can be specified to sign using integrity-block instead of signed exchange.

Should I already add the flag into READ.me or is it better to have it discrete until it actually works?