### PR TITLE
Update contributors

### DIFF
--- a/js/bundle/package.json
+++ b/js/bundle/package.json
@@ -31,6 +31,10 @@
     "bundled exchanges"
   ],
   "author": "Kunihiko Sakamoto <ksakamoto@chromium.org>",
+  "contributors": [
+    "Sonja Laurila <laurila@google.com> (https://github.com/sonkkeli)",
+    "Christian Flach <cmfcmf@google.com> (https://github.com/cmfcmf)"
+  ],
   "license": "W3C-20150513",
   "dependencies": {
     "cborg": "^1.9.4",

--- a/js/sign/README.md
+++ b/js/sign/README.md
@@ -15,6 +15,10 @@ Using npm:
 npm install wbn-sign
 ```
 
+## Requirements
+
+This plugin requires Node v14.0.0+.
+
 ## Usage
 
 Please be aware that the APIs are not stable yet and are subject to change at

--- a/js/sign/package.json
+++ b/js/sign/package.json
@@ -30,7 +30,10 @@
     "webpackage",
     "integrity-block"
   ],
-  "author": "Sonja Laurila <laurila@google.com>",
+  "author": "Sonja Laurila <laurila@google.com> (https://github.com/sonkkeli)",
+  "contributors": [
+    "Christian Flach <cmfcmf@google.com> (https://github.com/cmfcmf)"
+  ],
   "license": "W3C-20150513",
   "dependencies": {
     "base32-encode": "^2.0.0",


### PR DESCRIPTION
Note: wbn is JS compatible so thus only added Node v requirement to the wbn-sign library.