### PR TITLE
Calculate web bundle ID from private ed25519 key

### DIFF
--- a/go/bundle/cmd/sign-bundle/integrityblock.go
+++ b/go/bundle/cmd/sign-bundle/integrityblock.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"crypto/ed25519"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 
@@ -69,6 +70,9 @@ func SignWithIntegrityBlock(privKey crypto.PrivateKey) error {
 	if err != nil {
 		return err
 	}
+
+	webBundleId := integrityblock.GetWebBundleId(ed25519privKey)
+	fmt.Println("Web Bundle ID: " + webBundleId)
 
 	signedBundleFile, err := os.Create(*flagOutput)
 	if err != nil {

--- a/go/integrityblock/integrityblock_test.go
+++ b/go/integrityblock/integrityblock_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/WICG/webpackage/go/internal/cbor"
+	"github.com/WICG/webpackage/go/internal/signingalgorithm"
 	"github.com/WICG/webpackage/go/internal/testhelper"
 )
 
@@ -304,6 +305,21 @@ func TestSignAndAddNewSignatureWithExistingSignature(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if got != want {
+		t.Errorf("integrityblock: got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestGetWebBundleId(t *testing.T) {
+	privateKeyString := "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIB8nP5PpWU7HiILHSfh5PYzb5GAcIfHZ+bw6tcd/LZXh\n-----END PRIVATE KEY-----"
+	privateKey, err := signingalgorithm.ParsePrivateKey([]byte(privateKeyString))
+	if err != nil {
+		t.Errorf("integrityblock: Failed to parse the test private key. err: %v", err)
+	}
+
+	got := GetWebBundleId(privateKey.(ed25519.PrivateKey))
+	want := "4tkrnsmftl4ggvvdkfth3piainqragus2qbhf7rlz2a3wo3rh4wqaaic"
+
 	if got != want {
 		t.Errorf("integrityblock: got: %s\nwant: %s", got, want)
 	}


### PR DESCRIPTION
Add a helper function to calculate the web bundle's base32 encoded app ID. Also print it out after siging is complete.