### PR TITLE
go: Split SignWithIntegrityBlock to be usable without flags

### DIFF
--- a/go/bundle/cmd/sign-bundle/integrityblock.go
+++ b/go/bundle/cmd/sign-bundle/integrityblock.go
@@ -85,7 +85,7 @@ func DumpWebBundleId() error {
 	}
 }
 
-// SignWithIntegrityBlockWithCmdFlags is just a wrapper class for `SignWithIntegrityBlock`
+// SignWithIntegrityBlockWithCmdFlags is just a wrapper function for `SignWithIntegrityBlock`
 // function containing the actual logic so that it can be easily exported without having
 // to rely on reading and writing to files specified to be read from the CMD tool flags.
 func SignWithIntegrityBlockWithCmdFlags(signingStrategy integrityblock.ISigningStrategy) error {
@@ -105,12 +105,7 @@ func SignWithIntegrityBlockWithCmdFlags(signingStrategy integrityblock.ISigningS
 	}
 	defer signedBundleFile.Close()
 
-	err = SignWithIntegrityBlock(bundleFile, signedBundleFile, signingStrategy)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return SignWithIntegrityBlock(bundleFile, signedBundleFile, signingStrategy)
 }
 
 // SignWithIntegrityBlock creates a CBOR integrity block containing a signature
@@ -160,9 +155,5 @@ func SignWithIntegrityBlock(bundleFileIn, bundleFileOut *os.File, signingStrateg
 	webBundleId := webbundleid.GetWebBundleId(ed25519publicKey)
 	fmt.Println("Web Bundle ID: " + webBundleId)
 
-	if err := writeOutput(bundleFileIn, integrityBlockBytes, offset, bundleFileOut); err != nil {
-		return err
-	}
-
-	return nil
+	return writeOutput(bundleFileIn, integrityBlockBytes, offset, bundleFileOut)
 }

--- a/go/bundle/cmd/sign-bundle/main.go
+++ b/go/bundle/cmd/sign-bundle/main.go
@@ -74,7 +74,7 @@ func run() error {
 		}
 
 		var bss integrityblock.ISigningStrategy = integrityblock.NewParsedEd25519KeySigningStrategy(ed25519privKey)
-		return SignWithIntegrityBlock(bss)
+		return SignWithIntegrityBlockWithCmdFlags(bss)
 
 	case dumpWebBundleIdSubCmdName:
 		dumpWebBundleIdCmd.Parse(os.Args[2:])


### PR DESCRIPTION
This is a step towards being able to use the tooling with one's own signing strategy without being forced to use it as a CMD tool with flags. With this change one can create their own wrapper Golang tool with their own ISigningStrategy implementation and pass their input and output files without being forced to use flags.

The tool does not support providing the bytes directly as that would then limit the size of the web bundle into the max size of []byte array.