### PR TITLE
js/bundle: Switch to cborg CBOR library

### DIFF
--- a/js/bundle/README.md
+++ b/js/bundle/README.md
@@ -44,7 +44,7 @@ for (const url of bundle.urls) {
     url,
     status: resp.status,
     headers: resp.headers,
-    body: resp.body.toString('utf-8')
+    body: new TextDecoder('utf-8').decode(resp.body)
   });
 }
 console.log(JSON.stringify({

--- a/js/bundle/package-lock.json
+++ b/js/bundle/package-lock.json
@@ -4,15 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/cbor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/cbor/-/cbor-2.0.0.tgz",
-      "integrity": "sha1-xievwu4i8j8jN/7LNGKKT5fGr7s=",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/mime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
@@ -31,11 +22,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "bignumber.js": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -46,14 +32,10 @@
         "concat-map": "0.0.1"
       }
     },
-    "cbor": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.0.1.tgz",
-      "integrity": "sha512-l4ghwqioCyuAaD3LvY4ONwv8NMuERz62xjbMHGdWBqERJPygVmoFER1b4+VS6iW0rXwoVGuKZPPPTofwWOg3YQ==",
-      "requires": {
-        "bignumber.js": "^9.0.0",
-        "nofilter": "^1.0.3"
-      }
+    "cborg": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.4.tgz",
+      "integrity": "sha512-ltobKo17xKYJolhg8UxQhvzcqXhjtUnovwe9Xx59Izo32gLwozGoJs/efp+8dZ5+zu9pNJYnHtmp6iJnDUapww=="
     },
     "commander": {
       "version": "4.0.1",
@@ -132,11 +114,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "nofilter": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.3.tgz",
-      "integrity": "sha512-FlUlqwRK6reQCaFLAhMcF+6VkVG2caYjKQY3YsRDTl4/SEch595Qb3oLjJRDr8dkHAAOVj2pOx3VknfnSgkE5g=="
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -153,9 +130,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
       "dev": true
     },
     "wrappy": {

--- a/js/bundle/package.json
+++ b/js/bundle/package.json
@@ -25,16 +25,15 @@
   "author": "Kunihiko Sakamoto <ksakamoto@chromium.org>",
   "license": "W3C-20150513",
   "dependencies": {
-    "cbor": "^5.0.1",
+    "cborg": "^1.9.4",
     "commander": "^4.0.1",
     "mime": "^2.4.4"
   },
   "devDependencies": {
-    "@types/cbor": "^2.0.0",
     "@types/mime": "^2.0.1",
     "@types/node": "^12.7.11",
     "jasmine": "^3.5.0",
-    "typescript": "^3.6.3"
+    "typescript": "^4.7.3"
   },
   "engines": {
     "node": ">= 8.0.0"

--- a/js/bundle/tests/decoder_test.js
+++ b/js/bundle/tests/decoder_test.js
@@ -42,8 +42,8 @@ describe('Bundle', () => {
         'content-type': 'text/plain',
         'content-language': 'ja',
       });
-      expect(resp1.body.toString('utf-8')).toBe('Hello, world!');
-      expect(resp2.body.toString('utf-8')).toBe('こんにちは世界');
+      expect(new TextDecoder('utf-8').decode(resp1.body)).toBe('Hello, world!');
+      expect(new TextDecoder('utf-8').decode(resp2.body)).toBe('こんにちは世界');
     });
 
     it('throws if URL is not found', () => {
@@ -62,7 +62,7 @@ describe('Bundle', () => {
     const resp = b.getResponse('https://example.com/hello.html');
     expect(resp.status).toBe(200);
     expect(resp.headers['content-type']).toBe('text/html; charset=utf-8');
-    expect(resp.body.toString('utf-8')).toBe(
+    expect(new TextDecoder('utf-8').decode(resp.body)).toBe(
       '<html>Hello, Web Bundle!</html>\n'
     );
   });

--- a/js/bundle/tests/decoder_test_version_b1.js
+++ b/js/bundle/tests/decoder_test_version_b1.js
@@ -44,8 +44,8 @@ describe('Bundle', () => {
         'content-type': 'text/plain',
         'content-language': 'ja',
       });
-      expect(resp1.body.toString('utf-8')).toBe('Hello, world!');
-      expect(resp2.body.toString('utf-8')).toBe('こんにちは世界');
+      expect(new TextDecoder('utf-8').decode(resp1.body)).toBe('Hello, world!');
+      expect(new TextDecoder('utf-8').decode(resp2.body)).toBe('こんにちは世界');
     });
 
     it('throws if URL is not found', () => {
@@ -65,7 +65,7 @@ describe('Bundle', () => {
     const resp = b.getResponse('https://example.com/hello.html');
     expect(resp.status).toBe(200);
     expect(resp.headers['content-type']).toBe('text/html; charset=utf-8');
-    expect(resp.body.toString('utf-8')).toBe(
+    expect(new TextDecoder('utf-8').decode(resp.body)).toBe(
       '<html>Hello, Web Bundle!</html>\n'
     );
   });

--- a/js/bundle/tests/encoder_test.js
+++ b/js/bundle/tests/encoder_test.js
@@ -1,5 +1,5 @@
 const wbn = require('../lib/wbn');
-const CBOR = require('cbor');
+const cborg = require('cborg');
 const fs = require('fs');
 const path = require('path');
 
@@ -23,7 +23,7 @@ describe('Bundle Builder', () => {
     const builder = new wbn.BundleBuilder();
     const buf = builder.createBundle();
     // Just checks the result is a valid CBOR array.
-    expect(CBOR.decode(buf)).toBeInstanceOf(Array);
+    expect(cborg.decode(buf)).toBeInstanceOf(Array);
   });
 
   describe('addExchange', () => {
@@ -83,7 +83,7 @@ describe('Bundle Builder', () => {
       );
       const expected = refBuilder.createBundle();
 
-      expect(expected.equals(generated)).toBeTrue();
+      expect(Buffer.compare(expected, generated)).toBe(0);
     });
 
     it('throws on nonexistent file', () => {
@@ -129,7 +129,7 @@ describe('Bundle Builder', () => {
       );
       const expected = refBuilder.createBundle();
 
-      expect(expected.equals(generated)).toBeTrue();
+      expect(Buffer.compare(expected, generated)).toBe(0);
     });
 
     it('accepts relative base URL', () => {
@@ -161,7 +161,7 @@ describe('Bundle Builder', () => {
       );
       const expected = refBuilder.createBundle();
 
-      expect(expected.equals(generated)).toBeTrue();
+      expect(Buffer.compare(expected, generated)).toBe(0);
     });
 
     it('accepts empty base URL', () => {
@@ -192,7 +192,7 @@ describe('Bundle Builder', () => {
       );
       const expected = refBuilder.createBundle();
 
-      expect(expected.equals(generated)).toBeTrue();
+      expect(Buffer.compare(expected, generated)).toBe(0);
     });
 
     it('throws if baseURL does not end with a slash', () => {
@@ -230,6 +230,6 @@ describe('Bundle Builder', () => {
     builder.addExchange(exampleURL, 200, defaultHeaders, new Uint8Array(1024 * 1024));
     const buf = builder.createBundle();
     // Just checks the result is a valid CBOR array.
-    expect(CBOR.decode(buf)).toBeInstanceOf(Array);
+    expect(cborg.decode(buf)).toBeInstanceOf(Array);
   });
 });

--- a/js/bundle/tests/encoder_test_version_b1.js
+++ b/js/bundle/tests/encoder_test_version_b1.js
@@ -1,5 +1,5 @@
 const wbn = require('../lib/wbn');
-const CBOR = require('cbor');
+const cborg = require('cborg');
 const fs = require('fs');
 const path = require('path');
 
@@ -25,7 +25,7 @@ describe('Bundle Builder', () => {
     builder.addExchange(primaryURL, 200, defaultHeaders, defaultContent);
     const buf = builder.createBundle();
     // Just checks the result is a valid CBOR array.
-    expect(CBOR.decode(buf)).toBeInstanceOf(Array);
+    expect(cborg.decode(buf)).toBeInstanceOf(Array);
   });
 
   describe('addExchange', () => {
@@ -142,7 +142,7 @@ describe('Bundle Builder', () => {
       );
       const expected = refBuilder.createBundle();
 
-      expect(expected.equals(generated)).toBeTrue();
+      expect(Buffer.compare(expected, generated)).toBe(0);
     });
 
     it('throws if baseURL does not end with a slash', () => {
@@ -214,6 +214,6 @@ describe('Bundle Builder', () => {
     builder.addExchange(primaryURL, 200, defaultHeaders, new Uint8Array(1024 * 1024));
     const buf = builder.createBundle();
     // Just checks the result is a valid CBOR array.
-    expect(CBOR.decode(buf)).toBeInstanceOf(Array);
+    expect(cborg.decode(buf)).toBeInstanceOf(Array);
   });
 });


### PR DESCRIPTION
This would make the `wbn` library easier to be used in browsers, because the `cborg` library uses `Uint8Array`s rather than Node.js `Buffer`s.

This also removes some code to workaround the quirks of the `cbor` library.