### PR TITLE
Do not treat cborg as external in cjs build

### DIFF
--- a/js/sign/package-lock.json
+++ b/js/sign/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "wbn-sign",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wbn-sign",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "W3C-20150513",
       "dependencies": {
         "base32-encode": "^2.0.0",
-        "cborg": "^4.0.0",
+        "cborg": "^4.2.14",
         "commander": "^7.0.0",
         "read": "^2.0.0"
       },
@@ -481,9 +481,9 @@
       }
     },
     "node_modules/cborg": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.0.0.tgz",
-      "integrity": "sha512-VIUEqOvrpA3zgmFe6MmXyDSP9MIRPfOLYSk00jolUHZrlDUay6rKaW/TyzmSWLeOzwU0UhjbnE+NvMWG7PXADw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.14.tgz",
+      "integrity": "sha512-VwDKj4eWvoOBtMReabfiGyMh/bNFk8aXZRlMis1tTuMjN9R6VQdyrOwyQb0/aqYHk7r88a6xTWvnsJEC2Cw66Q==",
       "bin": {
         "cborg": "lib/bin.js"
       }

--- a/js/sign/package.json
+++ b/js/sign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wbn-sign",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Signing tool to sign a web bundle with integrity block",
   "homepage": "https://github.com/WICG/webpackage/tree/main/js/sign",
   "main": "./lib/wbn-sign.cjs",
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "tsc",
-    "build:cjs": "esbuild --bundle --format=cjs --external:cborg --outfile=lib/wbn-sign.cjs src/wbn-sign.ts --platform=node",
+    "build:cjs": "esbuild --bundle --format=cjs --outfile=lib/wbn-sign.cjs src/wbn-sign.ts --platform=node",
     "test": "jasmine tests/*.js tests/*.cjs",
     "lint": "npx prettier --write . --ignore-unknown --config ./package.json"
   },
@@ -40,7 +40,7 @@
   "license": "W3C-20150513",
   "dependencies": {
     "base32-encode": "^2.0.0",
-    "cborg": "^4.0.0",
+    "cborg": "^4.2.14",
     "commander": "^7.0.0",
     "read": "^2.0.0"
   },

--- a/js/sign/src/signers/integrity-block-signer.ts
+++ b/js/sign/src/signers/integrity-block-signer.ts
@@ -1,5 +1,5 @@
 import crypto, { KeyObject } from 'crypto';
-import * as cborg from 'cborg';
+import { encode } from 'cborg';
 import { INTEGRITY_BLOCK_MAGIC, VERSION_B2 } from '../utils/constants.js';
 import { checkDeterministic } from '../cbor/deterministic.js';
 import {
@@ -40,7 +40,7 @@ export class IntegrityBlockSigner {
       };
 
       const ibCbor = integrityBlock.toCBOR();
-      const attrCbor = cborg.encode(newAttributes);
+      const attrCbor = encode(newAttributes);
       checkDeterministic(ibCbor);
       checkDeterministic(attrCbor);
 
@@ -175,7 +175,7 @@ export class IntegrityBlock {
   }
 
   toCBOR(): Uint8Array {
-    return cborg.encode([
+    return encode([
       INTEGRITY_BLOCK_MAGIC,
       VERSION_B2,
       this.attributes,

--- a/js/sign/src/wbn-sign.ts
+++ b/js/sign/src/wbn-sign.ts
@@ -4,5 +4,5 @@ export {
   IntegrityBlock,
   IntegrityBlockSigner,
 } from './signers/integrity-block-signer.js';
-export { WebBundleId } from './web-bundle-id.js';
+export { WebBundleId, getBundleId } from './web-bundle-id.js';
 export { parsePemKey, readPassphrase, getRawPublicKey } from './utils/utils.js';

--- a/js/sign/src/web-bundle-id.ts
+++ b/js/sign/src/web-bundle-id.ts
@@ -6,7 +6,7 @@ import {
   getSignatureType,
 } from './utils/utils.js';
 import { SignatureType } from './utils/constants.js';
-import * as cborg from 'cborg';
+import { decodeFirst } from 'cborg';
 
 // Web Bundle ID is a base32-encoded (without padding) ed25519 public key
 // transformed to lowercase. More information:
@@ -58,7 +58,7 @@ export class WebBundleId {
 
 export function getBundleId(signedWebBundle: Uint8Array) {
   try {
-    const decodedData = cborg.decodeFirst(signedWebBundle);
+    const decodedData = decodeFirst(signedWebBundle);
 
     if (!decodedData[0] || !decodedData[0][2]) {
       throw Error('Signed Web Bundle structure is invalid');


### PR DESCRIPTION
It cannot be imported using require() after update, which breaks usage relying on CJS build