### PR TITLE
Fix the path restriction rule

### DIFF
--- a/subresource-loading.bs
+++ b/subresource-loading.bs
@@ -629,11 +629,16 @@ To <dfn>find a matching web bundle registration</dfn> given [=request=]
 
    2. If |url|'s [=url/scheme=] is not "`uuid-in-package`", then
 
+      1. If |url|'s [=url/origin=] and |registration|'s [=web bundle
+         registration/fetch entry=]'s [=web bundle fetch entry/source=]'s
+         [=url/origin=] are not [=same origin=], then [=continue=].
+
       1. Let |allowed path| be the result of [=shortening=] |registration|'s
          [=web bundle registration/fetch entry=]'s [=web bundle fetch
-         entry/source=].
+         entry/source=]'s [=url/path=].
 
-      2. If |url| doesn't start with |allowed path|, then [=continue=].
+      1. If |url|'s [=url/path=] doesn't start with |allowed path|, then
+         [=continue=].
 
    3. If |rule|'s [=bundle rule/resources=] [=list/contains=] |url|, then return
       |registration|.


### PR DESCRIPTION
The current definition doesn't consider URL's origin. This is an
unintentional. Let's fix it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hayatoito/webpackage/pull/794.html" title="Last updated on Aug 26, 2022, 6:45 AM UTC (d3c8567)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webpackage/794/c614114...hayatoito:d3c8567.html" title="Last updated on Aug 26, 2022, 6:45 AM UTC (d3c8567)">Diff</a>