### PR TITLE
Use sub commands for sign-bundle CLI tool and add dump-id

### DIFF
--- a/go/bundle/README.md
+++ b/go/bundle/README.md
@@ -1,25 +1,42 @@
 # go/bundle
-This directory contains a reference implementation of the [Web
-Bundles](https://wpack-wg.github.io/bundled-responses/draft-ietf-wpack-bundled-responses.html)
+
+This directory contains a reference implementation of the
+[Web Bundles](https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.html)
 spec.
 
 ## Overview
-We currently provide three command-line tools: `gen-bundle`, `sign-bundle` and `dump-bundle`.
 
-`gen-bundle` command is a bundle generator tool. `gen-bundle` consumes a set of http exchanges (currently in the form of [HAR format](https://w3c.github.io/web-performance/specs/HAR/Overview.html), URL list file, or static files in a local directory), and emits a web bundle.
+We currently provide three command-line tools: `gen-bundle`, `sign-bundle` and
+`dump-bundle`.
 
-`sign-bundle` command attaches a signature to a bundle. There are two supported ways to sign: using signatures section or integrity block. `sign-bundle` takes an existing bundle file, a private key and possibly a certificate, and emits a new bundle file with cryptographic signature added.
+`gen-bundle` command is a bundle generator tool. `gen-bundle` consumes a set of
+http exchanges (currently in the form of
+[HAR format](https://w3c.github.io/web-performance/specs/HAR/Overview.html), URL
+list file, or static files in a local directory), and emits a web bundle.
 
-`dump-bundle` command is a bundle inspector tool. `dump-bundle` dumps the enclosed http exchanges of a given web bundle file in a human readable form.
+`sign-bundle` command attaches a signature to a bundle. There are two supported
+ways to sign: using signatures section or integrity block. `sign-bundle` takes
+an existing bundle file, a private key and possibly a certificate, and emits a
+new bundle file with cryptographic signature added.
 
-You are also welcome to use the code as golang lib (e.g. `import "github.com/WICG/webpackage/go/bundle"`), but please be aware that the API is not yet stable and is subject to change any time.
+`dump-bundle` command is a bundle inspector tool. `dump-bundle` dumps the
+enclosed http exchanges of a given web bundle file in a human readable form.
+
+You are also welcome to use the code as golang lib (e.g.
+`import "github.com/WICG/webpackage/go/bundle"`), but please be aware that the
+API is not yet stable and is subject to change any time.
 
 ## Getting Started
 
 ### Prerequisite
-golang environment needs to be set up in prior to using the tool. We are testing the tool on latest golang. Please refer to [Go Getting Started documentation](https://golang.org/doc/install) for the details.
+
+golang environment needs to be set up in prior to using the tool. We are testing
+the tool on latest golang. Please refer to
+[Go Getting Started documentation](https://golang.org/doc/install) for the
+details.
 
 ### Installation
+
 We recommend using `go install` to install the command-line tool.
 
 ```
@@ -29,15 +46,24 @@ go install github.com/WICG/webpackage/go/bundle/cmd/...@latest
 ## Usage
 
 ### gen-bundle
-`gen-bundle` generates a web bundle. There are three ways to provide a set of exchanges to bundle; by a HAR file, by a URL list, and by a local directory.
+
+`gen-bundle` generates a web bundle. There are three ways to provide a set of
+exchanges to bundle; by a HAR file, by a URL list, and by a local directory.
 
 These command-line flags are common to all the three options:
 
-- `-version` specifies WebBundle format version. Possible values are: `b2` (default) and `b1`.
-- `-primaryURL` specifies the bundle's main resource URL. This URL is also used as the fallback destination when browser cannot process the bundle. If bundle format is `b1`, this option is required.
-- `-manifestURL` specifies the bundle's [manifest](https://www.w3.org/TR/appmanifest/) URL. This option can be specified only for bundle version `b1`.
-- `-o` specifies name of the output bundle file. Default file name if unspecified is `out.wbn`.
-- `-headerOverride` adds additional response header to all bundled responses. Existing values of the header are overwritten.
+- `-version` specifies WebBundle format version. Possible values are: `b2`
+  (default) and `b1`.
+- `-primaryURL` specifies the bundle's main resource URL. This URL is also used
+  as the fallback destination when browser cannot process the bundle. If bundle
+  format is `b1`, this option is required.
+- `-manifestURL` specifies the bundle's
+  [manifest](https://www.w3.org/TR/appmanifest/) URL. This option can be
+  specified only for bundle version `b1`.
+- `-o` specifies name of the output bundle file. Default file name if
+  unspecified is `out.wbn`.
+- `-headerOverride` adds additional response header to all bundled responses.
+  Existing values of the header are overwritten.
 
 #### From a HAR file
 
@@ -51,13 +77,16 @@ One convenient way to generate HAR file is via Chrome Devtools:
 ![generating har with devtools](https://raw.githubusercontent.com/WICG/webpackage/main/go/bundle/har-devtools.png)
 
 Once you have the har file, generate the web bundle via:
+
 ```
 gen-bundle -har foo.har -o foo.wbn -primaryURL https://example.com/
 ```
 
 #### From a URL list
 
-`gen-bundle` also accepts `-URLList FILE` flag. `FILE` is a plain text file with one URL on each line. `gen-bundle` fetches these URLs and put the responses into the bundle. For example, you could create `urls.txt` with:
+`gen-bundle` also accepts `-URLList FILE` flag. `FILE` is a plain text file with
+one URL on each line. `gen-bundle` fetches these URLs and put the responses into
+the bundle. For example, you could create `urls.txt` with:
 
 ```
 # A line starting with '#' is a comment.
@@ -65,23 +94,30 @@ https://example.com/
 https://example.com/style.css
 https://example.com/script.js
 ```
+
 then run:
+
 ```
 gen-bundle -URLList urls.txt \
            -primaryURL https://example.com/ \
            -o example_com.wbn
 ```
 
-Note that `gen-bundle` does not automatically discover subresources; you have to enumerate all the necessary subresources in the URL list file.
+Note that `gen-bundle` does not automatically discover subresources; you have to
+enumerate all the necessary subresources in the URL list file.
 
 #### From a local directory
 
-You can also create a bundle from a local directory. For example, if you have the necessary files for the site `https://www.example.com/` in `static/` directory, run:
+You can also create a bundle from a local directory. For example, if you have
+the necessary files for the site `https://www.example.com/` in `static/`
+directory, run:
+
 ```
 gen-bundle -dir static -baseURL https://example.com/ -o foo.wbn -primaryURL https://example.com/
 ```
 
-If `-baseURL` flag is not specified, resources will have relative URLs in the generated bundle file.
+If `-baseURL` flag is not specified, resources will have relative URLs in the
+generated bundle file.
 
 ### sign-bundle
 
@@ -93,11 +129,20 @@ If `-baseURL` flag is not specified, resources will have relative URLs in the ge
 
 #### Using `signatures-section` sub-command
 
-`sign-bundle signatures-section` takes an existing bundle file, a certificate and a private key, and emits a new bundle file with cryptographic signature for the bundled resources added.
+`sign-bundle signatures-section` takes an existing bundle file, a certificate
+and a private key, and emits a new bundle file with cryptographic signature for
+the bundled resources added.
 
-It updates a bundle attaching a cryptographic signature of its exchanges. To use this tool, you need a pair of a private key and a certificate in the `application/cert-chain+cbor` format. See [signatures-section extension](../../extensions/signatures-section.md) and [go/signedexchange](../signedexchange/README.md) for more information on how to create a key and certificate pair.
+It updates a bundle attaching a cryptographic signature of its exchanges. To use
+this tool, you need a pair of a private key and a certificate in the
+`application/cert-chain+cbor` format. See
+[signatures-section extension](../../extensions/signatures-section.md) and
+[go/signedexchange](../signedexchange/README.md) for more information on how to
+create a key and certificate pair.
 
-Assuming you have a key and certificate pair for `example.org`, this command will sign all exchanges in `unsigned.wbn` whose URL's hostname is `example.org`, and writes a new bundle to `signed.wbn`.
+Assuming you have a key and certificate pair for `example.org`, this command
+will sign all exchanges in `unsigned.wbn` whose URL's hostname is `example.org`,
+and writes a new bundle to `signed.wbn`.
 
 ```
 sign-bundle signatures-section \
@@ -110,9 +155,14 @@ sign-bundle signatures-section \
 
 #### Using `integrity-block` sub-command
 
-`sign-bundle integrity-block` takes an existing bundle file, an ed25519 private key, and emits a new bundle file with cryptographic signature added to the integrity block.
+`sign-bundle integrity-block` takes an existing bundle file and an ed25519
+private key, and emits a new bundle file with cryptographic signature added to
+the integrity block.
 
-It updates a bundle prepending the web bundle with an integrity block containing a stack of signatures over the hash of the web bundle. To use this tool, you need an ed25519 private key in .pem format, which can be generated with: `openssl genpkey -algorithm Ed25519 -out ed25519key.pem`. 
+It updates a bundle prepending the web bundle with an integrity block containing
+a stack of signatures over the hash of the web bundle. To use this tool, you
+need an ed25519 private key in .pem format, which can be generated with:
+`openssl genpkey -algorithm Ed25519 -out ed25519key.pem`.
 
 ```
 sign-bundle integrity-block \
@@ -121,18 +171,28 @@ sign-bundle integrity-block \
   -o signed.swbn
 ```
 
-See [integrityblock-explainer](../../explainers/integrity-signature.md) for more information about what an integrity block is.
+See [integrityblock-explainer](../../explainers/integrity-signature.md) for more
+information about what an integrity block is.
 
 #### Using `dump-id` sub-command
 
-`sign-bundle dump-id` is a helper tool to print out the [Web Bundle ID](https://github.com/WICG/isolated-web-apps/blob/main/Scheme.md#signed-web-bundle-ids) which is corresponding to the given ed25519 key.
-The ID is base32-encoded lowercase representation of the ed25519 public key with a predefined suffix.
+`sign-bundle dump-id` is a helper tool to print out the
+[Web Bundle ID](https://github.com/WICG/isolated-web-apps/blob/main/Scheme.md#signed-web-bundle-ids)
+which is corresponding to the given ed25519 private key. The ID is
+base32-encoded lowercase representation of the ed25519 public key with a
+predefined suffix.
 
-Web Bundle ID can be used for example in the origin of an Isolated Web App.
+Web Bundle ID can be used for example as the origin of an Isolated Web App.
+
+```
+sign-bundle dump-id -privateKey privkey.pem
+```
 
 ### dump-bundle
+
 `dump-bundle` dumps the content of a web bundle in a human readable form. To
 display content of a bundle file, invoke:
+
 ```
 dump-bundle -i foo.wbn
 ```
@@ -140,6 +200,10 @@ dump-bundle -i foo.wbn
 `dump-bundle` doesn't support web bundles signed with integrity block.
 
 ## Using Bundles
-Bundles generated with `gen-bundle` can be opened with web browsers supporting web bundles.
 
-Chrome (79+) experimentally supports Web Bundles with some limitations. See [this document](https://chromium.googlesource.com/chromium/src/+/refs/heads/master/content/browser/web_package/using_web_bundles.md) for more details.
+Bundles generated with `gen-bundle` can be opened with web browsers supporting
+web bundles.
+
+Chrome (79+) experimentally supports Web Bundles with some limitations. See
+[this document](https://chromium.googlesource.com/chromium/src/+/refs/heads/master/content/browser/web_package/using_web_bundles.md)
+for more details.

--- a/go/bundle/README.md
+++ b/go/bundle/README.md
@@ -85,18 +85,22 @@ If `-baseURL` flag is not specified, resources will have relative URLs in the ge
 
 ### sign-bundle
 
-There are two supported ways to sign: using signatures section or integrity block, which can be separated using `-signType` `signaturessection` or `integrityblock` flag values. Without the signType flag, the default is `signaturessection`. 
+`sign-bundle` is split into the following sub-commands:
 
-#### Using Signatures Section
+- `signatures-section`
+- `integrity-block`
+- `dump-id`
 
-`sign-bundle -signType signaturessection` takes an existing bundle file, a certificate and a private key, and emits a new bundle file with cryptographic signature for the bundled resources added.
+#### Using `signatures-section` sub-command
 
-`sign-bundle` updates a bundle attaching a cryptographic signature of its exchanges. To use this tool, you need a pair of a private key and a certificate in the `application/cert-chain+cbor` format. See [signatures-section extension](../../extensions/signatures-section.md) and [go/signedexchange](../signedexchange/README.md) for more information on how to create a key and certificate pair.
+`sign-bundle signatures-section` takes an existing bundle file, a certificate and a private key, and emits a new bundle file with cryptographic signature for the bundled resources added.
+
+It updates a bundle attaching a cryptographic signature of its exchanges. To use this tool, you need a pair of a private key and a certificate in the `application/cert-chain+cbor` format. See [signatures-section extension](../../extensions/signatures-section.md) and [go/signedexchange](../signedexchange/README.md) for more information on how to create a key and certificate pair.
 
 Assuming you have a key and certificate pair for `example.org`, this command will sign all exchanges in `unsigned.wbn` whose URL's hostname is `example.org`, and writes a new bundle to `signed.wbn`.
 
 ```
-sign-bundle \
+sign-bundle signatures-section \
   -i unsigned.wbn \
   -certificate cert.cbor \
   -privateKey priv.key \
@@ -104,21 +108,27 @@ sign-bundle \
   -o signed.wbn
 ```
 
-#### Using Integrity Block
+#### Using `integrity-block` sub-command
 
-`sign-bundle -signType integrityblock` takes an existing bundle file, an ed25519 private key, and emits a new bundle file with cryptographic signature added to the integrity block.
+`sign-bundle integrity-block` takes an existing bundle file, an ed25519 private key, and emits a new bundle file with cryptographic signature added to the integrity block.
 
-`sign-bundle` updates a bundle prepending the web bundle with an integrity block containing a stack of signatures over the hash of the web bundle. To use this tool, you need an ed25519 private key in .pem format, which can be generated with: `openssl genpkey -algorithm Ed25519 -out ed25519key.pem`. 
+It updates a bundle prepending the web bundle with an integrity block containing a stack of signatures over the hash of the web bundle. To use this tool, you need an ed25519 private key in .pem format, which can be generated with: `openssl genpkey -algorithm Ed25519 -out ed25519key.pem`. 
 
 ```
-sign-bundle \
-  -signType integrityblock \
+sign-bundle integrity-block \
   -i unsigned.wbn \
   -privateKey privkey.pem \
   -o signed.swbn
 ```
 
 See [integrityblock-explainer](../../explainers/integrity-signature.md) for more information about what an integrity block is.
+
+#### Using `dump-id` sub-command
+
+`sign-bundle dump-id` is a helper tool to print out the [Web Bundle ID](https://github.com/WICG/isolated-web-apps/blob/main/Scheme.md#signed-web-bundle-ids) which is corresponding to the given ed25519 key.
+The ID is base32-encoded lowercase representation of the ed25519 public key with a predefined suffix.
+
+Web Bundle ID can be used for example in the origin of an Isolated Web App.
 
 ### dump-bundle
 `dump-bundle` dumps the content of a web bundle in a human readable form. To

--- a/go/bundle/cmd/sign-bundle/integrityblock.go
+++ b/go/bundle/cmd/sign-bundle/integrityblock.go
@@ -25,7 +25,7 @@ func writeOutput(bundleFile io.ReadSeeker, integrityBlockBytes []byte, originalI
 	return nil
 }
 
-func ReadAndParseEd25519PrivateKey(path string) (ed25519.PrivateKey, error) {
+func readAndParseEd25519PrivateKey(path string) (ed25519.PrivateKey, error) {
 	privKey, err := readPrivateKeyFromFile(path)
 	if err != nil {
 		return nil, errors.New("SignIntegrityBlock: Unable to read the private key.")
@@ -39,7 +39,7 @@ func ReadAndParseEd25519PrivateKey(path string) (ed25519.PrivateKey, error) {
 }
 
 func DumpWebBundleId() error {
-	ed25519privKey, err := ReadAndParseEd25519PrivateKey(*dumpIdFlagPrivateKey)
+	ed25519privKey, err := readAndParseEd25519PrivateKey(*dumpIdFlagPrivateKey)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func SignWithIntegrityBlock() error {
 		return errors.New("SignIntegrityBlock: Input and output file cannot be the same.")
 	}
 
-	ed25519privKey, err := ReadAndParseEd25519PrivateKey(*ibFlagPrivateKey)
+	ed25519privKey, err := readAndParseEd25519PrivateKey(*ibFlagPrivateKey)
 	if err != nil {
 		return err
 	}

--- a/go/bundle/cmd/sign-bundle/main.go
+++ b/go/bundle/cmd/sign-bundle/main.go
@@ -16,15 +16,15 @@ const (
 )
 
 var (
-	signedExchangesCmd = flag.NewFlagSet(signaturesSectionSubCmdName, flag.ExitOnError)
-	flagInput          = signedExchangesCmd.String("i", "in.wbn", "Webbundle input file")
-	flagOutput         = signedExchangesCmd.String("o", "out.wbn", "Webbundle output file")
-	flagCertificate    = signedExchangesCmd.String("certificate", "cert.cbor", "Certificate chain CBOR file")
-	flagPrivateKey     = signedExchangesCmd.String("privateKey", "cert-key.pem", "Private key PEM file")
-	flagValidityUrl    = signedExchangesCmd.String("validityUrl", "https://example.com/resource.validity.msg", "The URL where resource validity info is hosted at.")
-	flagDate           = signedExchangesCmd.String("date", "", "Datetime for the signature in RFC3339 format (2006-01-02T15:04:05Z). (default: current time)")
-	flagExpire         = signedExchangesCmd.Duration("expire", 1*time.Hour, "Validity duration of the signature")
-	flagMIRecordSize   = signedExchangesCmd.Int("miRecordSize", 4096, "Record size of Merkle Integrity Content Encoding")
+	signedExchangesCmd  = flag.NewFlagSet(signaturesSectionSubCmdName, flag.ExitOnError)
+	sxgFlagInput        = signedExchangesCmd.String("i", "in.wbn", "Webbundle input file")
+	sxgFlagOutput       = signedExchangesCmd.String("o", "out.wbn", "Webbundle output file")
+	sxgFlagCertificate  = signedExchangesCmd.String("certificate", "cert.cbor", "Certificate chain CBOR file")
+	sxgFlagPrivateKey   = signedExchangesCmd.String("privateKey", "cert-key.pem", "Private key PEM file")
+	sxgFlagValidityUrl  = signedExchangesCmd.String("validityUrl", "https://example.com/resource.validity.msg", "The URL where resource validity info is hosted at.")
+	sxgFlagDate         = signedExchangesCmd.String("date", "", "Datetime for the signature in RFC3339 format (2006-01-02T15:04:05Z). (default: current time)")
+	sxgFlagExpire       = signedExchangesCmd.Duration("expire", 1*time.Hour, "Validity duration of the signature")
+	sxgFlagMIRecordSize = signedExchangesCmd.Int("miRecordSize", 4096, "Record size of Merkle Integrity Content Encoding")
 )
 
 var (

--- a/go/bundle/cmd/sign-bundle/signedexchange.go
+++ b/go/bundle/cmd/sign-bundle/signedexchange.go
@@ -57,7 +57,7 @@ func addSignature(b *bundle.Bundle, signer *signature.Signer) error {
 		if !signer.CanSignForURL(e.Request.URL) {
 			continue
 		}
-		payloadIntegrityHeader, err := e.AddPayloadIntegrity(b.Version, *flagMIRecordSize)
+		payloadIntegrityHeader, err := e.AddPayloadIntegrity(b.Version, *sxgFlagMIRecordSize)
 		if err != nil {
 			return err
 		}
@@ -75,42 +75,42 @@ func addSignature(b *bundle.Bundle, signer *signature.Signer) error {
 }
 
 func SignExchanges() error {
-	privKey, err := readPrivateKeyFromFile(*flagPrivateKey)
+	privKey, err := readPrivateKeyFromFile(*sxgFlagPrivateKey)
 	if err != nil {
-		return fmt.Errorf("%s: %v", *flagPrivateKey, err)
+		return fmt.Errorf("%s: %v", *sxgFlagPrivateKey, err)
 	}
 
 	if _, ok := privKey.(*ecdsa.PrivateKey); !ok {
 		return errors.New("Private key is not ECDSA type.")
 	}
 
-	certs, err := readCertChainFromFile(*flagCertificate)
+	certs, err := readCertChainFromFile(*sxgFlagCertificate)
 	if err != nil {
-		return fmt.Errorf("%s: %v", *flagCertificate, err)
+		return fmt.Errorf("%s: %v", *sxgFlagCertificate, err)
 	}
 
-	validityUrl, err := url.Parse(*flagValidityUrl)
+	validityUrl, err := url.Parse(*sxgFlagValidityUrl)
 	if err != nil {
-		return fmt.Errorf("failed to parse validity URL %q: %v", *flagValidityUrl, err)
+		return fmt.Errorf("failed to parse validity URL %q: %v", *sxgFlagValidityUrl, err)
 	}
 
 	var date time.Time
-	if *flagDate == "" {
+	if *sxgFlagDate == "" {
 		date = time.Now()
 	} else {
 		var err error
-		date, err = time.Parse(time.RFC3339, *flagDate)
+		date, err = time.Parse(time.RFC3339, *sxgFlagDate)
 		if err != nil {
-			return fmt.Errorf("failed to parse date %q: %v", *flagDate, err)
+			return fmt.Errorf("failed to parse date %q: %v", *sxgFlagDate, err)
 		}
 	}
 
-	b, err := readBundleFromFile(*flagInput)
+	b, err := readBundleFromFile(*sxgFlagInput)
 	if err != nil {
-		return fmt.Errorf("%s: %v", *flagInput, err)
+		return fmt.Errorf("%s: %v", *sxgFlagInput, err)
 	}
 
-	signer, err := signature.NewSigner(b.Version, certs, privKey, validityUrl, date, *flagExpire)
+	signer, err := signature.NewSigner(b.Version, certs, privKey, validityUrl, date, *sxgFlagExpire)
 	if err != nil {
 		return err
 	}
@@ -119,8 +119,8 @@ func SignExchanges() error {
 		return err
 	}
 
-	if err := writeBundleToFile(b, *flagOutput); err != nil {
-		return fmt.Errorf("%s: %v", *flagOutput, err)
+	if err := writeBundleToFile(b, *sxgFlagOutput); err != nil {
+		return fmt.Errorf("%s: %v", *sxgFlagOutput, err)
 	}
 	return nil
 }

--- a/go/bundle/cmd/sign-bundle/signedexchange.go
+++ b/go/bundle/cmd/sign-bundle/signedexchange.go
@@ -74,7 +74,12 @@ func addSignature(b *bundle.Bundle, signer *signature.Signer) error {
 	return nil
 }
 
-func SignExchanges(privKey crypto.PrivateKey) error {
+func SignExchanges() error {
+	privKey, err := readPrivateKeyFromFile(*flagPrivateKey)
+	if err != nil {
+		return fmt.Errorf("%s: %v", *flagPrivateKey, err)
+	}
+
 	if _, ok := privKey.(*ecdsa.PrivateKey); !ok {
 		return errors.New("Private key is not ECDSA type.")
 	}


### PR DESCRIPTION
Split the signType integrity block and signature-sections to sub commands instead of having a flag.

Also add a new sub-command dump-id to print out the corresponding Web Bundle ID to the given private key.