### PR TITLE
wbn-sign: Add support for WEB_BUNDLE_SIGNING_PASSPHRASE for the CLI tool

### DIFF
--- a/js/sign/README.md
+++ b/js/sign/README.md
@@ -116,7 +116,18 @@ openssl pkcs8 -in ed25519key.pem -topk8 -out encrypted_ed25519key.pem
 rm ed25519key.pem
 ```
 
+In case you chose to use an encrypted private key, it will be prompted during
+the signing process. If one wants to use the CLI tool programmatically (e.g. as
+part of their DevOps pipeline), they can bypass the prompt by setting the
+password into an environment variable named `WEB_BUNDLE_SIGNING_PASSPHRASE`.
+
 ## Release Notes
+
+### v0.1.1
+
+- Adds support for bypassing prompting passphrase for encrypted private keys by
+  using `WEB_BUNDLE_SIGNING_PASSPHRASE` environment variable if using the CLI
+  tool directly.
 
 ### v0.1.0
 

--- a/js/sign/README.md
+++ b/js/sign/README.md
@@ -116,18 +116,18 @@ openssl pkcs8 -in ed25519key.pem -topk8 -out encrypted_ed25519key.pem
 rm ed25519key.pem
 ```
 
-In case you chose to use an encrypted private key, it will be prompted during
-the signing process. If one wants to use the CLI tool programmatically (e.g. as
-part of their DevOps pipeline), they can bypass the prompt by setting the
-password into an environment variable named `WEB_BUNDLE_SIGNING_PASSPHRASE`.
+If you use an encrypted private key, you will be prompted for its passphrase as
+part of the signing process. If you want to use the CLI tool programmatically,
+then you can bypass the passphrase prompt by storing the passphrase in an
+environment variable named `WEB_BUNDLE_SIGNING_PASSPHRASE`.
 
 ## Release Notes
 
 ### v0.1.1
 
-- Adds support for bypassing prompting passphrase for encrypted private keys by
-  using `WEB_BUNDLE_SIGNING_PASSPHRASE` environment variable if using the CLI
-  tool directly.
+- Add support for bypassing the passphrase prompt for encrypted private keys by
+  reading the passphrase from the `WEB_BUNDLE_SIGNING_PASSPHRASE` environment
+  variable if it is set when using the CLI tool directly.
 
 ### v0.1.0
 

--- a/js/sign/package-lock.json
+++ b/js/sign/package-lock.json
@@ -21,6 +21,7 @@
         "@types/node": "^12.7.11",
         "esbuild": "^0.14.47",
         "jasmine": "^4.2.1",
+        "mock-stdin": "^1.0.0",
         "prettier": "2.8.0",
         "typescript": "^4.7.3"
       },
@@ -529,6 +530,12 @@
         "node": "*"
       }
     },
+    "node_modules/mock-stdin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mock-stdin/-/mock-stdin-1.0.0.tgz",
+      "integrity": "sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q==",
+      "dev": true
+    },
     "node_modules/mute-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
@@ -892,6 +899,12 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "mock-stdin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mock-stdin/-/mock-stdin-1.0.0.tgz",
+      "integrity": "sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q==",
+      "dev": true
     },
     "mute-stream": {
       "version": "1.0.0",

--- a/js/sign/package.json
+++ b/js/sign/package.json
@@ -42,6 +42,7 @@
     "@types/node": "^12.7.11",
     "esbuild": "^0.14.47",
     "jasmine": "^4.2.1",
+    "mock-stdin": "^1.0.0",
     "prettier": "2.8.0",
     "typescript": "^4.7.3"
   },

--- a/js/sign/src/cli.ts
+++ b/js/sign/src/cli.ts
@@ -31,7 +31,7 @@ function readOptions() {
 // reads the passphrase to decrypt them from either the
 // `WEB_BUNDLE_SIGNING_PASSPHRASE` environment variable, or, if not set, prompts
 // the user for the passphrase.
-async function parseMaybeEncryptedKey(
+export async function parseMaybeEncryptedKey(
   privateKeyFile: Buffer
 ): Promise<KeyObject> {
   // Read unencrypted private key.
@@ -58,7 +58,7 @@ async function parseMaybeEncryptedKey(
       `Failed decrypting encrypted private key with passphrase read from ${
         hasEnvVarSet
           ? '`WEB_BUNDLE_SIGNING_PASSPHRASE` environment variable'
-          : ' prompt'
+          : 'prompt'
       }`
     );
   }

--- a/js/sign/tests/cli_test.js
+++ b/js/sign/tests/cli_test.js
@@ -1,0 +1,75 @@
+import * as cli from '../lib/cli.js';
+import * as mockStdin from 'mock-stdin';
+
+const TEST_UNENCRYPTED_PRIVATE_KEY = Buffer.from(
+  '-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIB8nP5PpWU7HiILHSfh5PYzb5GAcIfHZ+bw6tcd/LZXh\n-----END PRIVATE KEY-----'
+);
+const TEST_ENCRYPTED_PRIVATE_KEY = Buffer.from(
+  '-----BEGIN ENCRYPTED PRIVATE KEY-----\nMIGbMFcGCSqGSIb3DQEFDTBKMCkGCSqGSIb3DQEFDDAcBAhOw2E7LxOkzQICCAAw\nDAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEEJZqH2axMFEvdFmJLZlnch4EQMfJ\nAa/4uAmWqu2N5aOn2yIz3Ri+vQ/rzBPrvIaoDxYUUxwujJFujSbr3lnagHlOPptU\n7XhjbPbeOqidLqyv5rA=\n-----END ENCRYPTED PRIVATE KEY-----'
+);
+const PASSPHRASE = 'helloworld';
+
+// Helper method to test async errors to be thrown, as Jasmine doesn't have
+// support for such matcher.
+async function expectToThrowErrorAsync(f) {
+  if (typeof f !== 'function') {
+    throw new Error(
+      `expectToThrowErrorAsync: Type of parameter "f" is not "function" but "${typeof f}" instead.`
+    );
+  }
+
+  let errorMessage = '';
+  try {
+    await f();
+  } catch (error) {
+    errorMessage = error.message;
+    console.log(errorMessage);
+  }
+
+  expect(errorMessage).not.toBe('');
+}
+
+describe('CLI key parsing', () => {
+  afterEach(() => {
+    if (process.env.WEB_BUNDLE_SIGNING_PASSPHRASE) {
+      delete process.env.WEB_BUNDLE_SIGNING_PASSPHRASE;
+    }
+  });
+
+  it('works for unencrypted key.', async () => {
+    const key = await cli.parseMaybeEncryptedKey(TEST_UNENCRYPTED_PRIVATE_KEY);
+    expect(key.type).toEqual('private');
+  });
+
+  it('works for encrypted key read from `WEB_BUNDLE_SIGNING_PASSPHRASE`.', async () => {
+    process.env.WEB_BUNDLE_SIGNING_PASSPHRASE = PASSPHRASE;
+    const key = await cli.parseMaybeEncryptedKey(TEST_ENCRYPTED_PRIVATE_KEY);
+    expect(key.type).toEqual('private');
+  });
+
+  it('works for encrypted key read from a prompt.', async () => {
+    const stdin = mockStdin.stdin();
+    const keyPromise = cli.parseMaybeEncryptedKey(TEST_ENCRYPTED_PRIVATE_KEY);
+    stdin.send(`${PASSPHRASE}\n`);
+    expect((await keyPromise).type).toEqual('private');
+  });
+
+  it('fails for faulty `WEB_BUNDLE_SIGNING_PASSPHRASE`.', async () => {
+    process.env.WEB_BUNDLE_SIGNING_PASSPHRASE = 'helloworld1';
+
+    await expectToThrowErrorAsync(() =>
+      cli.parseMaybeEncryptedKey(TEST_ENCRYPTED_PRIVATE_KEY)
+    );
+  });
+
+  it('fails for faulty passphrase read from a prompt.', async () => {
+    process.env.WEB_BUNDLE_SIGNING_PASSPHRASE = 'helloworld1';
+
+    await expectToThrowErrorAsync(async () => {
+      const stdin = mockStdin.stdin();
+      const keyPromise = cli.parseMaybeEncryptedKey(TEST_ENCRYPTED_PRIVATE_KEY);
+      stdin.send(`${PASSPHRASE}1\n`);
+      await keyPromise;
+    });
+  });
+});


### PR DESCRIPTION
With the new environment variable support one can bypass prompting passphrase if e.g. using the CLI tool programmatically.