### PR TITLE
Sign and verify data to be signed

### DIFF
--- a/js/sign/src/integrityblock.ts
+++ b/js/sign/src/integrityblock.ts
@@ -105,12 +105,9 @@ export class IntegrityBlockSigner {
     // (1) integrity block, and
     // (2) attributes.
     const dataParts = [
-      { length: webBundleHash.length, bytes: webBundleHash },
-      {
-        length: integrityBlockCborBytes.length,
-        bytes: integrityBlockCborBytes,
-      },
-      { length: newAttributesCborBytes.length, bytes: newAttributesCborBytes },
+      webBundleHash,
+      integrityBlockCborBytes,
+      newAttributesCborBytes,
     ];
 
     const bigEndianNumLength = 8;
@@ -121,12 +118,12 @@ export class IntegrityBlockSigner {
     let buffer = Buffer.alloc(totalLength);
 
     let offset = 0;
-    dataParts.forEach((data) => {
-      buffer.writeBigInt64BE(BigInt(data.length), offset);
+    dataParts.forEach((d) => {
+      buffer.writeBigInt64BE(BigInt(d.length), offset);
       offset += bigEndianNumLength;
 
-      Buffer.from(data.bytes).copy(buffer, offset);
-      offset += data.length;
+      Buffer.from(d).copy(buffer, offset);
+      offset += d.length;
     });
 
     return new Uint8Array(buffer);

--- a/js/sign/tests/integrityblock_test.js
+++ b/js/sign/tests/integrityblock_test.js
@@ -5,25 +5,42 @@ import * as path from 'path';
 import * as crypto from 'crypto';
 import * as cborg from 'cborg';
 import url from 'url';
+
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const TEST_WEB_BUNDLE_HASH =
+  '95f8713d382ffefb8f1e4f464e39a2bf18280c8b26434d2fcfc08d7d710c8919ace5a652e25e66f9292cda424f20e4b53bf613bf9488140272f56a455393f7e6';
+const EMPTY_INTEGRITY_BLOCK_HEX = '8348f09f968bf09f93a6443162000080';
 
 describe('Integrity Block Signer', () => {
-  function initSignerWithTestWebBundleAndKeys(keyType = 'ed25519') {
-    const keypair = crypto.generateKeyPairSync(keyType);
+  function initSignerWithTestWebBundleAndKeys(privateKey) {
     const file = path.resolve(__dirname, 'testdata/unsigned.wbn');
     const contents = fs.readFileSync(file);
     const signer = new wbnSign.IntegrityBlockSigner(contents, {
-      key: keypair.privateKey,
+      key: privateKey,
     });
     return signer;
   }
 
   it('accepts only ed25519 type of key.', () => {
-    const signer = initSignerWithTestWebBundleAndKeys();
-    const integrityBlock = signer.sign();
+    const keypair = crypto.generateKeyPairSync('ed25519');
+    const signer = initSignerWithTestWebBundleAndKeys(keypair.privateKey);
+    signer.sign();
 
-    for (const keyType of ['rsa', 'dsa', 'ec', 'ed448', 'x25519', 'x448']) {
-      expect(() => initSignerWithTestWebBundleAndKeys(keyType)).toThrowError();
+    for (const invalidKey of [
+      { keyType: 'rsa', options: { modulusLength: 2048 } },
+      { keyType: 'dsa', options: { modulusLength: 1024, divisorLength: 224 } },
+      { keyType: 'ec', options: { namedCurve: 'secp256k1' } },
+      { keyType: 'ed448' },
+      { keyType: 'x25519' },
+      { keyType: 'x448' },
+    ]) {
+      const keypairInvalid = crypto.generateKeyPairSync(
+        invalidKey.keyType,
+        invalidKey.options
+      );
+      expect(() =>
+        initSignerWithTestWebBundleAndKeys(keypairInvalid.privateKey)
+      ).toThrowError();
     }
   });
 
@@ -32,7 +49,7 @@ describe('Integrity Block Signer', () => {
     const cbor = integrityBlock.toCBOR();
 
     expect(cbor).toEqual(
-      Uint8Array.from(Buffer.from('8348F09F968BF09F93A6443162000080', 'hex'))
+      Uint8Array.from(Buffer.from(EMPTY_INTEGRITY_BLOCK_HEX, 'hex'))
     );
 
     const decoded = cborg.decode(cbor);
@@ -43,12 +60,67 @@ describe('Integrity Block Signer', () => {
   });
 
   it('calculates the hash of the web bundle correctly.', () => {
-    const signer = initSignerWithTestWebBundleAndKeys();
-    const hexHashString =
-      '95f8713d382ffefb8f1e4f464e39a2bf18280c8b26434d2fcfc08d7d710c8919ace5a652e25e66f9292cda424f20e4b53bf613bf9488140272f56a455393f7e6';
+    const keypair = crypto.generateKeyPairSync('ed25519');
+    const signer = initSignerWithTestWebBundleAndKeys(keypair.privateKey);
 
     expect(signer.calcWebBundleHash()).toEqual(
+      Uint8Array.from(Buffer.from(TEST_WEB_BUNDLE_HASH, 'hex'))
+    );
+  });
+
+  it('generates the dataToBeSigned correctly.', () => {
+    const keypair = crypto.generateKeyPairSync('ed25519');
+    const signer = initSignerWithTestWebBundleAndKeys(keypair.privateKey);
+    const rawPubKey = signer.getRawPublicKey(keypair.publicKey);
+    const dataToBeSigned = signer.generateDataToBeSigned(
+      signer.calcWebBundleHash(),
+      new wbnSign.IntegrityBlock().toCBOR(),
+      cborg.encode({
+        [constants.ED25519_PK_SIGNATURE_ATTRIBUTE_NAME]: rawPubKey,
+      })
+    );
+
+    const hexHashString =
+      /*64*/ '0000000000000040' +
+      TEST_WEB_BUNDLE_HASH +
+      /*16*/ '0000000000000010' +
+      EMPTY_INTEGRITY_BLOCK_HEX +
+      /*52*/ '0000000000000034' +
+      'a170656432353531395075626c69634b65795820' +
+      Buffer.from(rawPubKey).toString('hex');
+
+    expect(dataToBeSigned).toEqual(
       Uint8Array.from(Buffer.from(hexHashString, 'hex'))
     );
+  });
+
+  it('generates a valid signature.', () => {
+    const keypair = crypto.generateKeyPairSync('ed25519');
+    const signer = initSignerWithTestWebBundleAndKeys(keypair.privateKey);
+    const rawPubKey = signer.getRawPublicKey(keypair.publicKey);
+    const sigAttr = {
+      [constants.ED25519_PK_SIGNATURE_ATTRIBUTE_NAME]: rawPubKey,
+    };
+    const dataToBeSigned = signer.generateDataToBeSigned(
+      signer.calcWebBundleHash(),
+      new wbnSign.IntegrityBlock().toCBOR(),
+      cborg.encode(sigAttr)
+    );
+
+    const ib = cborg.decode(signer.sign());
+    expect(ib.length).toEqual(3);
+    expect(ib[0]).toEqual(constants.INTEGRITY_BLOCK_MAGIC);
+    expect(ib[1]).toEqual(constants.VERSION_B1);
+    expect(ib[2].length).toEqual(1);
+    expect(ib[2][0].length).toEqual(2);
+    expect(ib[2][0][0]).toEqual(sigAttr);
+    expect(
+      crypto.verify(
+        /*algorithm=*/ undefined,
+        dataToBeSigned,
+        keypair.publicKey,
+        ib[2][0][1]
+      )
+    ).toBeTruthy();
   });
 });

--- a/js/sign/tests/integrityblock_test.js
+++ b/js/sign/tests/integrityblock_test.js
@@ -109,17 +109,21 @@ describe('Integrity Block Signer', () => {
 
     const ib = cborg.decode(signer.sign());
     expect(ib.length).toEqual(3);
-    expect(ib[0]).toEqual(constants.INTEGRITY_BLOCK_MAGIC);
-    expect(ib[1]).toEqual(constants.VERSION_B1);
-    expect(ib[2].length).toEqual(1);
-    expect(ib[2][0].length).toEqual(2);
-    expect(ib[2][0][0]).toEqual(sigAttr);
+
+    const [magic, version, signatureStack] = ib;
+    expect(magic).toEqual(constants.INTEGRITY_BLOCK_MAGIC);
+    expect(version).toEqual(constants.VERSION_B1);
+    expect(signatureStack.length).toEqual(1);
+    expect(signatureStack[0].length).toEqual(2);
+
+    const [signatureAttributes, signature] = signatureStack[0];
+    expect(signatureAttributes).toEqual(sigAttr);
     expect(
       crypto.verify(
         /*algorithm=*/ undefined,
         dataToBeSigned,
         keypair.publicKey,
-        ib[2][0][1]
+        signature
       )
     ).toBeTruthy();
   });


### PR DESCRIPTION
Generate data to be signed to be a combination of
1. 64 bit big-endian integer length of the web bundle hash
2. web bundle hash
3. 64 bit big-endian integer length of integrity-block (CBOR)
4. integrity-block CBOR
5. 64 bit big-endian integer length of signature attributes (CBOR)
6. signature attributes CBOR

Sign the data to be signed and verify that the signature is ok.