### PR TITLE
Use public key instead of private key for GetWebBundleId()

### DIFF
--- a/go/bundle/cmd/sign-bundle/integrityblock.go
+++ b/go/bundle/cmd/sign-bundle/integrityblock.go
@@ -44,7 +44,7 @@ func DumpWebBundleId() error {
 		return err
 	}
 
-	webBundleId := integrityblock.GetWebBundleId(ed25519privKey)
+	webBundleId := integrityblock.GetWebBundleId(ed25519privKey.Public().(ed25519.PublicKey))
 	fmt.Printf("Web Bundle ID: %s\n", webBundleId)
 	return nil
 }
@@ -61,6 +61,7 @@ func SignWithIntegrityBlock() error {
 	if err != nil {
 		return err
 	}
+	ed25519pubKey := ed25519privKey.Public().(ed25519.PublicKey)
 
 	bundleFile, err := os.Open(*ibFlagInput)
 	if err != nil {
@@ -94,7 +95,7 @@ func SignWithIntegrityBlock() error {
 		return err
 	}
 
-	webBundleId := integrityblock.GetWebBundleId(ed25519privKey)
+	webBundleId := integrityblock.GetWebBundleId(ed25519pubKey)
 	fmt.Println("Web Bundle ID: " + webBundleId)
 
 	signedBundleFile, err := os.Create(*ibFlagOutput)

--- a/go/integrityblock/integrityblock.go
+++ b/go/integrityblock/integrityblock.go
@@ -267,8 +267,7 @@ func (integrityBlock *IntegrityBlock) SignAndAddNewSignature(ed25519privKey ed25
 // GetWebBundleId returns a base32-encoded (without padding) ed25519 public key
 // combined with a 3-byte long suffix and transformed to lowercase. More information:
 // https://github.com/WICG/isolated-web-apps/blob/main/Scheme.md#signed-web-bundle-ids
-func GetWebBundleId(ed25519privKey ed25519.PrivateKey) string {
-	ed25519publicKey := ed25519privKey.Public().(ed25519.PublicKey)
+func GetWebBundleId(ed25519publicKey ed25519.PublicKey) string {
 	keyWithSuffix := append([]byte(ed25519publicKey), WebBundleIdSuffix...)
 
 	// StdEncoding is the standard base32 encoding, as defined in RFC 4648.

--- a/go/integrityblock/integrityblock_test.go
+++ b/go/integrityblock/integrityblock_test.go
@@ -317,7 +317,7 @@ func TestGetWebBundleId(t *testing.T) {
 		t.Errorf("integrityblock: Failed to parse the test private key. err: %v", err)
 	}
 
-	got := GetWebBundleId(privateKey.(ed25519.PrivateKey))
+	got := GetWebBundleId(privateKey.(ed25519.PrivateKey).Public().(ed25519.PublicKey))
 	want := "4tkrnsmftl4ggvvdkfth3piainqragus2qbhf7rlz2a3wo3rh4wqaaic"
 
 	if got != want {


### PR DESCRIPTION
This will be needed later on when the private key is no longer certain to be available for the tools.