### PR TITLE
Signature attributes should always be freshly generated and never read from the stack

### DIFF
--- a/go/bundle/cmd/sign-bundle/integrityblock.go
+++ b/go/bundle/cmd/sign-bundle/integrityblock.go
@@ -55,8 +55,8 @@ func SignWithIntegrityBlock(privKey crypto.PrivateKey) error {
 		return err
 	}
 
-	signatureAttributes := integrityblock.GetLastSignatureAttributes(integrityBlock)
-	signatureAttributes[integrityblock.Ed25519publicKeyAttributeName] = []byte(ed25519publicKey)
+	// Signature attributes used in data to be signed is always freshly generated.
+	signatureAttributes := map[string][]byte{integrityblock.Ed25519publicKeyAttributeName: []byte(ed25519publicKey)}
 
 	integrityBlockBytes, err := integrityBlock.CborBytes()
 	if err != nil {

--- a/go/integrityblock/integrityblock.go
+++ b/go/integrityblock/integrityblock.go
@@ -162,18 +162,6 @@ func (integrityBlock *IntegrityBlock) AddNewSignatureToIntegrityBlock(signatureA
 	integrityBlock.SignatureStack = append(is, integrityBlock.SignatureStack...)
 }
 
-// getLastSignatureAttributes returns the signature attributes from the newest (the first)
-// signature stack or a new empty map if the signature stack is empty.
-func GetLastSignatureAttributes(integrityBlock *IntegrityBlock) map[string][]byte {
-	var signatureAttributes map[string][]byte
-	if len(integrityBlock.SignatureStack) == 0 {
-		signatureAttributes = make(map[string][]byte, 1)
-	} else {
-		signatureAttributes = (*integrityBlock.SignatureStack[0]).SignatureAttributes
-	}
-	return signatureAttributes
-}
-
 // ComputeWebBundleSha512 computes the SHA-512 hash over the given web bundle file.
 func ComputeWebBundleSha512(bundleFile io.ReadSeeker, offset int64) ([]byte, error) {
 	h := sha512.New()

--- a/go/integrityblock/integrityblock_test.go
+++ b/go/integrityblock/integrityblock_test.go
@@ -78,37 +78,6 @@ func TestIntegritySignature(t *testing.T) {
 	}
 }
 
-func TestGetLastSignatureAttributesWithEmptySingatureStack(t *testing.T) {
-	got := GetLastSignatureAttributes(generateEmptyIntegrityBlock())
-	if len(got) != 0 {
-		t.Error("integrityblock: GetLastSignatureAttributes is not empty.")
-	}
-}
-
-func TestGetLastSignatureAttributesWithOneSingatureInTheStack(t *testing.T) {
-	pubKey := []byte("publickey")
-	attributes := map[string][]byte{Ed25519publicKeyAttributeName: pubKey}
-
-	integritySignatures := []*IntegritySignature{{
-		SignatureAttributes: attributes,
-		Signature:           []byte("signature"),
-	}}
-
-	integrityBlock := &IntegrityBlock{
-		Magic:          IntegrityBlockMagic,
-		Version:        VersionB1,
-		SignatureStack: integritySignatures,
-	}
-
-	got := GetLastSignatureAttributes(integrityBlock)
-	if len(got) != 1 {
-		t.Error("integrityblock: GetLastSignatureAttributes is either empty or contains other attributes.")
-	}
-	if !bytes.Equal(got[Ed25519publicKeyAttributeName], pubKey) {
-		t.Errorf("integrityblock: got: %s\nwant: %s", got, pubKey)
-	}
-}
-
 func TestComputeWebBundleSha512(t *testing.T) {
 	bundleFile, err := os.Open("./testfile.wbn")
 	if err != nil {


### PR DESCRIPTION
This fixes a bug which I had on generating the payload for signing in case there would already be existing signatures on the signature stack.