### PR TITLE
Disable trying to use dump-bundle with integrity-block

### DIFF
--- a/go/bundle/cmd/dump-bundle/main.go
+++ b/go/bundle/cmd/dump-bundle/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/WICG/webpackage/go/bundle"
 	"github.com/WICG/webpackage/go/bundle/signature"
+	"github.com/WICG/webpackage/go/integrityblock"
 )
 
 var (
@@ -24,6 +26,16 @@ func ReadBundleFromFile(path string) (*bundle.Bundle, error) {
 		return nil, fmt.Errorf("Failed to open input file %q for reading. err: %v", path, err)
 	}
 	defer fi.Close()
+
+	hasIntegrityBlock, err := integrityblock.WebBundleHasIntegrityBlock(fi)
+	if err != nil {
+		return nil, err
+	}
+
+	if hasIntegrityBlock {
+		return nil, errors.New("dump-bundle doesn't support bundles which have been signed using integrity block.")
+	}
+
 	return bundle.Read(fi)
 }
 

--- a/go/integrityblock/integrityblock.go
+++ b/go/integrityblock/integrityblock.go
@@ -220,3 +220,23 @@ func ComputeEd25519Signature(ed25519privKey ed25519.PrivateKey, dataToBeSigned [
 	}
 	return signature, nil
 }
+
+// WebBundleHasIntegrityBlock is a helper function that can be called with any file path to check if it has
+// an integrtiy block. Basically this checks if the bytes fileBytes[2:10] match with the magic bytes.
+func WebBundleHasIntegrityBlock(bundleFile io.ReadSeeker) (bool, error) {
+	bundleFile.Seek(2, io.SeekStart)
+
+	possibleMagic := make([]byte, len(IntegrityBlockMagic))
+	numBytesRead, err := io.ReadFull(bundleFile, possibleMagic)
+	if err != nil {
+		return false, err
+	}
+	if numBytesRead != len(IntegrityBlockMagic) {
+		return false, nil
+	}
+
+	// Return to the start of the file.
+	bundleFile.Seek(0, io.SeekStart)
+
+	return bytes.Compare(IntegrityBlockMagic, possibleMagic) == 0, nil
+}

--- a/go/integrityblock/integrityblock_test.go
+++ b/go/integrityblock/integrityblock_test.go
@@ -197,3 +197,30 @@ func TestIntegrityBlockGeneratedWithTheToolIsDeterministic(t *testing.T) {
 		t.Error("Integrity block with one signature generated using our tool should be deterministic.")
 	}
 }
+
+func TestUnsignedWebBundleDoesntHaveIntegrityBlock(t *testing.T) {
+	bundleFile, err := os.Open("./testfile.wbn")
+	if err != nil {
+		t.Error("Error opening testfile.wbn")
+	}
+	defer bundleFile.Close()
+
+	hasIntegrityBlock, err := WebBundleHasIntegrityBlock(bundleFile)
+	if err != nil {
+		t.Error(err)
+	} else if hasIntegrityBlock {
+		t.Error("Unsigned web bundle should not have an integrity block.")
+	}
+}
+
+func TestSignedWebBundleHasIntegrityBlockestAnother(t *testing.T) {
+	ib, err := generateEmptyIntegrityBlock().CborBytes()
+	r := bytes.NewReader(ib)
+
+	hasIntegrityBlock, err := WebBundleHasIntegrityBlock(r)
+	if err != nil {
+		t.Error(err)
+	} else if !hasIntegrityBlock {
+		t.Error("Signed web bundle should have an integrity block.")
+	}
+}


### PR DESCRIPTION
peletskyi@ 's opinion was that this approach would be better than trusting on the web bundle length vs file size. Let me know if you disagree :) 