### PR TITLE
Add github action to enforce lint pre-merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16.6'
+          go-version: "^1.16.6"
       - run: go test -v ./go/...
 
   javascript:
@@ -23,3 +23,14 @@ jobs:
       - run: npm --prefix ./js/bundle ci
       - run: npm --prefix ./js/bundle run build
       - run: npm --prefix ./js/bundle test
+
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: creyD/prettier_action@v4.2
+        with:
+          prettier_options: --write **/*.{js,ts}
+          only_changed: True
+          dry: True
+          prettier_version: 2.7.1

--- a/js/bundle/tests/cli_test.js
+++ b/js/bundle/tests/cli_test.js
@@ -2,12 +2,12 @@ import * as wbn from '../lib/wbn.js';
 import * as cli from '../lib/cli.js';
 import * as fs from 'fs';
 import * as path from 'path';
-import url from "url";
+import url from 'url';
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
 describe('CLI', () => {
   const exampleURL = 'https://example.com/';
-    describe('addFile', () => {
+  describe('addFile', () => {
     it('adds an exchange as expected', () => {
       const file = path.resolve(__dirname, 'testdata/encoder_test/index.html');
       const builder = new wbn.BundleBuilder();
@@ -112,12 +112,7 @@ describe('CLI', () => {
         { 'Content-Type': 'text/html' },
         fs.readFileSync(path.resolve(dir, 'index.html'))
       );
-      refBuilder.addExchange(
-        'index.html',
-        301,
-        { Location: './' },
-        ''
-      );
+      refBuilder.addExchange('index.html', 301, { Location: './' }, '');
       refBuilder.addExchange(
         'resources/style.css',
         200,

--- a/js/bundle/tests/decoder_test.js
+++ b/js/bundle/tests/decoder_test.js
@@ -1,7 +1,7 @@
 import * as wbn from '../lib/wbn.js';
 import * as fs from 'fs';
 import * as path from 'path';
-import url from "url";
+import url from 'url';
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
 // Tests for webbundle format version b2
@@ -45,7 +45,9 @@ describe('Bundle', () => {
         'content-language': 'ja',
       });
       expect(new TextDecoder('utf-8').decode(resp1.body)).toBe('Hello, world!');
-      expect(new TextDecoder('utf-8').decode(resp2.body)).toBe('こんにちは世界');
+      expect(new TextDecoder('utf-8').decode(resp2.body)).toBe(
+        'こんにちは世界'
+      );
     });
 
     it('throws if URL is not found', () => {
@@ -57,7 +59,9 @@ describe('Bundle', () => {
   });
 
   it('parses pregenerated bundle', () => {
-    const buf = fs.readFileSync(path.resolve(__dirname, 'testdata/hello_b2.wbn'));
+    const buf = fs.readFileSync(
+      path.resolve(__dirname, 'testdata/hello_b2.wbn')
+    );
     const b = new wbn.Bundle(buf);
     expect(b.primaryURL).toBe(null);
     expect(b.urls).toEqual(['https://example.com/hello.html']);

--- a/js/bundle/tests/decoder_test_version_b1.cjs
+++ b/js/bundle/tests/decoder_test_version_b1.cjs
@@ -45,7 +45,9 @@ describe('Bundle', () => {
         'content-language': 'ja',
       });
       expect(new TextDecoder('utf-8').decode(resp1.body)).toBe('Hello, world!');
-      expect(new TextDecoder('utf-8').decode(resp2.body)).toBe('こんにちは世界');
+      expect(new TextDecoder('utf-8').decode(resp2.body)).toBe(
+        'こんにちは世界'
+      );
     });
 
     it('throws if URL is not found', () => {
@@ -57,7 +59,9 @@ describe('Bundle', () => {
   });
 
   it('parses pregenerated bundle', () => {
-    const buf = fs.readFileSync(path.resolve(__dirname, 'testdata/hello_b1.wbn'));
+    const buf = fs.readFileSync(
+      path.resolve(__dirname, 'testdata/hello_b1.wbn')
+    );
     const b = new wbn.Bundle(buf);
     expect(b.primaryURL).toBe('https://example.com/hello.html');
     expect(b.manifestURL).toBe(null);

--- a/js/bundle/tests/encoder_test.js
+++ b/js/bundle/tests/encoder_test.js
@@ -9,7 +9,7 @@ describe('Bundle Builder', () => {
   const validURLs = [
     'https://example.com/',
     'relative/url',
-    '',  // An empty string is a valid relative URL.
+    '', // An empty string is a valid relative URL.
   ];
   const exampleURL = validURLs[0];
   const invalidURLs = [
@@ -34,7 +34,7 @@ describe('Bundle Builder', () => {
 
     it('accepts valid URLs', () => {
       const builder = new wbn.BundleBuilder();
-      validURLs.forEach(url => {
+      validURLs.forEach((url) => {
         expect(
           builder.addExchange(url, 200, defaultHeaders, defaultContent)
         ).toBe(builder);
@@ -43,7 +43,7 @@ describe('Bundle Builder', () => {
 
     it('rejects invalid URLs', () => {
       const builder = new wbn.BundleBuilder();
-      invalidURLs.forEach(url => {
+      invalidURLs.forEach((url) => {
         expect(() =>
           builder.addExchange(url, 200, defaultHeaders, defaultContent)
         ).toThrowError();
@@ -67,7 +67,7 @@ describe('Bundle Builder', () => {
 
     it('rejects invalid URLs', () => {
       const builder = new wbn.BundleBuilder();
-      invalidURLs.forEach(url => {
+      invalidURLs.forEach((url) => {
         expect(() => builder.setPrimaryURL(url)).toThrowError();
       });
     });
@@ -75,15 +75,18 @@ describe('Bundle Builder', () => {
     it('rejects double call', () => {
       const builder = new wbn.BundleBuilder();
       builder.setPrimaryURL(exampleURL);
-      expect(() =>
-        builder.setPrimaryURL(exampleURL)
-      ).toThrowError();
+      expect(() => builder.setPrimaryURL(exampleURL)).toThrowError();
     });
   });
 
   it('builds large bundle', () => {
     const builder = new wbn.BundleBuilder();
-    builder.addExchange(exampleURL, 200, defaultHeaders, new Uint8Array(1024 * 1024));
+    builder.addExchange(
+      exampleURL,
+      200,
+      defaultHeaders,
+      new Uint8Array(1024 * 1024)
+    );
     const buf = builder.createBundle();
     // Just checks the result is a valid CBOR array.
     expect(cborg.decode(buf)).toBeInstanceOf(Array);

--- a/js/bundle/tests/encoder_test_version_b1.cjs
+++ b/js/bundle/tests/encoder_test_version_b1.cjs
@@ -6,11 +6,7 @@ const cborg = require('cborg');
 describe('Bundle Builder', () => {
   const defaultHeaders = { 'Content-Type': 'text/plain' };
   const defaultContent = 'Hello, world!';
-  const validURLs = [
-    'https://example.com/',
-    'relative/url',
-    '',
-  ]
+  const validURLs = ['https://example.com/', 'relative/url', ''];
   const primaryURL = validURLs[0];
   const invalidURLs = [
     'https://example.com/#fragment',
@@ -38,7 +34,7 @@ describe('Bundle Builder', () => {
     it('accepts valid URLs', () => {
       const builder = new wbn.BundleBuilder('b1');
       builder.setPrimaryURL(primaryURL);
-      validURLs.forEach(url => {
+      validURLs.forEach((url) => {
         expect(
           builder.addExchange(url, 200, defaultHeaders, defaultContent)
         ).toBe(builder);
@@ -48,7 +44,7 @@ describe('Bundle Builder', () => {
     it('rejects invalid URLs', () => {
       const builder = new wbn.BundleBuilder('b1');
       builder.setPrimaryURL(primaryURL);
-      invalidURLs.forEach(url => {
+      invalidURLs.forEach((url) => {
         expect(() =>
           builder.addExchange(url, 200, defaultHeaders, defaultContent)
         ).toThrowError();
@@ -72,14 +68,14 @@ describe('Bundle Builder', () => {
     });
 
     it('must be called before createBundle', () => {
-      invalidURLs.forEach(url => {
+      invalidURLs.forEach((url) => {
         const builder = new wbn.BundleBuilder('b1');
         expect(() => builder.createBundle()).toThrowError();
       });
     });
 
     it('rejects invalid URLs', () => {
-      invalidURLs.forEach(url => {
+      invalidURLs.forEach((url) => {
         const builder = new wbn.BundleBuilder('b1');
         expect(() => builder.setPrimaryURL(url)).toThrowError();
       });
@@ -88,9 +84,7 @@ describe('Bundle Builder', () => {
     it('rejects double call', () => {
       const builder = new wbn.BundleBuilder('b1');
       builder.setPrimaryURL(primaryURL);
-      expect(() =>
-        builder.setPrimaryURL(primaryURL)
-      ).toThrowError();
+      expect(() => builder.setPrimaryURL(primaryURL)).toThrowError();
     });
   });
 
@@ -104,7 +98,7 @@ describe('Bundle Builder', () => {
     it('rejects invalid URLs', () => {
       const builder = new wbn.BundleBuilder('b1');
       builder.setPrimaryURL(primaryURL);
-      invalidURLs.forEach(url => {
+      invalidURLs.forEach((url) => {
         expect(() => builder.setManifestURL(url)).toThrowError();
       });
     });
@@ -122,7 +116,12 @@ describe('Bundle Builder', () => {
   it('builds large bundle', () => {
     const builder = new wbn.BundleBuilder('b1');
     builder.setPrimaryURL(primaryURL);
-    builder.addExchange(primaryURL, 200, defaultHeaders, new Uint8Array(1024 * 1024));
+    builder.addExchange(
+      primaryURL,
+      200,
+      defaultHeaders,
+      new Uint8Array(1024 * 1024)
+    );
     const buf = builder.createBundle();
     // Just checks the result is a valid CBOR array.
     expect(cborg.decode(buf)).toBeInstanceOf(Array);


### PR DESCRIPTION
To use prettier on save, one can install the [VScode prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and then in VScode's settings have the following entries:

```
"editor.formatOnSave": true,
"[javascript]": {
        "editor.defaultFormatter": "esbenp.prettier-vscode"
}
```

Also prettifying the test files