### PR TITLE
Move certs.go from signedexchange to internal

### DIFF
--- a/go/bundle/bundle_test.go
+++ b/go/bundle/bundle_test.go
@@ -9,7 +9,7 @@ import (
 
 	. "github.com/WICG/webpackage/go/bundle"
 	"github.com/WICG/webpackage/go/bundle/version"
-	"github.com/WICG/webpackage/go/signedexchange"
+	"github.com/WICG/webpackage/go/internal/signingalgorithm"
 	"github.com/WICG/webpackage/go/signedexchange/certurl"
 )
 
@@ -95,7 +95,7 @@ func createTestBundleWithVariants(ver version.Version) *Bundle {
 }
 
 func createTestCerts(t *testing.T) []*certurl.AugmentedCertificate {
-	certs, err := signedexchange.ParseCertificates([]byte(pemCerts))
+	certs, err := signingalgorithm.ParseCertificates([]byte(pemCerts))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +149,6 @@ func TestWriteAndReadWithVariants(t *testing.T) {
 		}
 	}
 }
-
 
 func TestB2BundleWithSpecifiedManifestURLShouldFail(t *testing.T) {
 	bundle := createTestBundle(t, version.VersionB2)

--- a/go/bundle/cmd/sign-bundle/signedexchange.go
+++ b/go/bundle/cmd/sign-bundle/signedexchange.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/WICG/webpackage/go/bundle"
 	"github.com/WICG/webpackage/go/bundle/signature"
-	"github.com/WICG/webpackage/go/signedexchange"
+	"github.com/WICG/webpackage/go/internal/signingalgorithm"
 	"github.com/WICG/webpackage/go/signedexchange/certurl"
 )
 
@@ -28,7 +28,7 @@ func readPrivateKeyFromFile(path string) (crypto.PrivateKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	return signedexchange.ParsePrivateKey(privkeytext)
+	return signingalgorithm.ParsePrivateKey(privkeytext)
 }
 
 func readBundleFromFile(path string) (*bundle.Bundle, error) {

--- a/go/bundle/signature/signer_test.go
+++ b/go/bundle/signature/signer_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/WICG/webpackage/go/bundle/signature"
 	"github.com/WICG/webpackage/go/bundle/version"
 	"github.com/WICG/webpackage/go/internal/signingalgorithm"
-	"github.com/WICG/webpackage/go/signedexchange"
 	"github.com/WICG/webpackage/go/signedexchange/certurl"
 )
 
@@ -58,7 +57,7 @@ func urlMustParse(rawurl string) *url.URL {
 }
 
 func createTestCertChain(t *testing.T) certurl.CertChain {
-	certs, err := signedexchange.ParseCertificates([]byte(pemCerts))
+	certs, err := signingalgorithm.ParseCertificates([]byte(pemCerts))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +71,7 @@ func createTestCertChain(t *testing.T) certurl.CertChain {
 func createTestSigner(t *testing.T) *Signer {
 	certChain := createTestCertChain(t)
 
-	privKey, err := signedexchange.ParsePrivateKey([]byte(pemPrivateKey))
+	privKey, err := signingalgorithm.ParsePrivateKey([]byte(pemPrivateKey))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,9 +149,9 @@ func TestSignatureGeneration(t *testing.T) {
 	}
 	expectedSigned, err := (&SignedSubset{
 		ValidityUrl: urlMustParse(validityURL),
-		AuthSha256: expectedCerts[0].CertSha256(),
-		Date: signatureDate,
-		Expires: signatureDate.Add(signatureDuration),
+		AuthSha256:  expectedCerts[0].CertSha256(),
+		Date:        signatureDate,
+		Expires:     signatureDate.Add(signatureDuration),
 		SubsetHashes: map[string]*ResponseHashes{
 			e.Request.URL.String(): &ResponseHashes{
 				VariantsValue: nil,

--- a/go/internal/signingalgorithm/certs.go
+++ b/go/internal/signingalgorithm/certs.go
@@ -1,4 +1,4 @@
-package signedexchange
+package signingalgorithm
 
 import (
 	"crypto"

--- a/go/internal/signingalgorithm/certs.go
+++ b/go/internal/signingalgorithm/certs.go
@@ -18,10 +18,10 @@ func ParseCertificates(text []byte) ([]*x509.Certificate, error) {
 			break
 		}
 		if block.Type != "CERTIFICATE" {
-			return nil, fmt.Errorf("signedexchange: found a block that contains %q.", block.Type)
+			return nil, fmt.Errorf("signingalgorithm: found a block that contains %q.", block.Type)
 		}
 		if len(block.Headers) > 0 {
-			return nil, fmt.Errorf("signedexchange: unexpected certificate headers: %v", block.Headers)
+			return nil, fmt.Errorf("signingalgorithm: unexpected certificate headers: %v", block.Headers)
 		}
 		cert, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {
@@ -37,7 +37,7 @@ func ParsePrivateKey(text []byte) (crypto.PrivateKey, error) {
 		var block *pem.Block
 		block, text = pem.Decode(text)
 		if block == nil {
-			return nil, errors.New("signedexchange: invalid PEM block in private key.")
+			return nil, errors.New("signingalgorithm: invalid PEM block in private key.")
 		}
 
 		privkey, err := parsePrivateKeyBlock(block.Bytes)
@@ -45,7 +45,7 @@ func ParsePrivateKey(text []byte) (crypto.PrivateKey, error) {
 			return privkey, nil
 		}
 	}
-	return nil, errors.New("signedexchange: could not find private key.")
+	return nil, errors.New("signingalgorithm: could not find private key.")
 }
 
 func parsePrivateKeyBlock(derKey []byte) (crypto.PrivateKey, error) {
@@ -55,11 +55,11 @@ func parsePrivateKeyBlock(derKey []byte) (crypto.PrivateKey, error) {
 		case *ecdsa.PrivateKey:
 			return typedKey, nil
 		default:
-			return nil, fmt.Errorf("signedexchange: unknown private key type in PKCS#8: %T", typedKey)
+			return nil, fmt.Errorf("signingalgorithm: unknown private key type in PKCS#8: %T", typedKey)
 		}
 	}
 	if key, err := x509.ParseECPrivateKey(derKey); err == nil {
 		return key, nil
 	}
-	return nil, errors.New("signedexchange: couldn't parse private key.")
+	return nil, errors.New("signingalgorithm: couldn't parse private key.")
 }

--- a/go/signedexchange/certurl/certchain_test.go
+++ b/go/signedexchange/certurl/certchain_test.go
@@ -5,8 +5,8 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/WICG/webpackage/go/internal/signingalgorithm"
 	"github.com/WICG/webpackage/go/internal/testhelper"
-	"github.com/WICG/webpackage/go/signedexchange"
 	. "github.com/WICG/webpackage/go/signedexchange/certurl"
 )
 
@@ -15,7 +15,7 @@ func createCertChain(t *testing.T) CertChain {
 	if err != nil {
 		t.Fatalf("Cannot read test-cert.pem: %v", err)
 	}
-	certs, err := signedexchange.ParseCertificates(in)
+	certs, err := signingalgorithm.ParseCertificates(in)
 	if err != nil {
 		t.Fatalf("Cannot parse test-cert.pem: %v", err)
 	}

--- a/go/signedexchange/certurl/ocsp_test.go
+++ b/go/signedexchange/certurl/ocsp_test.go
@@ -1,11 +1,12 @@
 package certurl_test
 
 import (
-	"github.com/WICG/webpackage/go/signedexchange"
-	. "github.com/WICG/webpackage/go/signedexchange/certurl"
-	"golang.org/x/crypto/ocsp"
 	"io/ioutil"
 	"testing"
+
+	"github.com/WICG/webpackage/go/internal/signingalgorithm"
+	. "github.com/WICG/webpackage/go/signedexchange/certurl"
+	"golang.org/x/crypto/ocsp"
 )
 
 func TestCreateOCSPRequestSmall(t *testing.T) {
@@ -15,7 +16,7 @@ func TestCreateOCSPRequestSmall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Cannot read test-cert.pem: %v", err)
 	}
-	certs, err := signedexchange.ParseCertificates(pem)
+	certs, err := signingalgorithm.ParseCertificates(pem)
 	if err != nil {
 		t.Fatalf("Cannot parse test-cert.pem: %v", err)
 	}
@@ -51,7 +52,7 @@ func TestCreateOCSPRequestLarge(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Cannot read test-cert-long.pem: %v", err)
 	}
-	certs, err := signedexchange.ParseCertificates(pem)
+	certs, err := signingalgorithm.ParseCertificates(pem)
 	if err != nil {
 		t.Fatalf("Cannot parse test-cert-long.pem: %v", err)
 	}

--- a/go/signedexchange/cmd/gen-certurl/main.go
+++ b/go/signedexchange/cmd/gen-certurl/main.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"golang.org/x/crypto/ocsp"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 
-	"github.com/WICG/webpackage/go/signedexchange"
+	"golang.org/x/crypto/ocsp"
+
+	"github.com/WICG/webpackage/go/internal/signingalgorithm"
 	"github.com/WICG/webpackage/go/signedexchange/certurl"
 )
 
@@ -26,7 +27,7 @@ func run(pemFilePath, ocspFilePath, sctDirPath string) error {
 	if err != nil {
 		return err
 	}
-	certs, err := signedexchange.ParseCertificates(pem)
+	certs, err := signingalgorithm.ParseCertificates(pem)
 	if err != nil {
 		return err
 	}

--- a/go/signedexchange/cmd/gen-signedexchange/main.go
+++ b/go/signedexchange/cmd/gen-signedexchange/main.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/WICG/webpackage/go/internal/signingalgorithm"
 	"github.com/WICG/webpackage/go/signedexchange"
 	"github.com/WICG/webpackage/go/signedexchange/certurl"
 	"github.com/WICG/webpackage/go/signedexchange/version"
@@ -69,7 +70,7 @@ func run() error {
 		return fmt.Errorf("failed to read certificate file %q. err: %v", *flagCertificate, err)
 
 	}
-	certs, err := signedexchange.ParseCertificates(certtext)
+	certs, err := signingalgorithm.ParseCertificates(certtext)
 	if err != nil {
 		return fmt.Errorf("failed to parse certificate file %q. err: %v", *flagCertificate, err)
 	}
@@ -91,7 +92,7 @@ func run() error {
 	if !ok {
 		return fmt.Errorf("failed to parse version %q", *flagVersion)
 	}
-	privkey, err := signedexchange.ParsePrivateKey(privkeytext)
+	privkey, err := signingalgorithm.ParsePrivateKey(privkeytext)
 	if err != nil {
 		return fmt.Errorf("failed to parse private key file %q. err: %v", *flagPrivateKey, err)
 	}

--- a/go/signedexchange/signedexchange_test.go
+++ b/go/signedexchange/signedexchange_test.go
@@ -62,12 +62,12 @@ func testForEachVersion(t *testing.T, testFunc func(ver version.Version, t *test
 }
 
 func TestSignedExchange(t *testing.T) {
-	certs, err := ParseCertificates([]byte(pemCerts))
+	certs, err := signingalgorithm.ParseCertificates([]byte(pemCerts))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	privKey, err := ParsePrivateKey([]byte(pemPrivateKey))
+	privKey, err := signingalgorithm.ParsePrivateKey([]byte(pemPrivateKey))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,10 +187,10 @@ func TestSignedExchangeBannedCertUrlScheme(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		certs, _ := ParseCertificates([]byte(pemCerts))
+		certs, _ := signingalgorithm.ParseCertificates([]byte(pemCerts))
 		certUrl, _ := url.Parse("http://example.com/cert.msg")
 		validityUrl, _ := url.Parse("https://example.com/resource.validity")
-		privKey, _ := ParsePrivateKey([]byte(pemPrivateKey))
+		privKey, _ := signingalgorithm.ParsePrivateKey([]byte(pemPrivateKey))
 		s := &Signer{
 			Date:        signatureDate,
 			Expires:     signatureDate.Add(1 * time.Hour),
@@ -214,12 +214,12 @@ func createTestExchange(ver version.Version, t *testing.T) (e *Exchange, s *Sign
 		t.Fatal(err)
 	}
 
-	certs, err := ParseCertificates([]byte(pemCerts))
+	certs, err := signingalgorithm.ParseCertificates([]byte(pemCerts))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	privKey, err := ParsePrivateKey([]byte(pemPrivateKey))
+	privKey, err := signingalgorithm.ParsePrivateKey([]byte(pemPrivateKey))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -358,7 +358,7 @@ func TestVerifyBadSignature(t *testing.T) {
 func TestVerifyNoContentType(t *testing.T) {
 	testForEachVersion(t, func(ver version.Version, t *testing.T) {
 		e, s, c := createTestExchange(ver, t)
-		e.ResponseHeaders.Del("Content-Type");
+		e.ResponseHeaders.Del("Content-Type")
 		if err := e.AddSignatureHeader(s); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
I will in the following CLs update ParsePrivateKey and parsePrivateKeyBlock functions so that they can also support our use case with ed25519.